### PR TITLE
feat(website): add banner management

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -368,6 +368,45 @@ model WebsiteSlide {
   atualizadoEm DateTime @updatedAt
 }
 
+model WebsiteBanner {
+  id           String   @id @default(uuid())
+  imagemUrl    String
+  imagemTitulo String
+  link         String?
+  ordem        Int
+  criadoEm     DateTime @default(now())
+  atualizadoEm DateTime @updatedAt
+}
+
+model WebsiteBusinessGroupInformation {
+  id         String   @id @default(uuid())
+  slug       String   @unique
+  titulo     String
+  descricao  String
+  botaoLabel String
+  botaoUrl   String
+  imagemUrl  String
+  imagemAlt  String
+  reverse    Boolean  @default(false)
+  ordem      Int
+  ativo      Boolean  @default(true)
+  criadoEm   DateTime @default(now())
+  atualizadoEm DateTime @updatedAt
+}
+
+model WebsiteLogoEnterprise {
+  id         String   @id @default(uuid())
+  nome       String
+  imagemUrl  String
+  imagemAlt  String
+  website    String
+  categoria  String
+  ordem      Int
+  ativo      Boolean  @default(true)
+  criadoEm   DateTime @default(now())
+  atualizadoEm DateTime @updatedAt
+}
+
 // =============================================
 // ENUMS EXISTENTES
 // =============================================

--- a/src/modules/website/controllers/banner.controller.ts
+++ b/src/modules/website/controllers/banner.controller.ts
@@ -1,0 +1,115 @@
+import { Request, Response } from "express";
+import path from "path";
+import { supabase } from "../../superbase/client";
+import { bannerService } from "../services/banner.service";
+
+function generateImageTitle(url: string): string {
+  try {
+    const pathname = new URL(url).pathname;
+    return path.basename(pathname).split(".")[0];
+  } catch {
+    return "";
+  }
+}
+
+async function uploadImage(file: Express.Multer.File): Promise<string> {
+  const fileExt = path.extname(file.originalname);
+  const fileName = `banner-${Date.now()}${fileExt}`;
+  const { error } = await supabase.storage
+    .from("website")
+    .upload(`banners/${fileName}`, file.buffer, {
+      contentType: file.mimetype,
+    });
+  if (error) throw error;
+  const { data } = supabase.storage
+    .from("website")
+    .getPublicUrl(`banners/${fileName}`);
+  return data.publicUrl;
+}
+
+export class BannerController {
+  static list = async (req: Request, res: Response) => {
+    const itens = await bannerService.list();
+    res.json(itens);
+  };
+
+  static get = async (req: Request, res: Response) => {
+    try {
+      const { id } = req.params;
+      const banner = await bannerService.get(id);
+      if (!banner) {
+        return res.status(404).json({ message: "Banner não encontrado" });
+      }
+      res.json(banner);
+    } catch (error: any) {
+      res.status(500).json({
+        message: "Erro ao buscar banner",
+        error: error.message,
+      });
+    }
+  };
+
+  static create = async (req: Request, res: Response) => {
+    try {
+      const { link, ordem } = req.body;
+      let imagemUrl = "";
+      if (req.file) {
+        imagemUrl = await uploadImage(req.file);
+      } else if (req.body.imagemUrl) {
+        imagemUrl = req.body.imagemUrl;
+      }
+      const imagemTitulo = imagemUrl ? generateImageTitle(imagemUrl) : "";
+      const banner = await bannerService.create({
+        imagemUrl,
+        imagemTitulo,
+        link,
+        ordem: ordem ? parseInt(ordem, 10) : 0,
+      });
+      res.status(201).json(banner);
+    } catch (error: any) {
+      res.status(500).json({
+        message: "Erro ao criar banner",
+        error: error.message,
+      });
+    }
+  };
+
+  static update = async (req: Request, res: Response) => {
+    try {
+      const { id } = req.params;
+      const { link, ordem } = req.body;
+      let imagemUrl = req.body.imagemUrl as string | undefined;
+      if (req.file) {
+        imagemUrl = await uploadImage(req.file);
+      }
+      const data: any = { link };
+      if (ordem !== undefined) {
+        data.ordem = parseInt(ordem, 10);
+      }
+      if (imagemUrl) {
+        data.imagemUrl = imagemUrl;
+        data.imagemTitulo = generateImageTitle(imagemUrl);
+      }
+      const banner = await bannerService.update(id, data);
+      res.json(banner);
+    } catch (error: any) {
+      res.status(500).json({
+        message: "Erro ao atualizar banner",
+        error: error.message,
+      });
+    }
+  };
+
+  static remove = async (req: Request, res: Response) => {
+    try {
+      const { id } = req.params;
+      await bannerService.remove(id);
+      res.status(204).send();
+    } catch (error: any) {
+      res.status(500).json({
+        message: "Erro ao remover banner",
+        error: error.message,
+      });
+    }
+  };
+}

