### PR TITLE
feat: add company plan recurrence and audit module

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -55,6 +55,7 @@ model Usuario {
   mercadoPagoSubscriptions      MercadoPagoSubscription[]
   mercadoPagoSubscriptionPayments MercadoPagoSubscriptionPayment[]
   mercadoPagoTransactions       MercadoPagoTransaction[]
+  auditLogs                     AuditLog[]
   
   @@index([tokenRecuperacao])
   @@index([emailVerificationToken])
@@ -65,6 +66,8 @@ model Empresa {
   nome     String
   criadoEm DateTime  @default(now())
   usuarios Usuario[]
+  planos   EmpresaPlano[]
+  auditLogs AuditLog[]
 }
 
 model Endereco {
@@ -348,6 +351,66 @@ model MercadoPagoTransaction {
   @@map("mercadopago_transactions")
 }
 
+// Plano de assinaturas disponíveis para empresas
+model MercadoPagoPlan {
+  id          String   @id @default(uuid())
+  nome        String
+  valor       Float
+  descricao   String
+  recursos    String[]
+  ativo       Boolean  @default(true)
+  mercadoPagoPlanId String? @unique
+  frequency   Int
+  frequencyType PlanFrequencyType
+  repetitions Int?
+  criadoEm    DateTime @default(now())
+  atualizadoEm DateTime @updatedAt
+  empresaPlanos EmpresaPlano[]
+
+  @@map("mercadopago_plans")
+}
+
+// Associação de planos com empresas
+model EmpresaPlano {
+  id             String             @id @default(uuid())
+  empresaId      String
+  planoId        String
+  metodoPagamento PlanPaymentMethod
+  tipo           CompanyPlanType    @default(STANDARD)
+  validade       PlanValidity?
+  inicio         DateTime           @default(now())
+  fim            DateTime?
+  criadoEm       DateTime           @default(now())
+  atualizadoEm   DateTime           @updatedAt
+
+  empresa        Empresa            @relation(fields: [empresaId], references: [id])
+  plano          MercadoPagoPlan    @relation(fields: [planoId], references: [id])
+
+  @@index([empresaId])
+  @@index([planoId])
+  @@index([metodoPagamento])
+  @@unique([empresaId])
+  @@map("empresa_planos")
+}
+
+// Logs de auditoria para rastrear ações administrativas
+model AuditLog {
+  id        String   @id @default(uuid())
+  usuarioId String
+  empresaId String?
+  acao      String
+  detalhes  Json?
+  criadoEm  DateTime @default(now())
+
+  usuario   Usuario  @relation(fields: [usuarioId], references: [id])
+  empresa   Empresa? @relation(fields: [empresaId], references: [id])
+
+  @@index([usuarioId])
+  @@index([empresaId])
+  @@index([acao])
+  @@map("audit_logs")
+}
+
 model WebsiteSobre {
   id           String   @id @default(uuid())
   imagemUrl    String
@@ -464,4 +527,34 @@ enum StatusSMS {
 enum CodigoTipo {
   USUARIO
   EMPRESA
+}
+
+// Métodos de pagamento aceitos para planos
+enum PlanPaymentMethod {
+  PIX
+  BOLETO
+  CARTAO_CREDITO
+  CARTAO_DEBITO
+  DINHEIRO
+}
+
+// Indica se o plano foi atribuído como padrão ou para empresa parceira
+enum CompanyPlanType {
+  STANDARD
+  PARTNER
+}
+
+// Tipo de frequência para recorrência de planos
+enum PlanFrequencyType {
+  DIAS
+  MESES
+}
+
+// Validades permitidas para planos atribuídos a empresas
+enum PlanValidity {
+  DIAS_15
+  DIAS_30
+  DIAS_90
+  DIAS_120
+  SEM_VALIDADE
 }

--- a/src/modules/audit/controllers/audit-controller.ts
+++ b/src/modules/audit/controllers/audit-controller.ts
@@ -1,0 +1,27 @@
+import { Request, Response } from "express";
+import { AuditService } from "../services/audit-service";
+
+export class AuditController {
+  private auditService: AuditService;
+
+  constructor() {
+    this.auditService = new AuditService();
+  }
+
+  public getLogs = async (req: Request, res: Response) => {
+    try {
+      const empresaId = typeof req.query.empresaId === "string" ? req.query.empresaId : undefined;
+      const result = await this.auditService.getLogs(empresaId);
+      if (result.success) {
+        res.json({ logs: result.data });
+      } else {
+        res.status(400).json({ message: result.error?.message, error: result.error });
+      }
+    } catch (error) {
+      res.status(500).json({
+        message: "Erro interno do servidor",
+        error: error instanceof Error ? error.message : error,
+      });
+    }
+  };
+}

--- a/src/modules/audit/index.ts
+++ b/src/modules/audit/index.ts
@@ -1,0 +1,12 @@
+export { auditRoutes } from "./routes";
+export { AuditService } from "./services/audit-service";
+export { AuditController } from "./controllers/audit-controller";
+
+export const AuditModule = {
+  name: "Audit",
+  version: "1.0.0",
+  description: "Logs de auditoria do sistema",
+  endpoints: {
+    logs: "/api/v1/audit/logs",
+  },
+} as const;

--- a/src/modules/audit/routes/index.ts
+++ b/src/modules/audit/routes/index.ts
@@ -1,0 +1,20 @@
+import { Router } from "express";
+import { logsRoutes } from "./logs";
+
+const router = Router();
+
+router.get("/", (req, res) => {
+  res.json({
+    message: "Audit Module API",
+    version: "v1",
+    timestamp: new Date().toISOString(),
+    endpoints: {
+      logs: "/logs",
+    },
+    status: "operational",
+  });
+});
+
+router.use("/logs", logsRoutes);
+
+export { router as auditRoutes };

--- a/src/modules/audit/routes/logs.ts
+++ b/src/modules/audit/routes/logs.ts
@@ -1,0 +1,11 @@
+import { Router } from "express";
+import { AuditController } from "../controllers/audit-controller";
+import { authMiddlewareWithDB } from "../../usuarios/middlewares";
+import { Role } from "../../usuarios/enums/Role";
+
+const router = Router();
+const controller = new AuditController();
+
+router.get("/", authMiddlewareWithDB([Role.ADMIN]), controller.getLogs);
+
+export { router as logsRoutes };

--- a/src/modules/audit/services/audit-service.ts
+++ b/src/modules/audit/services/audit-service.ts
@@ -1,0 +1,23 @@
+import { prisma } from "../../../config/prisma";
+import { ServiceResponse } from "../../mercadopago/types/order";
+
+export class AuditService {
+  async getLogs(empresaId?: string): Promise<ServiceResponse<any>> {
+    try {
+      const logs = await prisma.auditLog.findMany({
+        where: empresaId ? { empresaId } : undefined,
+        orderBy: { criadoEm: "desc" },
+      });
+      return { success: true, data: logs };
+    } catch (error) {
+      return {
+        success: false,
+        error: {
+          message: "Erro ao buscar logs de auditoria",
+          details: error instanceof Error ? error.message : error,
+          code: "GET_AUDIT_LOGS_ERROR",
+        },
+      };
+    }
+  }
+}

--- a/src/modules/empresa/controllers/plan-controller.ts
+++ b/src/modules/empresa/controllers/plan-controller.ts
@@ -1,0 +1,113 @@
+import { Request, Response } from "express";
+import { PlanService } from "../services/plan-service";
+
+export class PlanController {
+  private planService: PlanService;
+
+  constructor() {
+    this.planService = new PlanService();
+  }
+
+  public createPlan = async (req: Request, res: Response) => {
+    try {
+      const userId = req.user?.id;
+      if (!userId) {
+        return res.status(401).json({ message: "Usuário não autenticado" });
+      }
+
+      const result = await this.planService.createPlan(req.body, userId);
+      if (result.success) {
+        res.status(201).json({ message: "Plano criado", plan: result.data });
+      } else {
+        res.status(400).json({ message: result.error?.message, error: result.error });
+      }
+    } catch (error) {
+      res.status(500).json({
+        message: "Erro interno do servidor",
+        error: error instanceof Error ? error.message : error,
+      });
+    }
+  };
+
+  public getPlans = async (req: Request, res: Response) => {
+    try {
+      const result = await this.planService.getPlans();
+      if (result.success) {
+        res.json({ plans: result.data });
+      } else {
+        res.status(400).json({ message: result.error?.message, error: result.error });
+      }
+    } catch (error) {
+      res.status(500).json({
+        message: "Erro interno do servidor",
+        error: error instanceof Error ? error.message : error,
+      });
+    }
+  };
+
+  public updatePlan = async (req: Request, res: Response) => {
+    try {
+      const userId = req.user?.id;
+      if (!userId) {
+        return res.status(401).json({ message: "Usuário não autenticado" });
+      }
+      const { planId } = req.params;
+      const result = await this.planService.updatePlan(planId, req.body, userId);
+      if (result.success) {
+        res.json({ message: "Plano atualizado", plan: result.data });
+      } else {
+        res.status(400).json({ message: result.error?.message, error: result.error });
+      }
+    } catch (error) {
+      res.status(500).json({
+        message: "Erro interno do servidor",
+        error: error instanceof Error ? error.message : error,
+      });
+    }
+  };
+
+  public assignPlan = async (req: Request, res: Response) => {
+    try {
+      const userId = req.user?.id;
+      if (!userId) {
+        return res.status(401).json({ message: "Usuário não autenticado" });
+      }
+      const { planId } = req.params;
+      const result = await this.planService.assignPlan(planId, req.body, userId);
+      if (result.success) {
+        res.json({
+          message: "Plano vinculado à empresa",
+          empresaPlano: result.data,
+        });
+      } else {
+        res.status(400).json({ message: result.error?.message, error: result.error });
+      }
+    } catch (error) {
+      res.status(500).json({
+        message: "Erro interno do servidor",
+        error: error instanceof Error ? error.message : error,
+      });
+    }
+  };
+
+  public unassignPlan = async (req: Request, res: Response) => {
+    try {
+      const userId = req.user?.id;
+      if (!userId) {
+        return res.status(401).json({ message: "Usuário não autenticado" });
+      }
+      const { empresaId } = req.params;
+      const result = await this.planService.unassignPlan(empresaId, userId);
+      if (result.success) {
+        res.json({ message: "Plano desvinculado da empresa" });
+      } else {
+        res.status(400).json({ message: result.error?.message, error: result.error });
+      }
+    } catch (error) {
+      res.status(500).json({
+        message: "Erro interno do servidor",
+        error: error instanceof Error ? error.message : error,
+      });
+    }
+  };
+}

--- a/src/modules/empresa/enums/CompanyPlanType.ts
+++ b/src/modules/empresa/enums/CompanyPlanType.ts
@@ -1,0 +1,7 @@
+/**
+ * Indica se o plano atribuído à empresa é padrão ou por parceria
+ */
+export enum CompanyPlanType {
+  STANDARD = "STANDARD",
+  PARTNER = "PARTNER",
+}

--- a/src/modules/empresa/enums/PlanFrequencyType.ts
+++ b/src/modules/empresa/enums/PlanFrequencyType.ts
@@ -1,0 +1,4 @@
+export enum PlanFrequencyType {
+  DIAS = "DIAS",
+  MESES = "MESES",
+}

--- a/src/modules/empresa/enums/PlanPaymentMethod.ts
+++ b/src/modules/empresa/enums/PlanPaymentMethod.ts
@@ -1,0 +1,10 @@
+/**
+ * Métodos de pagamento aceitos para planos
+ */
+export enum PlanPaymentMethod {
+  PIX = "PIX",
+  BOLETO = "BOLETO",
+  CARTAO_CREDITO = "CARTAO_CREDITO",
+  CARTAO_DEBITO = "CARTAO_DEBITO",
+  DINHEIRO = "DINHEIRO",
+}

--- a/src/modules/empresa/enums/PlanValidity.ts
+++ b/src/modules/empresa/enums/PlanValidity.ts
@@ -1,0 +1,7 @@
+export enum PlanValidity {
+  DIAS_15 = "DIAS_15",
+  DIAS_30 = "DIAS_30",
+  DIAS_90 = "DIAS_90",
+  DIAS_120 = "DIAS_120",
+  SEM_VALIDADE = "SEM_VALIDADE",
+}

--- a/src/modules/empresa/enums/index.ts
+++ b/src/modules/empresa/enums/index.ts
@@ -1,0 +1,4 @@
+export { PlanPaymentMethod } from "./PlanPaymentMethod";
+export { CompanyPlanType } from "./CompanyPlanType";
+export { PlanFrequencyType } from "./PlanFrequencyType";
+export { PlanValidity } from "./PlanValidity";

--- a/src/modules/empresa/index.ts
+++ b/src/modules/empresa/index.ts
@@ -1,0 +1,20 @@
+/**
+ * Módulo Empresa - gerenciamento de planos e auditoria
+ */
+
+export * from "./enums";
+export * from "./types";
+
+export { PlanService } from "./services/plan-service";
+export { PlanController } from "./controllers/plan-controller";
+
+export { empresaRoutes } from "./routes";
+
+export const EmpresaModule = {
+  name: "Empresa",
+  version: "1.0.0",
+  description: "Gestão de planos para empresas",
+  endpoints: {
+    plans: "/api/v1/empresa/plans",
+  },
+} as const;

--- a/src/modules/empresa/routes/index.ts
+++ b/src/modules/empresa/routes/index.ts
@@ -1,0 +1,20 @@
+import { Router } from "express";
+import { plansRoutes } from "./plans";
+
+const router = Router();
+
+router.get("/", (req, res) => {
+  res.json({
+    message: "Empresa Module API",
+    version: "v1",
+    timestamp: new Date().toISOString(),
+    endpoints: {
+      plans: "/plans",
+    },
+    status: "operational",
+  });
+});
+
+router.use("/plans", plansRoutes);
+
+export { router as empresaRoutes };

--- a/src/modules/empresa/routes/plans.ts
+++ b/src/modules/empresa/routes/plans.ts
@@ -1,0 +1,27 @@
+import { Router } from "express";
+import { PlanController } from "../controllers/plan-controller";
+import { authMiddlewareWithDB } from "../../usuarios/middlewares";
+import { Role } from "../../usuarios/enums/Role";
+
+const router = Router();
+const controller = new PlanController();
+
+router.post("/", authMiddlewareWithDB([Role.ADMIN]), controller.createPlan);
+router.get("/", controller.getPlans);
+router.put(
+  "/:planId",
+  authMiddlewareWithDB([Role.ADMIN]),
+  controller.updatePlan
+);
+router.post(
+  "/:planId/assign",
+  authMiddlewareWithDB([Role.ADMIN]),
+  controller.assignPlan
+);
+router.delete(
+  "/companies/:empresaId/plan",
+  authMiddlewareWithDB([Role.ADMIN]),
+  controller.unassignPlan
+);
+
+export { router as plansRoutes };

--- a/src/modules/empresa/services/plan-service.ts
+++ b/src/modules/empresa/services/plan-service.ts
@@ -1,0 +1,199 @@
+import { prisma } from "../../../config/prisma";
+import {
+  CreatePlanRequest,
+  UpdatePlanRequest,
+  AssignPlanRequest,
+} from "../types/plan";
+import { ServiceResponse } from "../../mercadopago/types/order";
+import { CompanyPlanType, PlanValidity } from "../enums";
+
+const MAX_PLANS = 4;
+
+export class PlanService {
+  async createPlan(
+    data: CreatePlanRequest,
+    usuarioId: string
+  ): Promise<ServiceResponse<any>> {
+    try {
+      const count = await prisma.mercadoPagoPlan.count();
+      if (count >= MAX_PLANS) {
+        return {
+          success: false,
+          error: {
+            message: "Limite de planos atingido",
+            code: "PLAN_LIMIT_REACHED",
+          },
+        };
+      }
+
+      const plan = await prisma.mercadoPagoPlan.create({ data });
+
+      await prisma.auditLog.create({
+        data: {
+          usuarioId,
+          acao: "CREATE_PLAN",
+          detalhes: plan,
+        },
+      });
+
+      return { success: true, data: plan };
+    } catch (error) {
+      return {
+        success: false,
+        error: {
+          message: "Erro ao criar plano",
+          details: error instanceof Error ? error.message : error,
+          code: "CREATE_PLAN_ERROR",
+        },
+      };
+    }
+  }
+
+  async getPlans(): Promise<ServiceResponse<any>> {
+    try {
+      const plans = await prisma.mercadoPagoPlan.findMany();
+      return { success: true, data: plans };
+    } catch (error) {
+      return {
+        success: false,
+        error: {
+          message: "Erro ao buscar planos",
+          details: error instanceof Error ? error.message : error,
+          code: "GET_PLANS_ERROR",
+        },
+      };
+    }
+  }
+
+  async updatePlan(
+    id: string,
+    data: UpdatePlanRequest,
+    usuarioId: string
+  ): Promise<ServiceResponse<any>> {
+    try {
+      const plan = await prisma.mercadoPagoPlan.update({
+        where: { id },
+        data,
+      });
+
+      await prisma.auditLog.create({
+        data: {
+          usuarioId,
+          acao: "UPDATE_PLAN",
+          detalhes: { id, data },
+        },
+      });
+
+      return { success: true, data: plan };
+    } catch (error) {
+      return {
+        success: false,
+        error: {
+          message: "Erro ao atualizar plano",
+          details: error instanceof Error ? error.message : error,
+          code: "UPDATE_PLAN_ERROR",
+        },
+      };
+    }
+  }
+
+  async assignPlan(
+    planId: string,
+    payload: AssignPlanRequest,
+    usuarioId: string
+  ): Promise<ServiceResponse<any>> {
+    try {
+      const empresa = await prisma.empresa.findUnique({
+        where: { id: payload.empresaId },
+      });
+
+      if (!empresa) {
+        return {
+          success: false,
+          error: {
+            message: "Empresa não encontrada",
+            code: "COMPANY_NOT_FOUND",
+          },
+        };
+      }
+
+      const diasMap: Record<PlanValidity, number> = {
+        [PlanValidity.DIAS_15]: 15,
+        [PlanValidity.DIAS_30]: 30,
+        [PlanValidity.DIAS_90]: 90,
+        [PlanValidity.DIAS_120]: 120,
+        [PlanValidity.SEM_VALIDADE]: 0,
+      };
+
+      const dias = payload.validade ? diasMap[payload.validade] : 0;
+
+      const data = {
+        empresaId: payload.empresaId,
+        planoId: planId,
+        metodoPagamento: payload.metodoPagamento,
+        tipo: payload.tipo ?? CompanyPlanType.STANDARD,
+        validade: payload.validade ?? null,
+        inicio: new Date(),
+        fim:
+          dias > 0 ? new Date(Date.now() + dias * 24 * 60 * 60 * 1000) : null,
+      };
+
+      const empresaPlano = await prisma.empresaPlano.upsert({
+        where: { empresaId: payload.empresaId },
+        update: data,
+        create: data,
+      });
+
+      await prisma.auditLog.create({
+        data: {
+          usuarioId,
+          empresaId: payload.empresaId,
+          acao: "ASSIGN_PLAN",
+          detalhes: { planId, ...data },
+        },
+      });
+
+      return { success: true, data: empresaPlano };
+    } catch (error) {
+      return {
+        success: false,
+        error: {
+          message: "Erro ao vincular plano",
+          details: error instanceof Error ? error.message : error,
+          code: "ASSIGN_PLAN_ERROR",
+        },
+      };
+    }
+  }
+
+  async unassignPlan(
+    empresaId: string,
+    usuarioId: string
+  ): Promise<ServiceResponse<any>> {
+    try {
+      const deleted = await prisma.empresaPlano.deleteMany({
+        where: { empresaId },
+      });
+
+      await prisma.auditLog.create({
+        data: {
+          usuarioId,
+          empresaId,
+          acao: "UNASSIGN_PLAN",
+          detalhes: { removed: deleted.count },
+        },
+      });
+
+      return { success: true, data: deleted };
+    } catch (error) {
+      return {
+        success: false,
+        error: {
+          message: "Erro ao desvincular plano",
+          details: error instanceof Error ? error.message : error,
+          code: "UNASSIGN_PLAN_ERROR",
+        },
+      };
+    }
+  }
+}

--- a/src/modules/empresa/types/index.ts
+++ b/src/modules/empresa/types/index.ts
@@ -1,0 +1,1 @@
+export * from "./plan";

--- a/src/modules/empresa/types/plan.ts
+++ b/src/modules/empresa/types/plan.ts
@@ -1,0 +1,36 @@
+import {
+  PlanPaymentMethod,
+  CompanyPlanType,
+  PlanFrequencyType,
+  PlanValidity,
+} from "../enums";
+
+export interface CreatePlanRequest {
+  nome: string;
+  valor: number;
+  descricao: string;
+  recursos: string[];
+  mercadoPagoPlanId?: string;
+  frequency: number;
+  frequencyType: PlanFrequencyType;
+  repetitions?: number | null;
+}
+
+export interface UpdatePlanRequest {
+  nome?: string;
+  valor?: number;
+  descricao?: string;
+  recursos?: string[];
+  ativo?: boolean;
+  mercadoPagoPlanId?: string | null;
+  frequency?: number;
+  frequencyType?: PlanFrequencyType;
+  repetitions?: number | null;
+}
+
+export interface AssignPlanRequest {
+  empresaId: string;
+  metodoPagamento: PlanPaymentMethod;
+  tipo?: CompanyPlanType;
+  validade?: PlanValidity | null;
+}

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -3,6 +3,8 @@ import { usuarioRoutes } from "../modules/usuarios";
 import { mercadoPagoRoutes } from "../modules/mercadopago";
 import { brevoRoutes } from "../modules/brevo/routes";
 import { websiteRoutes } from "../modules/website";
+import { empresaRoutes } from "../modules/empresa";
+import { auditRoutes } from "../modules/audit";
 import { EmailVerificationController } from "../modules/brevo/controllers/email-verification-controller";
 
 /**
@@ -32,6 +34,8 @@ router.get("/", (req, res) => {
       mercadopago: "/api/v1/mercadopago",
       brevo: "/api/v1/brevo",
       website: "/api/v1/website",
+      empresa: "/api/v1/empresa",
+      audit: "/api/v1/audit",
       health: "/health",
     },
   };
@@ -65,6 +69,8 @@ router.get("/", (req, res) => {
         <li>🏦 MercadoPago: <code>${data.endpoints.mercadopago}</code></li>
         <li>📧 Brevo: <code>${data.endpoints.brevo}</code></li>
         <li>🌐 Website: <code>${data.endpoints.website}</code></li>
+      <li>🏢 Empresa: <code>${data.endpoints.empresa}</code></li>
+        <li>📜 Audit: <code>${data.endpoints.audit}</code></li>
         <li>💚 Health: <code>${data.endpoints.health}</code></li>
       </ul>
       <footer>
@@ -97,6 +103,8 @@ router.get("/health", (req, res) => {
       mercadopago: "✅ active",
       brevo: "✅ active",
       website: "✅ active",
+      empresa: "✅ active",
+      audit: "✅ active",
     },
   });
 });
@@ -166,6 +174,36 @@ if (websiteRoutes) {
   }
 } else {
   console.error("❌ websiteRoutes não está definido");
+}
+
+/**
+ * Módulo Empresa - COM VALIDAÇÃO
+ * /api/v1/empresa/*
+ */
+if (empresaRoutes) {
+  try {
+    router.use("/api/v1/empresa", empresaRoutes);
+    console.log("✅ Módulo Empresa registrado com sucesso");
+  } catch (error) {
+    console.error("❌ ERRO - Módulo Empresa:", error);
+  }
+} else {
+  console.error("❌ empresaRoutes não está definido");
+}
+
+/**
+ * Módulo de Auditoria - COM VALIDAÇÃO
+ * /api/v1/audit/*
+ */
+if (auditRoutes) {
+  try {
+    router.use("/api/v1/audit", auditRoutes);
+    console.log("✅ Módulo Auditoria registrado com sucesso");
+  } catch (error) {
+    console.error("❌ ERRO - Módulo Auditoria:", error);
+  }
+} else {
+  console.error("❌ auditRoutes não está definido");
 }
 
 /**


### PR DESCRIPTION
## Summary
- track MercadoPago plan recurrence with frequency and validity enums
- allow administrators to audit plan operations via dedicated /api/v1/audit/logs

## Testing
- `pnpm prisma:generate`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8a4560bc083259ab374c96d0f7d91