### PR TITLE
feat: delete expired unverified users after token expiry

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import cors from "cors";
 import helmet from "helmet";
 import { serverConfig } from "./config/env";
 import { appRoutes } from "./routes";
+import { startExpiredUserCleanupJob } from "./modules/usuarios/services/user-cleanup-service";
 
 /**
  * Aplicação principal - AdvanceMais API
@@ -62,6 +63,7 @@ app.use(express.urlencoded({ extended: true }));
 try {
   app.use("/", appRoutes);
   console.log("✅ Router principal carregado com sucesso");
+  startExpiredUserCleanupJob();
 } catch (error) {
   console.error("❌ Erro crítico ao carregar router principal:", error);
 

--- a/src/modules/brevo/controllers/email-verification-controller.ts
+++ b/src/modules/brevo/controllers/email-verification-controller.ts
@@ -67,9 +67,10 @@ export class EmailVerificationController {
         res.status(400).json({
           success: false,
           message:
-            "Token de verificação expirado. Solicite um novo email de verificação.",
+            "Token de verificação expirado. Seu cadastro foi removido. Por favor, realize um novo cadastro.",
           code: "TOKEN_EXPIRED",
           userId: result.userId,
+          deleted: result.deleted,
         });
         return;
       }

--- a/src/modules/brevo/services/email-service.ts
+++ b/src/modules/brevo/services/email-service.ts
@@ -273,7 +273,8 @@ export class EmailService {
         usuario.emailVerificationTokenExp &&
         usuario.emailVerificationTokenExp < new Date()
       ) {
-        return { valid: false, expired: true, userId: usuario.id };
+        await prisma.usuario.delete({ where: { id: usuario.id } });
+        return { valid: false, expired: true, userId: usuario.id, deleted: true };
       }
 
       await prisma.usuario.update({

--- a/src/modules/brevo/services/email-verification-service.ts
+++ b/src/modules/brevo/services/email-verification-service.ts
@@ -25,6 +25,7 @@ export interface VerificationTokenResult {
   expired?: boolean;
   alreadyVerified?: boolean;
   error?: string;
+  deleted?: boolean;
 }
 
 export class EmailVerificationService {
@@ -243,7 +244,8 @@ export class EmailVerificationService {
         usuario.emailVerificationTokenExp &&
         usuario.emailVerificationTokenExp < new Date()
       ) {
-        return { valid: false, expired: true, userId: usuario.id };
+        await prisma.usuario.delete({ where: { id: usuario.id } });
+        return { valid: false, expired: true, userId: usuario.id, deleted: true };
       }
 
       // Token válido - marca como verificado

--- a/src/modules/usuarios/services/user-cleanup-service.ts
+++ b/src/modules/usuarios/services/user-cleanup-service.ts
@@ -1,0 +1,43 @@
+import { prisma } from "../../../config/prisma";
+
+/**
+ * Remove usuários que não confirmaram o email e cujo token expirou.
+ * @returns quantidade de registros removidos
+ */
+export async function deleteExpiredUnverifiedUsers(): Promise<number> {
+  const result = await prisma.usuario.deleteMany({
+    where: {
+      emailVerificado: false,
+      emailVerificationTokenExp: {
+        lt: new Date(),
+      },
+    },
+  });
+
+  if (result.count > 0) {
+    console.log(
+      `🧹 Removidos ${result.count} usuários com verificação de email expirada`
+    );
+  }
+
+  return result.count;
+}
+
+/**
+ * Agenda verificação periódica para remoção de usuários expirados.
+ * Executa imediatamente na inicialização e depois a cada hora.
+ */
+export function startExpiredUserCleanupJob(): void {
+  const runCleanup = async () => {
+    try {
+      await deleteExpiredUnverifiedUsers();
+    } catch (error) {
+      console.error("Erro ao remover usuários expirados:", error);
+    }
+  };
+
+  // Executa uma vez na inicialização
+  runCleanup();
+  // Executa a cada hora
+  setInterval(runCleanup, 60 * 60 * 1000);
+}


### PR DESCRIPTION
## Summary
- remove users with expired email verification
- run hourly cleanup of expired unverified accounts

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4fb6d8a8883259471e709ee9b39f4