--- a/src/modules/website/controllers/businessGroupInformation.controller.ts
+++ b/src/modules/website/controllers/businessGroupInformation.controller.ts
@@ -1,0 +1,158 @@
+import { Request, Response } from "express";
+import path from "path";
+import { supabase } from "../../superbase/client";
+import { businessGroupInformationService } from "../services/businessGroupInformation.service";
+
+function generateImageTitle(url: string): string {
+  try {
+    const pathname = new URL(url).pathname;
+    return path.basename(pathname).split(".")[0];
+  } catch {
+    return "";
+  }
+}
+
+async function uploadImage(file: Express.Multer.File): Promise<string> {
+  const fileExt = path.extname(file.originalname);
+  const fileName = `business-${Date.now()}${fileExt}`;
+  const { error } = await supabase.storage
+    .from("website")
+    .upload(`business/${fileName}`, file.buffer, {
+      contentType: file.mimetype,
+    });
+  if (error) throw error;
+  const { data } = supabase.storage
+    .from("website")
+    .getPublicUrl(`business/${fileName}`);
+  return data.publicUrl;
+}
+
+export class BusinessGroupInformationController {
+  static list = async (req: Request, res: Response) => {
+    const itens = await businessGroupInformationService.list();
+    res.json(itens);
+  };
+
+  static get = async (req: Request, res: Response) => {
+    try {
+      const { id } = req.params;
+      const item = await businessGroupInformationService.get(id);
+      if (!item) {
+        return res
+          .status(404)
+          .json({ message: "Informação de grupo não encontrada" });
+      }
+      res.json(item);
+    } catch (error: any) {
+      res.status(500).json({
+        message: "Erro ao buscar informação de grupo",
+        error: error.message,
+      });
+    }
+  };
+
+  static create = async (req: Request, res: Response) => {
+    try {
+      const {
+        slug,
+        titulo,
+        descricao,
+        botaoLabel,
+        botaoUrl,
+        reverse,
+        ordem,
+        ativo,
+        imagemAlt,
+      } = req.body;
+      let imagemUrl = "";
+      if (req.file) {
+        imagemUrl = await uploadImage(req.file);
+      } else if (req.body.imagemUrl) {
+        imagemUrl = req.body.imagemUrl;
+      }
+      const alt = imagemAlt || (imagemUrl ? generateImageTitle(imagemUrl) : "");
+      const item = await businessGroupInformationService.create({
+        slug,
+        titulo,
+        descricao,
+        botaoLabel,
+        botaoUrl,
+        imagemUrl,
+        imagemAlt: alt,
+        reverse: reverse === "true" || reverse === true,
+        ordem: ordem ? parseInt(ordem, 10) : 0,
+        ativo: ativo === undefined ? true : ativo === "true" || ativo === true,
+      });
+      res.status(201).json(item);
+    } catch (error: any) {
+      res.status(500).json({
+        message: "Erro ao criar informação de grupo",
+        error: error.message,
+      });
+    }
+  };
+
+  static update = async (req: Request, res: Response) => {
+    try {
+      const { id } = req.params;
+      const {
+        slug,
+        titulo,
+        descricao,
+        botaoLabel,
+        botaoUrl,
+        reverse,
+        ordem,
+        ativo,
+        imagemAlt,
+      } = req.body;
+      let imagemUrl = req.body.imagemUrl as string | undefined;
+      if (req.file) {
+        imagemUrl = await uploadImage(req.file);
+      }
+      const data: any = {
+        slug,
+        titulo,
+        descricao,
+        botaoLabel,
+        botaoUrl,
+        imagemAlt,
+      };
+      if (reverse !== undefined) {
+        data.reverse = reverse === "true" || reverse === true;
+      }
+      if (ordem !== undefined) {
+        data.ordem = parseInt(ordem, 10);
+      }
+      if (ativo !== undefined) {
+        data.ativo = ativo === "true" || ativo === true;
+      }
+      if (imagemUrl) {
+        data.imagemUrl = imagemUrl;
+        if (!imagemAlt) {
+          data.imagemAlt = generateImageTitle(imagemUrl);
+        }
+      }
+      const item = await businessGroupInformationService.update(id, data);
+      res.json(item);
+    } catch (error: any) {
+      res.status(500).json({
+        message: "Erro ao atualizar informação de grupo",
+        error: error.message,
+      });
+    }
+  };
+
+  static remove = async (req: Request, res: Response) => {
+    try {
+      const { id } = req.params;
+      await businessGroupInformationService.remove(id);
+      res.status(204).send();
+    } catch (error: any) {
+      res.status(500).json({
+        message: "Erro ao remover informação de grupo",
+        error: error.message,
+      });
+    }
+  };
+}

