### PR TITLE
refactor: remove welcome email tracking columns

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -43,11 +43,7 @@ model Usuario {
   emailVerificationTokenExp    DateTime?
   emailVerificationAttempts    Int       @default(0)
   ultimaTentativaVerificacao   DateTime?
-  
-  // CAMPOS PARA AUDITORIA DE EMAILS
-  emailBoasVindasEnviado Boolean   @default(false)
-  dataEmailBoasVindas    DateTime?
-  
+
   // RELACIONAMENTOS EXISTENTES
   enderecos     Endereco[]
   empresa       Empresa?    @relation(fields: [codEmpresa], references: [id])

--- a/src/modules/usuarios/controllers/usuario-controller.ts
+++ b/src/modules/usuarios/controllers/usuario-controller.ts
@@ -541,8 +541,6 @@ export const obterPerfil = async (req: Request, res: Response) => {
         supabaseId: true,
         emailVerificado: true,
         emailVerificadoEm: true,
-        emailBoasVindasEnviado: true,
-        dataEmailBoasVindas: true,
         ultimoLogin: true,
         criadoEm: true,
         atualizadoEm: true,
@@ -599,8 +597,6 @@ export const obterPerfil = async (req: Request, res: Response) => {
       emailVerificationStatus: {
         verified: usuario.emailVerificado,
         verifiedAt: usuario.emailVerificadoEm,
-        welcomeEmailSent: usuario.emailBoasVindasEnviado,
-        welcomeEmailSentAt: usuario.dataEmailBoasVindas,
       },
     };
 

--- a/src/modules/usuarios/services/admin-service.ts
+++ b/src/modules/usuarios/services/admin-service.ts
@@ -41,7 +41,6 @@ export class AdminService {
           tipoUsuario: true,
           criadoEm: true,
           ultimoLogin: true,
-          emailBoasVindasEnviado: true,
           _count: {
             select: {
               mercadoPagoOrders: true,
@@ -95,8 +94,6 @@ export class AdminService {
         ultimoLogin: true,
         criadoEm: true,
         atualizadoEm: true,
-        emailBoasVindasEnviado: true,
-        dataEmailBoasVindas: true,
         empresa: {
           select: { id: true, nome: true },
         },


### PR DESCRIPTION
## Summary
- drop welcome email tracking fields from user schema to send only combined welcome/verification email
- update user profile and admin services to remove welcome email fields

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_689253d8fa2083258cc4d07385c5d5dc