### PR TITLE
feat(db): allow ipv4 database connection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,11 @@ DATABASE_URL="postgresql://postgres.xxx:password@aws-0-sa-east-1.pooler.supabase
 # URL direta para migrações Prisma (sem pooler)
 DIRECT_URL="postgresql://postgres.xxx:password@aws-0-sa-east-1.pooler.supabase.com:5432/postgres"
 
+# Para ambientes que não suportam IPv6 (ex: alguns provedores de hospedagem),
+# é possível fornecer URLs alternativas explicitamente:
+# DATABASE_POOL_URL="postgresql://postgres.xxx:password@aws-0-sa-east-1.pooler.supabase.com:6543/postgres?pgbouncer=true&connection_limit=1"
+# DIRECT_POOL_URL="postgresql://postgres.xxx:password@aws-0-sa-east-1.pooler.supabase.com:5432/postgres"
+
 # =============================================
 # SUPABASE (OBRIGATÓRIO)
 # =============================================

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -448,8 +448,10 @@ export const serverConfig = {
 // =============================================
 
 export const databaseConfig = {
-  url: process.env.DATABASE_URL || "",
-  directUrl: process.env.DIRECT_URL || "",
+  // Allow overriding the connection string with an IPv4 friendly version
+  url: process.env.DATABASE_POOL_URL || process.env.DATABASE_URL || "",
+  directUrl:
+    process.env.DIRECT_POOL_URL || process.env.DIRECT_URL || "",
 
   // Validação da configuração
   isValid(): boolean {
@@ -460,8 +462,10 @@ export const databaseConfig = {
   getStatus(): { configured: boolean; issues: string[] } {
     const issues: string[] = [];
 
-    if (!this.url) issues.push("DATABASE_URL não configurada");
-    if (!this.directUrl) issues.push("DIRECT_URL não configurada");
+    if (!this.url)
+      issues.push("DATABASE_URL/DATABASE_POOL_URL não configurada");
+    if (!this.directUrl)
+      issues.push("DIRECT_URL/DIRECT_POOL_URL não configurada");
 
     return {
       configured: issues.length === 0,

--- a/src/config/prisma.ts
+++ b/src/config/prisma.ts
@@ -1,3 +1,10 @@
 import { PrismaClient } from "@prisma/client";
 
-export const prisma = new PrismaClient();
+// Prefer an IPv4-compatible connection string if provided
+// This allows deployments in environments without IPv6 support
+const datasourceUrl =
+  process.env.DATABASE_POOL_URL || process.env.DATABASE_URL;
+
+export const prisma = new PrismaClient({
+  datasourceUrl,
+});


### PR DESCRIPTION
## Summary
- allow overriding Prisma datasource with `DATABASE_POOL_URL` for IPv4-only hosts
- add environment configuration entries to use IPv4 friendly URLs
- document optional `DATABASE_POOL_URL` and `DIRECT_POOL_URL` in env example

## Testing
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6892e68d1d3c83258a39677d014163ae