--- a/src/modules/website/controllers/logoEnterprise.controller.ts
+++ b/src/modules/website/controllers/logoEnterprise.controller.ts
@@ -1,0 +1,123 @@
+import { Request, Response } from "express";
+import path from "path";
+import { supabase } from "../../superbase/client";
+import { logoEnterpriseService } from "../services/logoEnterprise.service";
+
+function generateImageTitle(url: string): string {
+  try {
+    const pathname = new URL(url).pathname;
+    return path.basename(pathname).split(".")[0];
+  } catch {
+    return "";
+  }
+}
+
+async function uploadImage(file: Express.Multer.File): Promise<string> {
+  const fileExt = path.extname(file.originalname);
+  const fileName = `logo-${Date.now()}${fileExt}`;
+  const { error } = await supabase.storage
+    .from("website")
+    .upload(`logos/${fileName}`, file.buffer, {
+      contentType: file.mimetype,
+    });
+  if (error) throw error;
+  const { data } = supabase.storage
+    .from("website")
+    .getPublicUrl(`logos/${fileName}`);
+  return data.publicUrl;
+}
+
+export class LogoEnterpriseController {
+  static list = async (req: Request, res: Response) => {
+    const itens = await logoEnterpriseService.list();
+    res.json(itens);
+  };
+
+  static get = async (req: Request, res: Response) => {
+    try {
+      const { id } = req.params;
+      const item = await logoEnterpriseService.get(id);
+      if (!item) {
+        return res.status(404).json({ message: "Logo não encontrado" });
+      }
+      res.json(item);
+    } catch (error: any) {
+      res.status(500).json({
+        message: "Erro ao buscar logo",
+        error: error.message,
+      });
+    }
+  };
+
+  static create = async (req: Request, res: Response) => {
+    try {
+      const { nome, website, categoria, ordem, ativo, imagemAlt } = req.body;
+      let imagemUrl = "";
+      if (req.file) {
+        imagemUrl = await uploadImage(req.file);
+      } else if (req.body.imagemUrl) {
+        imagemUrl = req.body.imagemUrl;
+      }
+      const alt = imagemAlt || (imagemUrl ? generateImageTitle(imagemUrl) : "");
+      const item = await logoEnterpriseService.create({
+        nome,
+        imagemUrl,
+        imagemAlt: alt,
+        website,
+        categoria,
+        ordem: ordem ? parseInt(ordem, 10) : 0,
+        ativo: ativo === undefined ? true : ativo === "true" || ativo === true,
+      });
+      res.status(201).json(item);
+    } catch (error: any) {
+      res.status(500).json({
+        message: "Erro ao criar logo",
+        error: error.message,
+      });
+    }
+  };
+
+  static update = async (req: Request, res: Response) => {
+    try {
+      const { id } = req.params;
+      const { nome, website, categoria, ordem, ativo, imagemAlt } = req.body;
+      let imagemUrl = req.body.imagemUrl as string | undefined;
+      if (req.file) {
+        imagemUrl = await uploadImage(req.file);
+      }
+      const data: any = { nome, website, categoria, imagemAlt };
+      if (ordem !== undefined) {
+        data.ordem = parseInt(ordem, 10);
+      }
+      if (ativo !== undefined) {
+        data.ativo = ativo === "true" || ativo === true;
+      }
+      if (imagemUrl) {
+        data.imagemUrl = imagemUrl;
+        if (!imagemAlt) {
+          data.imagemAlt = generateImageTitle(imagemUrl);
+        }
+      }
+      const item = await logoEnterpriseService.update(id, data);
+      res.json(item);
+    } catch (error: any) {
+      res.status(500).json({
+        message: "Erro ao atualizar logo",
+        error: error.message,
+      });
+    }
+  };
+
+  static remove = async (req: Request, res: Response) => {
+    try {
+      const { id } = req.params;
+      await logoEnterpriseService.remove(id);
+      res.status(204).send();
+    } catch (error: any) {
+      res.status(500).json({
+        message: "Erro ao remover logo",
+        error: error.message,
+      });
+    }
+  };
+}

