### PR TITLE
fix: adjust verification flow for auth subdomain

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -126,6 +126,9 @@ MERCADOPAGO_DEFAULT_FREQUENCY_TYPE=months
 # URL do frontend (importante para links em emails)
 FRONTEND_URL=http://localhost:3000
 
+# URL do frontend de autenticação (opcional, para subdomínios)
+AUTH_FRONTEND_URL=http://localhost:3000/auth
+
 # CORS Origin (* para desenvolvimento, domínio específico para produção)
 CORS_ORIGIN=*
 

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -413,8 +413,11 @@ export const serverConfig = {
   port: parseInt(process.env.PORT || "3000", 10),
   nodeEnv: NODE_ENV,
   corsOrigin:
-    process.env.CORS_ORIGIN ||
-    (isDevelopment ? "*" : "https://advancemais.com"),
+    process.env.CORS_ORIGIN
+      ? process.env.CORS_ORIGIN.split(",").map((o) => o.trim())
+      : isDevelopment
+      ? "*"
+      : ["https://advancemais.com", "https://auth.advancemais.com"],
   frontendUrl: process.env.FRONTEND_URL || "http://localhost:3000",
 
   // Validação da configuração

--- a/src/modules/brevo/__tests__/email-verification.test.ts
+++ b/src/modules/brevo/__tests__/email-verification.test.ts
@@ -3,8 +3,9 @@ import request from "supertest";
 import { EmailVerificationController } from "../controllers/email-verification-controller";
 
 describe("Email verification flow", () => {
-  it("redirects to frontend on valid token", async () => {
+  it("returns success JSON on valid token", async () => {
     process.env.FRONTEND_URL = "http://app.advancemais.com";
+    process.env.AUTH_FRONTEND_URL = "http://auth.advancemais.com";
     const controller = new EmailVerificationController();
     // @ts-ignore accessing private property for test
     controller["emailService"] = {
@@ -17,8 +18,10 @@ describe("Email verification flow", () => {
     app.get("/verificar-email", controller.verifyEmail);
 
     const res = await request(app).get("/verificar-email?token=test");
-    expect(res.status).toBe(302);
-    expect(res.headers.location).toBe("http://app.advancemais.com");
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.redirectUrl).toBe("http://app.advancemais.com");
+    expect(res.body.userId).toBe("1");
   });
 
   it("returns 400 for invalid token", async () => {

--- a/src/modules/brevo/config/brevo-config.ts
+++ b/src/modules/brevo/config/brevo-config.ts
@@ -112,6 +112,8 @@ export class BrevoConfigManager {
   private buildConfiguration(): BrevoConfiguration {
     const isConfigured = !!(brevoConfig.apiKey && brevoConfig.fromEmail);
     const frontendUrl = process.env.FRONTEND_URL || "http://localhost:3000";
+    const authUrl =
+      process.env.AUTH_FRONTEND_URL || `${frontendUrl}/auth`;
 
     return {
       apiKey: brevoConfig.apiKey || "",
@@ -124,8 +126,8 @@ export class BrevoConfigManager {
 
       urls: {
         frontend: frontendUrl,
-        verification: `${frontendUrl}/auth/verify-email`,
-        passwordRecovery: `${frontendUrl}/recuperar-senha`,
+        verification: `${authUrl}/verify-email`,
+        passwordRecovery: `${authUrl}/recuperar-senha`,
       },
 
       emailVerification: {

--- a/src/modules/brevo/controllers/email-verification-controller.ts
+++ b/src/modules/brevo/controllers/email-verification-controller.ts
@@ -48,7 +48,12 @@ export class EmailVerificationController {
         );
 
         const redirectUrl = this.config.getConfig().urls.frontend;
-        res.redirect(redirectUrl);
+        res.json({
+          success: true,
+          message: "Email verificado com sucesso",
+          redirectUrl,
+          userId: result.userId,
+        });
         return;
       }
 


### PR DESCRIPTION
## Summary
- handle multiple CORS origins and include auth subdomain
- support AUTH_FRONTEND_URL and build verification/password recovery URLs
- return JSON from email verification instead of redirect
- document AUTH_FRONTEND_URL in env example

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a506e926048325998d184d0f2197f3