### PR TITLE
fix: move build output to dist root

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "sourceMap": true,
+    "rootDir": "./src",
     "outDir": "./dist",
     "strict": true,
     "esModuleInterop": true,
@@ -11,5 +12,6 @@
     "isolatedModules": true,
     "types": ["node", "jest"]
   },
+  "include": ["src"],
   "exclude": ["node_modules", "**/*.test.ts"]
 }


### PR DESCRIPTION
## Summary
- ensure ts build outputs to dist root so Render can find index.js

## Testing
- `pnpm run build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6892d84e68148325bf5e69ccad3e592c