--- a/src/modules/website/routes/banner.ts
+++ b/src/modules/website/routes/banner.ts
@@ -1,0 +1,29 @@
+import { Router } from "express";
+import multer from "multer";
+import { supabaseAuthMiddleware } from "../../usuarios/auth";
+import { BannerController } from "../controllers/banner.controller";
+
+const router = Router();
+const upload = multer({ storage: multer.memoryStorage() });
+
+router.get("/", BannerController.list);
+router.get("/:id", BannerController.get);
+router.post(
+  "/",
+  supabaseAuthMiddleware(["ADMIN", "MODERADOR"]),
+  upload.single("imagem"),
+  BannerController.create
+);
+router.put(
+  "/:id",
+  supabaseAuthMiddleware(["ADMIN", "MODERADOR"]),
+  upload.single("imagem"),
+  BannerController.update
+);
+router.delete(
+  "/:id",
+  supabaseAuthMiddleware(["ADMIN", "MODERADOR"]),
+  BannerController.remove
+);
+
+export { router as bannerRoutes };

--- a/src/modules/website/routes/business-group-information.ts
+++ b/src/modules/website/routes/business-group-information.ts
@@ -1,0 +1,29 @@
+import { Router } from "express";
+import multer from "multer";
+import { supabaseAuthMiddleware } from "../../usuarios/auth";
+import { BusinessGroupInformationController } from "../controllers/businessGroupInformation.controller";
+
+const router = Router();
+const upload = multer({ storage: multer.memoryStorage() });
+
+router.get("/", BusinessGroupInformationController.list);
+router.get("/:id", BusinessGroupInformationController.get);
+router.post(
+  "/",
+  supabaseAuthMiddleware(["ADMIN", "MODERADOR"]),
+  upload.single("imagem"),
+  BusinessGroupInformationController.create
+);
+router.put(
+  "/:id",
+  supabaseAuthMiddleware(["ADMIN", "MODERADOR"]),
+  upload.single("imagem"),
+  BusinessGroupInformationController.update
+);
+router.delete(
+  "/:id",
+  supabaseAuthMiddleware(["ADMIN", "MODERADOR"]),
+  BusinessGroupInformationController.remove
+);
+
+export { router as businessGroupInformationRoutes };

--- a/src/modules/website/routes/index.ts
+++ b/src/modules/website/routes/index.ts
@@ -1,6 +1,9 @@
 import { Router } from "express";
 import { sobreRoutes } from "./sobre";
 import { slideRoutes } from "./slide";
+import { bannerRoutes } from "./banner";
+import { businessGroupInformationRoutes } from "./business-group-information";
+import { logoEnterpriseRoutes } from "./logo-enterprises";
 
 const router = Router();
 
@@ -12,6 +15,9 @@ router.get("/", (req, res) => {
     endpoints: {
       sobre: "/sobre",
       slide: "/slide",
+      banner: "/banner",
+      businessGroupInformation: "/business-group-information",
+      logoEnterprises: "/logo-enterprises",
     },
     status: "operational",
   });
