### PR TITLE
fix: allow app domain via cors

### DIFF
--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -416,6 +416,7 @@ export const serverConfig = {
     const defaultOrigins = [
       "https://advancemais.com",
       "https://auth.advancemais.com",
+      "https://app.advancemais.com",
     ];
 
     if (process.env.CORS_ORIGIN) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,8 @@ app.use(
   cors({
     origin: serverConfig.corsOrigin,
     credentials: true,
+    methods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+    allowedHeaders: ["Authorization", "Content-Type"],
   })
 );
 


### PR DESCRIPTION
## Summary
- add explicit methods and headers to CORS middleware
- include app.advancemais.com in default CORS origins

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a67152f03c83259346d21273937d52