@@ -19,5 +25,8 @@ router.get("/", (req, res) => {
 
 router.use("/sobre", sobreRoutes);
 router.use("/slide", slideRoutes);
+  router.use("/banner", bannerRoutes);
+  router.use("/business-group-information", businessGroupInformationRoutes);
+  router.use("/logo-enterprises", logoEnterpriseRoutes);
 
 export { router as websiteRoutes };

--- a/src/modules/website/routes/logo-enterprises.ts
+++ b/src/modules/website/routes/logo-enterprises.ts
@@ -1,0 +1,29 @@
+import { Router } from "express";
+import multer from "multer";
+import { supabaseAuthMiddleware } from "../../usuarios/auth";
+import { LogoEnterpriseController } from "../controllers/logoEnterprise.controller";
+
+const router = Router();
+const upload = multer({ storage: multer.memoryStorage() });
+
+router.get("/", LogoEnterpriseController.list);
+router.get("/:id", LogoEnterpriseController.get);
+router.post(
+  "/",
+  supabaseAuthMiddleware(["ADMIN", "MODERADOR"]),
+  upload.single("imagem"),
+  LogoEnterpriseController.create
+);
+router.put(
+  "/:id",
+  supabaseAuthMiddleware(["ADMIN", "MODERADOR"]),
+  upload.single("imagem"),
+  LogoEnterpriseController.update
+);
+router.delete(
+  "/:id",
+  supabaseAuthMiddleware(["ADMIN", "MODERADOR"]),
+  LogoEnterpriseController.remove
+);
+
+export { router as logoEnterpriseRoutes };

--- a/src/modules/website/services/banner.service.ts
+++ b/src/modules/website/services/banner.service.ts
@@ -1,0 +1,16 @@
+import { prisma } from "../../../config/prisma";
+import { WebsiteBanner } from "@prisma/client";
+
+export const bannerService = {
+  list: () =>
+    prisma.websiteBanner.findMany({
+      orderBy: { ordem: "asc" },
+    }),
+  get: (id: string) => prisma.websiteBanner.findUnique({ where: { id } }),
+  create: (
+    data: Omit<WebsiteBanner, "id" | "criadoEm" | "atualizadoEm">
+  ) => prisma.websiteBanner.create({ data }),
+  update: (id: string, data: Partial<WebsiteBanner>) =>
+    prisma.websiteBanner.update({ where: { id }, data }),
+  remove: (id: string) => prisma.websiteBanner.delete({ where: { id } }),
+};

--- a/src/modules/website/services/businessGroupInformation.service.ts
+++ b/src/modules/website/services/businessGroupInformation.service.ts
@@ -1,0 +1,21 @@
+import { prisma } from "../../../config/prisma";
+import { WebsiteBusinessGroupInformation } from "@prisma/client";
+
+export const businessGroupInformationService = {
+  list: () =>
+    prisma.websiteBusinessGroupInformation.findMany({
+      orderBy: { ordem: "asc" },
+    }),
+  get: (id: string) =>
+    prisma.websiteBusinessGroupInformation.findUnique({ where: { id } }),
+  create: (
+    data: Omit<
+      WebsiteBusinessGroupInformation,
+      "id" | "criadoEm" | "atualizadoEm"
+    >
+  ) => prisma.websiteBusinessGroupInformation.create({ data }),
+  update: (id: string, data: Partial<WebsiteBusinessGroupInformation>) =>
+    prisma.websiteBusinessGroupInformation.update({ where: { id }, data }),
+  remove: (id: string) =>
+    prisma.websiteBusinessGroupInformation.delete({ where: { id } }),
+};

--- a/src/modules/website/services/logoEnterprise.service.ts
+++ b/src/modules/website/services/logoEnterprise.service.ts
@@ -1,0 +1,18 @@
+import { prisma } from "../../../config/prisma";
+import { WebsiteLogoEnterprise } from "@prisma/client";
+
+export const logoEnterpriseService = {
+  list: () =>
+    prisma.websiteLogoEnterprise.findMany({
+      orderBy: { ordem: "asc" },
+    }),
+  get: (id: string) =>
+    prisma.websiteLogoEnterprise.findUnique({ where: { id } }),
+  create: (
+    data: Omit<WebsiteLogoEnterprise, "id" | "criadoEm" | "atualizadoEm">
+  ) => prisma.websiteLogoEnterprise.create({ data }),
+  update: (id: string, data: Partial<WebsiteLogoEnterprise>) =>
+    prisma.websiteLogoEnterprise.update({ where: { id }, data }),
+  remove: (id: string) =>
+    prisma.websiteLogoEnterprise.delete({ where: { id } }),
+};


### PR DESCRIPTION
## Summary
- add `WebsiteLogoEnterprise` model to Prisma schema
- implement logo enterprise controller/service/routes with image upload and ordering
- expose `/logo-enterprises` endpoints in website module
- introduce business group information model and CRUD endpoints

## Testing
- `pnpm prisma:generate`
- `pnpm build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6892bf4446ec8325bb55e869fbeb9692