### PR TITLE
feat: expand swagger docs across modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,8 @@
     "@types/multer": "^2.0.0",
     "@types/node": "^24.1.0",
     "@types/supertest": "^2.0.16",
+    "@types/swagger-jsdoc": "^6.0.4",
+    "@types/swagger-ui-express": "^4.1.8",
     "cross-env": "^7.0.3",
     "jest": "^29.7.0",
     "supertest": "^6.3.3",
@@ -68,6 +70,8 @@
     "mercadopago": "^2.8.0",
     "multer": "^2.0.2",
     "prisma": "^6.13.0",
+    "swagger-jsdoc": "^6.2.8",
+    "swagger-ui-express": "^5.0.1",
     "zod": "^3.23.8"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,12 @@ importers:
       prisma:
         specifier: ^6.13.0
         version: 6.13.0(typescript@5.9.2)
+      swagger-jsdoc:
+        specifier: ^6.2.8
+        version: 6.2.8(openapi-types@12.1.3)
+      swagger-ui-express:
+        specifier: ^5.0.1
+        version: 5.0.1(express@4.21.2)
       zod:
         specifier: ^3.23.8
         version: 3.25.76
@@ -75,6 +81,12 @@ importers:
       '@types/supertest':
         specifier: ^2.0.16
         version: 2.0.16
+      '@types/swagger-jsdoc':
+        specifier: ^6.0.4
+        version: 6.0.4
+      '@types/swagger-ui-express':
+        specifier: ^4.1.8
+        version: 4.1.8
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -99,6 +111,21 @@ packages:
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
+
+  '@apidevtools/json-schema-ref-parser@9.1.2':
+    resolution: {integrity: sha512-r1w81DpR+KyRWd3f+rk6TNqMgedmAxZP5v5KWlXQWlgMUUtyEJch0DKEci1SorPMiSeM8XPl7MZ3miJ60JIpQg==}
+
+  '@apidevtools/openapi-schemas@2.1.0':
+    resolution: {integrity: sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ==}
+    engines: {node: '>=10'}
+
+  '@apidevtools/swagger-methods@3.0.2':
+    resolution: {integrity: sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg==}
+
+  '@apidevtools/swagger-parser@10.0.3':
+    resolution: {integrity: sha512-sNiLY51vZOmSPFZA5TF35KZ2HbgYklQnTSDnkghamzLb3EkNtcQnrBQEj5AOCxHpTtXpqMCRM1CrmV2rG6nw4g==}
+    peerDependencies:
+      openapi-types: '>=7'
 
   '@babel/code-frame@7.27.1':
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
@@ -393,6 +420,9 @@ packages:
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
+  '@jsdevtools/ono@7.1.3':
+    resolution: {integrity: sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==}
+
   '@noble/hashes@1.8.0':
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
@@ -441,6 +471,9 @@ packages:
 
   '@prisma/get-platform@6.13.0':
     resolution: {integrity: sha512-Nii2pX50fY4QKKxQwm7/vvqT6Ku8yYJLZAFX4e2vzHwRdMqjugcOG5hOSLjxqoXb0cvOspV70TOhMzrw8kqAnw==}
+
+  '@scarf/scarf@1.4.0':
+    resolution: {integrity: sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==}
 
   '@sinclair/typebox@0.27.8':
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
@@ -539,6 +572,9 @@ packages:
   '@types/jest@29.5.14':
     resolution: {integrity: sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==}
 
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
   '@types/jsonwebtoken@9.0.10':
     resolution: {integrity: sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==}
 
@@ -589,6 +625,12 @@ packages:
 
   '@types/supertest@2.0.16':
     resolution: {integrity: sha512-6c2ogktZ06tr2ENoZivgm7YnprnhYE4ZoXGMY+oA7IuAf17M8FWvujXZGmxLv8y0PTyts4x5A+erSwVUFA8XSg==}
+
+  '@types/swagger-jsdoc@6.0.4':
+    resolution: {integrity: sha512-W+Xw5epcOZrF/AooUM/PccNMSAFOKWZA5dasNyMujTwsBkU74njSJBpvCCJhHAJ95XRMzQrrW844Btu0uoetwQ==}
+
+  '@types/swagger-ui-express@4.1.8':
+    resolution: {integrity: sha512-AhZV8/EIreHFmBV5wAs0gzJUNq9JbbSXgJLQubCC0jtIo6prnI9MIRRxnU4MZX9RB9yXxF1V4R7jtLl/Wcj31g==}
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
@@ -772,6 +814,9 @@ packages:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
 
+  call-me-maybe@1.0.2:
+    resolution: {integrity: sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==}
+
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
@@ -837,6 +882,14 @@ packages:
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
+
+  commander@6.2.0:
+    resolution: {integrity: sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q==}
+    engines: {node: '>= 6'}
+
+  commander@9.5.0:
+    resolution: {integrity: sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==}
+    engines: {node: ^12.20.0 || >=14}
 
   component-emitter@1.3.1:
     resolution: {integrity: sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==}
@@ -1250,6 +1303,10 @@ packages:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
 
+  glob@7.1.6:
+    resolution: {integrity: sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==}
+    deprecated: Glob versions prior to v9 are no longer supported
+
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     deprecated: Glob versions prior to v9 are no longer supported
@@ -1662,11 +1719,19 @@ packages:
   lodash.clonedeep@4.5.0:
     resolution: {integrity: sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==}
 
+  lodash.get@4.4.2:
+    resolution: {integrity: sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==}
+    deprecated: This package is deprecated. Use the optional chaining (?.) operator instead.
+
   lodash.includes@4.3.0:
     resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
 
   lodash.isboolean@3.0.3:
     resolution: {integrity: sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==}
+
+  lodash.isequal@4.5.0:
+    resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
+    deprecated: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
 
   lodash.isinteger@4.0.4:
     resolution: {integrity: sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==}
@@ -1685,6 +1750,9 @@ packages:
 
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  lodash.mergewith@4.6.2:
+    resolution: {integrity: sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==}
 
   lodash.once@4.1.1:
     resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
@@ -1861,6 +1929,9 @@ packages:
   onetime@5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
+
+  openapi-types@12.1.3:
+    resolution: {integrity: sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -2241,6 +2312,24 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  swagger-jsdoc@6.2.8:
+    resolution: {integrity: sha512-VPvil1+JRpmJ55CgAtn8DIcpBs0bL5L3q5bVQvF4tAW/k/9JYSj7dCpaYCAv5rufe0vcCbBRQXGvzpkWjvLklQ==}
+    engines: {node: '>=12.0.0'}
+    hasBin: true
+
+  swagger-parser@10.0.3:
+    resolution: {integrity: sha512-nF7oMeL4KypldrQhac8RyHerJeGPD1p2xDh900GPvc+Nk7nWP6jX2FcC7WmkinMoAmoO774+AFXcWsW8gMWEIg==}
+    engines: {node: '>=10'}
+
+  swagger-ui-dist@5.27.1:
+    resolution: {integrity: sha512-oGtpYO3lnoaqyGtlJalvryl7TwzgRuxpOVWqEHx8af0YXI+Kt+4jMpLdgMtMcmWmuQ0QTCHLKExwrBFMSxvAUA==}
+
+  swagger-ui-express@5.0.1:
+    resolution: {integrity: sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==}
+    engines: {node: '>= v0.10.32'}
+    peerDependencies:
+      express: '>=4.0.0 || >=5.0.0-beta'
+
   test-exclude@6.0.0:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
     engines: {node: '>=8'}
@@ -2417,6 +2506,10 @@ packages:
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
 
+  validator@13.15.15:
+    resolution: {integrity: sha512-BgWVbCI72aIQy937xbawcs+hrVaN/CZ2UwutgaJ36hGqRrLNM+f5LUT/YPRbo8IV/ASeFzXszezV+y2+rq3l8A==}
+    engines: {node: '>= 0.10'}
+
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
@@ -2483,6 +2576,10 @@ packages:
   yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
 
+  yaml@2.0.0-1:
+    resolution: {integrity: sha512-W7h5dEhywMKenDJh2iX/LABkbFnBxasD27oyXWDS/feDsxiw0dD5ncXdYXgkvAsXIY2MpW/ZKkr9IU30DBdMNQ==}
+    engines: {node: '>= 6'}
+
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
@@ -2499,6 +2596,11 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
+  z-schema@5.0.5:
+    resolution: {integrity: sha512-D7eujBWkLa3p2sIpJA0d1pr7es+a7m0vFAnZLlCEKq/Ij2k0MLi9Br2UPxoxdYystm5K1yeBGzub0FlYUEWj2Q==}
+    engines: {node: '>=8.0.0'}
+    hasBin: true
+
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
@@ -2508,6 +2610,27 @@ snapshots:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.12
       '@jridgewell/trace-mapping': 0.3.29
+
+  '@apidevtools/json-schema-ref-parser@9.1.2':
+    dependencies:
+      '@jsdevtools/ono': 7.1.3
+      '@types/json-schema': 7.0.15
+      call-me-maybe: 1.0.2
+      js-yaml: 4.1.0
+
+  '@apidevtools/openapi-schemas@2.1.0': {}
+
+  '@apidevtools/swagger-methods@3.0.2': {}
+
+  '@apidevtools/swagger-parser@10.0.3(openapi-types@12.1.3)':
+    dependencies:
+      '@apidevtools/json-schema-ref-parser': 9.1.2
+      '@apidevtools/openapi-schemas': 2.1.0
+      '@apidevtools/swagger-methods': 3.0.2
+      '@jsdevtools/ono': 7.1.3
+      call-me-maybe: 1.0.2
+      openapi-types: 12.1.3
+      z-schema: 5.0.5
 
   '@babel/code-frame@7.27.1':
     dependencies:
@@ -2936,6 +3059,8 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.4
 
+  '@jsdevtools/ono@7.1.3': {}
+
   '@noble/hashes@1.8.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
@@ -2988,6 +3113,8 @@ snapshots:
   '@prisma/get-platform@6.13.0':
     dependencies:
       '@prisma/debug': 6.13.0
+
+  '@scarf/scarf@1.4.0': {}
 
   '@sinclair/typebox@0.27.8': {}
 
@@ -3127,6 +3254,8 @@ snapshots:
       expect: 29.7.0
       pretty-format: 29.7.0
 
+  '@types/json-schema@7.0.15': {}
+
   '@types/jsonwebtoken@9.0.10':
     dependencies:
       '@types/ms': 2.1.0
@@ -3181,6 +3310,13 @@ snapshots:
   '@types/supertest@2.0.16':
     dependencies:
       '@types/superagent': 8.1.9
+
+  '@types/swagger-jsdoc@6.0.4': {}
+
+  '@types/swagger-ui-express@4.1.8':
+    dependencies:
+      '@types/express': 4.17.23
+      '@types/serve-static': 1.15.8
 
   '@types/ws@8.18.1':
     dependencies:
@@ -3405,6 +3541,8 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
 
+  call-me-maybe@1.0.2: {}
+
   callsites@3.1.0: {}
 
   camelcase@5.3.1: {}
@@ -3465,6 +3603,11 @@ snapshots:
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
+
+  commander@6.2.0: {}
+
+  commander@9.5.0:
+    optional: true
 
   component-emitter@1.3.1: {}
 
@@ -3917,6 +4060,15 @@ snapshots:
   glob-parent@6.0.2:
     dependencies:
       is-glob: 4.0.3
+
+  glob@7.1.6:
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 3.1.2
+      once: 1.4.0
+      path-is-absolute: 1.0.1
 
   glob@7.2.3:
     dependencies:
@@ -4506,9 +4658,13 @@ snapshots:
 
   lodash.clonedeep@4.5.0: {}
 
+  lodash.get@4.4.2: {}
+
   lodash.includes@4.3.0: {}
 
   lodash.isboolean@3.0.3: {}
+
+  lodash.isequal@4.5.0: {}
 
   lodash.isinteger@4.0.4: {}
 
@@ -4521,6 +4677,8 @@ snapshots:
   lodash.memoize@4.1.2: {}
 
   lodash.merge@4.6.2: {}
+
+  lodash.mergewith@4.6.2: {}
 
   lodash.once@4.1.1: {}
 
@@ -4668,6 +4826,8 @@ snapshots:
   onetime@5.1.2:
     dependencies:
       mimic-fn: 2.1.0
+
+  openapi-types@12.1.3: {}
 
   optionator@0.9.4:
     dependencies:
@@ -5083,6 +5243,32 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  swagger-jsdoc@6.2.8(openapi-types@12.1.3):
+    dependencies:
+      commander: 6.2.0
+      doctrine: 3.0.0
+      glob: 7.1.6
+      lodash.mergewith: 4.6.2
+      swagger-parser: 10.0.3(openapi-types@12.1.3)
+      yaml: 2.0.0-1
+    transitivePeerDependencies:
+      - openapi-types
+
+  swagger-parser@10.0.3(openapi-types@12.1.3):
+    dependencies:
+      '@apidevtools/swagger-parser': 10.0.3(openapi-types@12.1.3)
+    transitivePeerDependencies:
+      - openapi-types
+
+  swagger-ui-dist@5.27.1:
+    dependencies:
+      '@scarf/scarf': 1.4.0
+
+  swagger-ui-express@5.0.1(express@4.21.2):
+    dependencies:
+      express: 4.21.2
+      swagger-ui-dist: 5.27.1
+
   test-exclude@6.0.0:
     dependencies:
       '@istanbuljs/schema': 0.1.3
@@ -5240,6 +5426,8 @@ snapshots:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
 
+  validator@13.15.15: {}
+
   vary@1.1.2: {}
 
   verror@1.10.0:
@@ -5290,6 +5478,8 @@ snapshots:
 
   yallist@4.0.0: {}
 
+  yaml@2.0.0-1: {}
+
   yargs-parser@21.1.1: {}
 
   yargs@17.7.2:
@@ -5305,5 +5495,13 @@ snapshots:
   yn@3.1.1: {}
 
   yocto-queue@0.1.0: {}
+
+  z-schema@5.0.5:
+    dependencies:
+      lodash.get: 4.4.2
+      lodash.isequal: 4.5.0
+      validator: 13.15.15
+    optionalDependencies:
+      commander: 9.5.0
 
   zod@3.25.76: {}

--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -1,0 +1,36 @@
+import type { Application } from "express";
+import swaggerJsdoc, { Options } from "swagger-jsdoc";
+import swaggerUi from "swagger-ui-express";
+
+const options: Options = {
+  definition: {
+    openapi: "3.0.0",
+    info: {
+      title: "AdvanceMais API",
+      version: "1.0.0",
+      description: "Documentação da API AdvanceMais",
+    },
+    components: {
+      securitySchemes: {
+        bearerAuth: {
+          type: "http",
+          scheme: "bearer",
+          bearerFormat: "JWT",
+        },
+      },
+    },
+    servers: [
+      {
+        url: "http://localhost:3000",
+        description: "Servidor de desenvolvimento",
+      },
+    ],
+  },
+  apis: ["./src/routes/**/*.ts", "./src/modules/**/*.ts"],
+};
+
+const swaggerSpec = swaggerJsdoc(options);
+
+export function setupSwagger(app: Application): void {
+  app.use("/docs", swaggerUi.serve, swaggerUi.setup(swaggerSpec));
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import helmet from "helmet";
 import { serverConfig } from "./config/env";
 import { appRoutes } from "./routes";
 import { startExpiredUserCleanupJob } from "./modules/usuarios/services/user-cleanup-service";
+import { setupSwagger } from "./config/swagger";
 
 /**
  * Aplicação principal - AdvanceMais API
@@ -53,6 +54,11 @@ app.use(express.json({ limit: "10mb" }));
  * Para formulários HTML tradicionais
  */
 app.use(express.urlencoded({ extended: true }));
+
+// =============================================
+// SWAGGER DOCS
+// =============================================
+setupSwagger(app);
 
 // =============================================
 // ROUTER PRINCIPAL
@@ -158,6 +164,12 @@ const server = app.listen(serverConfig.port, () => {
   );
   console.log(
     `   🌐 Website: http://localhost:${serverConfig.port}/api/v1/website`
+  );
+  console.log(
+    `   🏢 Empresa: http://localhost:${serverConfig.port}/api/v1/empresa`
+  );
+  console.log(
+    `   📊 Auditoria: http://localhost:${serverConfig.port}/api/v1/audit`
   );
   console.log("");
   console.log("🧪 Testes Rápidos:");

--- a/src/modules/audit/routes/index.ts
+++ b/src/modules/audit/routes/index.ts
@@ -3,6 +3,16 @@ import { logsRoutes } from "./logs";
 
 const router = Router();
 
+/**
+ * @openapi
+ * /api/v1/audit:
+ *   get:
+ *     summary: Informações do módulo de auditoria
+ *     tags: [Audit]
+ *     responses:
+ *       200:
+ *         description: Detalhes do módulo
+ */
 router.get("/", (req, res) => {
   res.json({
     message: "Audit Module API",

--- a/src/modules/audit/routes/logs.ts
+++ b/src/modules/audit/routes/logs.ts
@@ -6,6 +6,18 @@ import { Role } from "../../usuarios/enums/Role";
 const router = Router();
 const controller = new AuditController();
 
+/**
+ * @openapi
+ * /api/v1/audit/logs:
+ *   get:
+ *     summary: Listar logs de auditoria
+ *     tags: [Audit]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Lista de logs
+ */
 router.get("/", authMiddlewareWithDB([Role.ADMIN]), controller.getLogs);
 
 export { router as logsRoutes };

--- a/src/modules/brevo/routes/index.ts
+++ b/src/modules/brevo/routes/index.ts
@@ -9,14 +9,72 @@ const router = Router();
 const brevoController = new BrevoController();
 const emailVerificationController = new EmailVerificationController();
 
+/**
+ * @openapi
+ * /api/v1/brevo:
+ *   get:
+ *     summary: Informações do módulo Brevo
+ *     tags: [Brevo]
+ *     responses:
+ *       200:
+ *         description: Detalhes do módulo
+ */
 router.get("/", brevoController.getModuleInfo);
+
+/**
+ * @openapi
+ * /api/v1/brevo/health:
+ *   get:
+ *     summary: Health check do módulo Brevo
+ *     tags: [Brevo]
+ *     responses:
+ *       200:
+ *         description: Status de saúde
+ */
 router.get("/health", brevoController.healthCheck);
+/**
+ * @openapi
+ * /api/v1/brevo/config:
+ *   get:
+ *     summary: Obter status de configuração do Brevo
+ *     tags: [Brevo]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Configurações do Brevo
+ */
 router.get(
   "/config",
   supabaseAuthMiddleware(["ADMIN", "MODERADOR"]),
   brevoController.getConfigStatus
 );
+/**
+ * @openapi
+ * /api/v1/brevo/verificar-email:
+ *   get:
+ *     summary: Verificar email de usuário
+ *     tags: [Brevo]
+ *     parameters:
+ *       - in: query
+ *         name: token
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Email verificado
+ */
 router.get("/verificar-email", emailVerificationController.verifyEmail);
+/**
+ * @openapi
+ * /api/v1/brevo/reenviar-verificacao:
+ *   post:
+ *     summary: Reenviar email de verificação
+ *     tags: [Brevo]
+ *     responses:
+ *       200:
+ *         description: Email reenviado
+ */
 router.post(
   "/reenviar-verificacao",
   emailVerificationController.resendVerification
@@ -25,6 +83,23 @@ router.get(
   "/status-verificacao/:userId",
   emailVerificationController.getVerificationStatus
 );
+
+/**
+ * @openapi
+ * /api/v1/brevo/status-verificacao/{userId}:
+ *   get:
+ *     summary: Consultar status de verificação de email
+ *     tags: [Brevo]
+     parameters:
+       - in: path
+         name: userId
+         required: true
+         schema:
+           type: string
+     responses:
+       200:
+         description: Status retornado
+ */
 
 router.get(
   "/status/:email",
@@ -87,18 +162,86 @@ router.get(
   }
 );
 
+/**
+ * @openapi
+ * /api/v1/brevo/status/{email}:
+ *   get:
+ *     summary: Consultar status por email
+ *     tags: [Brevo]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: email
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Status do usuário
+ */
+
 router.post(
   "/test/email",
   supabaseAuthMiddleware(["ADMIN", "MODERADOR"]),
   brevoController.testEmail
 );
+
+/**
+ * @openapi
+ * /api/v1/brevo/test/email:
+ *   post:
+ *     summary: Enviar email de teste
+ *     tags: [Brevo]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Email enviado
+ */
 router.post(
   "/test/sms",
   supabaseAuthMiddleware(["ADMIN", "MODERADOR"]),
   brevoController.testSMS
 );
+
+/**
+ * @openapi
+ * /api/v1/brevo/test/sms:
+ *   post:
+ *     summary: Enviar SMS de teste
+ *     tags: [Brevo]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: SMS enviado
+ */
 router.get("/verificar", emailVerificationController.verifyEmail);
 router.post("/reenviar", emailVerificationController.resendVerification);
+
+/**
+ * @openapi
+ * /api/v1/brevo/verificar:
+ *   get:
+ *     summary: Verificar email (alias)
+ *     tags: [Brevo]
+ *     parameters:
+ *       - in: query
+ *         name: token
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Email verificado
+ * /api/v1/brevo/reenviar:
+ *   post:
+ *     summary: Reenviar verificação (alias)
+ *     tags: [Brevo]
+ *     responses:
+ *       200:
+ *         description: Reenvio realizado
+ */
 
 router.use((err: any, req: any, res: any, next: any) => {
   const correlationId = req.headers["x-correlation-id"] || "unknown";

--- a/src/modules/empresa/routes/index.ts
+++ b/src/modules/empresa/routes/index.ts
@@ -3,6 +3,16 @@ import { plansRoutes } from "./plans";
 
 const router = Router();
 
+/**
+ * @openapi
+ * /api/v1/empresa:
+ *   get:
+ *     summary: Informações do módulo Empresa
+ *     tags: [Empresa]
+ *     responses:
+ *       200:
+ *         description: Detalhes do módulo
+ */
 router.get("/", (req, res) => {
   res.json({
     message: "Empresa Module API",

--- a/src/modules/empresa/routes/plans.ts
+++ b/src/modules/empresa/routes/plans.ts
@@ -6,18 +6,98 @@ import { Role } from "../../usuarios/enums/Role";
 const router = Router();
 const controller = new PlanController();
 
+/**
+ * @openapi
+ * /api/v1/empresa/plans:
+ *   post:
+ *     summary: Criar novo plano
+ *     tags: [Empresa]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       201:
+ *         description: Plano criado com sucesso
+ */
 router.post("/", authMiddlewareWithDB([Role.ADMIN]), controller.createPlan);
+
+/**
+ * @openapi
+ * /api/v1/empresa/plans:
+ *   get:
+ *     summary: Listar planos disponíveis
+ *     tags: [Empresa]
+ *     responses:
+ *       200:
+ *         description: Lista de planos
+ */
 router.get("/", controller.getPlans);
+
+/**
+ * @openapi
+ * /api/v1/empresa/plans/{planId}:
+ *   put:
+ *     summary: Atualizar plano existente
+ *     tags: [Empresa]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: planId
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Plano atualizado
+ */
 router.put(
   "/:planId",
   authMiddlewareWithDB([Role.ADMIN]),
   controller.updatePlan
 );
+
+/**
+ * @openapi
+ * /api/v1/empresa/plans/{planId}/assign:
+ *   post:
+ *     summary: Atribuir plano a uma empresa
+ *     tags: [Empresa]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: planId
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Plano atribuído
+ */
 router.post(
   "/:planId/assign",
   authMiddlewareWithDB([Role.ADMIN]),
   controller.assignPlan
 );
+
+/**
+ * @openapi
+ * /api/v1/empresa/plans/companies/{empresaId}/plan:
+ *   delete:
+ *     summary: Remover plano de uma empresa
+ *     tags: [Empresa]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: empresaId
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Plano removido
+ */
 router.delete(
   "/companies/:empresaId/plan",
   authMiddlewareWithDB([Role.ADMIN]),

--- a/src/modules/mercadopago/routes/config.ts
+++ b/src/modules/mercadopago/routes/config.ts
@@ -16,6 +16,16 @@ const configController = new ConfigController();
  * Informações sobre configurações
  * GET /config
  */
+/**
+ * @openapi
+ * /api/v1/mercadopago/config:
+ *   get:
+ *     summary: Informações de configuração do MercadoPago
+ *     tags: [MercadoPago]
+ *     responses:
+ *       200:
+ *         description: Detalhes das rotas de configuração
+ */
 router.get("/", (req, res) => {
   res.json({
     message: "MercadoPago Config API",
@@ -32,11 +42,31 @@ router.get("/", (req, res) => {
  * Obter chave pública (rota pública para frontend)
  * GET /config/public-key
  */
+/**
+ * @openapi
+ * /api/v1/mercadopago/config/public-key:
+ *   get:
+ *     summary: Obter chave pública
+ *     tags: [MercadoPago]
+ *     responses:
+ *       200:
+ *         description: Chave pública retornada
+ */
 router.get("/public-key", configController.getPublicKey);
 
 /**
  * Obter métodos de pagamento (rota pública)
  * GET /config/payment-methods
+ */
+/**
+ * @openapi
+ * /api/v1/mercadopago/config/payment-methods:
+ *   get:
+ *     summary: Listar métodos de pagamento
+ *     tags: [MercadoPago]
+ *     responses:
+ *       200:
+ *         description: Métodos de pagamento
  */
 router.get("/payment-methods", configController.getPaymentMethods);
 
@@ -49,6 +79,18 @@ router.get(
   supabaseAuthMiddleware(["ADMIN", "FINANCEIRO"]),
   configController.getAccountInfo
 );
+/**
+ * @openapi
+ * /api/v1/mercadopago/config/account-info:
+ *   get:
+ *     summary: Obter informações da conta MercadoPago
+ *     tags: [MercadoPago]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Informações da conta
+ */
 
 /**
  * Testar conexão (apenas ADMIN/FINANCEIRO)
@@ -59,5 +101,17 @@ router.get(
   supabaseAuthMiddleware(["ADMIN", "FINANCEIRO"]),
   configController.testConnection
 );
+/**
+ * @openapi
+ * /api/v1/mercadopago/config/test-connection:
+ *   get:
+ *     summary: Testar conexão com MercadoPago
+ *     tags: [MercadoPago]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Conexão bem-sucedida
+ */
 
 export { router as configRoutes };

--- a/src/modules/mercadopago/routes/index.ts
+++ b/src/modules/mercadopago/routes/index.ts
@@ -17,6 +17,16 @@ const router = Router();
  * Informações do módulo
  * GET /mercadopago
  */
+/**
+ * @openapi
+ * /api/v1/mercadopago:
+ *   get:
+ *     summary: Informações do módulo MercadoPago
+ *     tags: [MercadoPago]
+ *     responses:
+ *       200:
+ *         description: Detalhes do módulo
+ */
 router.get("/", (req, res) => {
   res.json({
     message: "MercadoPago Module API",
@@ -35,6 +45,16 @@ router.get("/", (req, res) => {
 /**
  * Health check do módulo
  * GET /mercadopago/health
+ */
+/**
+ * @openapi
+ * /api/v1/mercadopago/health:
+ *   get:
+ *     summary: Health check do módulo MercadoPago
+ *     tags: [MercadoPago]
+ *     responses:
+ *       200:
+ *         description: Status de saúde
  */
 router.get("/health", (req, res) => {
   res.json({

--- a/src/modules/mercadopago/routes/orders.ts
+++ b/src/modules/mercadopago/routes/orders.ts
@@ -16,6 +16,16 @@ const ordersController = new OrdersController();
  * Informações sobre orders
  * GET /orders
  */
+/**
+ * @openapi
+ * /api/v1/mercadopago/orders:
+ *   get:
+ *     summary: Informações gerais sobre orders
+ *     tags: [MercadoPago]
+ *     responses:
+ *       200:
+ *         description: Detalhes das rotas de orders
+ */
 router.get("/", (req, res) => {
   res.json({
     message: "MercadoPago Orders API",
@@ -32,17 +42,65 @@ router.get("/", (req, res) => {
  * Criar nova order
  * POST /orders
  */
+/**
+ * @openapi
+ * /api/v1/mercadopago/orders:
+ *   post:
+ *     summary: Criar nova order
+ *     tags: [MercadoPago]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       201:
+ *         description: Order criada
+ */
 router.post("/", supabaseAuthMiddleware(), ordersController.createOrder);
 
 /**
  * Obter informações de uma order
  * GET /orders/:orderId
  */
+/**
+ * @openapi
+ * /api/v1/mercadopago/orders/{orderId}:
+ *   get:
+ *     summary: Obter informações de uma order
+ *     tags: [MercadoPago]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: orderId
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Dados da order
+ */
 router.get("/:orderId", supabaseAuthMiddleware(), ordersController.getOrder);
 
 /**
  * Cancelar uma order
  * PUT /orders/:orderId/cancel
+ */
+/**
+ * @openapi
+ * /api/v1/mercadopago/orders/{orderId}/cancel:
+ *   put:
+ *     summary: Cancelar uma order
+ *     tags: [MercadoPago]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: orderId
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Order cancelada
  */
 router.put(
   "/:orderId/cancel",
@@ -53,6 +111,24 @@ router.put(
 /**
  * Processar reembolso de uma order
  * POST /orders/:orderId/refund
+ */
+/**
+ * @openapi
+ * /api/v1/mercadopago/orders/{orderId}/refund:
+ *   post:
+ *     summary: Processar reembolso de uma order
+ *     tags: [MercadoPago]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: orderId
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Reembolso processado
  */
 router.post(
   "/:orderId/refund",

--- a/src/modules/mercadopago/routes/subscriptions.ts
+++ b/src/modules/mercadopago/routes/subscriptions.ts
@@ -16,6 +16,18 @@ const subscriptionController = new SubscriptionController();
  * Informações sobre assinaturas
  * GET /subscriptions
  */
+/**
+ * @openapi
+ * /api/v1/mercadopago/subscriptions:
+ *   get:
+ *     summary: Listar assinaturas do usuário
+ *     tags: [MercadoPago]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Lista de assinaturas
+ */
 router.get(
   "/",
   supabaseAuthMiddleware(),
@@ -25,6 +37,18 @@ router.get(
 /**
  * Criar nova assinatura
  * POST /subscriptions
+ */
+/**
+ * @openapi
+ * /api/v1/mercadopago/subscriptions:
+ *   post:
+ *     summary: Criar nova assinatura
+ *     tags: [MercadoPago]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       201:
+ *         description: Assinatura criada
  */
 router.post(
   "/",
@@ -36,6 +60,24 @@ router.post(
  * Obter informações de uma assinatura
  * GET /subscriptions/:subscriptionId
  */
+/**
+ * @openapi
+ * /api/v1/mercadopago/subscriptions/{subscriptionId}:
+ *   get:
+ *     summary: Obter assinatura específica
+ *     tags: [MercadoPago]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: subscriptionId
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Dados da assinatura
+ */
 router.get(
   "/:subscriptionId",
   supabaseAuthMiddleware(),
@@ -45,6 +87,24 @@ router.get(
 /**
  * Pausar assinatura
  * PUT /subscriptions/:subscriptionId/pause
+ */
+/**
+ * @openapi
+ * /api/v1/mercadopago/subscriptions/{subscriptionId}/pause:
+ *   put:
+ *     summary: Pausar assinatura
+ *     tags: [MercadoPago]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: subscriptionId
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Assinatura pausada
  */
 router.put(
   "/:subscriptionId/pause",
@@ -56,6 +116,24 @@ router.put(
  * Cancelar assinatura
  * PUT /subscriptions/:subscriptionId/cancel
  */
+/**
+ * @openapi
+ * /api/v1/mercadopago/subscriptions/{subscriptionId}/cancel:
+ *   put:
+ *     summary: Cancelar assinatura
+ *     tags: [MercadoPago]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: subscriptionId
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Assinatura cancelada
+ */
 router.put(
   "/:subscriptionId/cancel",
   supabaseAuthMiddleware(),
@@ -65,6 +143,24 @@ router.put(
 /**
  * Reativar assinatura
  * PUT /subscriptions/:subscriptionId/reactivate
+ */
+/**
+ * @openapi
+ * /api/v1/mercadopago/subscriptions/{subscriptionId}/reactivate:
+ *   put:
+ *     summary: Reativar assinatura
+ *     tags: [MercadoPago]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: subscriptionId
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Assinatura reativada
  */
 router.put(
   "/:subscriptionId/reactivate",

--- a/src/modules/mercadopago/routes/webhooks.ts
+++ b/src/modules/mercadopago/routes/webhooks.ts
@@ -15,6 +15,16 @@ const webhookController = new WebhookController();
  * Informações sobre webhooks
  * GET /webhooks
  */
+/**
+ * @openapi
+ * /api/v1/mercadopago/webhooks:
+ *   get:
+ *     summary: Informações sobre endpoints de webhook
+ *     tags: [MercadoPago]
+ *     responses:
+ *       200:
+ *         description: Detalhes dos webhooks
+ */
 router.get("/", (req, res) => {
   res.json({
     message: "MercadoPago Webhooks API",
@@ -30,11 +40,31 @@ router.get("/", (req, res) => {
  * Receber notificações do MercadoPago
  * POST /webhooks
  */
+/**
+ * @openapi
+ * /api/v1/mercadopago/webhooks:
+ *   post:
+ *     summary: Receber notificações do MercadoPago
+ *     tags: [MercadoPago]
+ *     responses:
+ *       200:
+ *         description: Notificação recebida
+ */
 router.post("/", webhookController.processWebhook);
 
 /**
  * Endpoint de teste para validar configuração
  * GET /webhooks/test
+ */
+/**
+ * @openapi
+ * /api/v1/mercadopago/webhooks/test:
+ *   get:
+ *     summary: Testar configuração de webhook
+ *     tags: [MercadoPago]
+ *     responses:
+ *       200:
+ *         description: Teste bem-sucedido
  */
 router.get("/test", webhookController.testWebhook);
 

--- a/src/modules/usuarios/routes/admin-routes.ts
+++ b/src/modules/usuarios/routes/admin-routes.ts
@@ -29,17 +29,59 @@ router.use(supabaseAuthMiddleware(["ADMIN", "MODERADOR"]));
  * Área administrativa principal
  * GET /admin
  */
+/**
+ * @openapi
+ * /api/v1/usuarios/admin:
+ *   get:
+ *     summary: Informações do painel administrativo
+ *     tags: [Usuários - Admin]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Detalhes do painel
+ */
 router.get("/", adminController.getAdminInfo);
 
 /**
  * Listar usuários com filtros
  * GET /admin/usuarios
  */
+/**
+ * @openapi
+ * /api/v1/usuarios/admin/usuarios:
+ *   get:
+ *     summary: Listar usuários
+ *     tags: [Usuários - Admin]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Lista de usuários
+ */
 router.get("/usuarios", adminController.listarUsuarios);
 
 /**
  * Buscar usuário específico por ID
  * GET /admin/usuarios/:userId
+ */
+/**
+ * @openapi
+ * /api/v1/usuarios/admin/usuarios/{userId}:
+ *   get:
+ *     summary: Buscar usuário por ID
+ *     tags: [Usuários - Admin]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: userId
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Usuário encontrado
  */
 router.get("/usuarios/:userId", adminController.buscarUsuario);
 
@@ -52,6 +94,24 @@ router.get(
   supabaseAuthMiddleware(["ADMIN", "MODERADOR", "FINANCEIRO"]),
   adminController.historicoPagamentosUsuario
 );
+/**
+ * @openapi
+ * /api/v1/usuarios/admin/usuarios/{userId}/pagamentos:
+ *   get:
+ *     summary: Histórico de pagamentos do usuário
+ *     tags: [Usuários - Admin]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: userId
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Histórico retornado
+ */
 
 // =============================================
 // ROTAS DE MODIFICAÇÃO (APENAS ADMIN)
@@ -66,6 +126,24 @@ router.patch(
   supabaseAuthMiddleware(["ADMIN"]),
   adminController.atualizarStatus
 );
+/**
+ * @openapi
+ * /api/v1/usuarios/admin/usuarios/{userId}/status:
+ *   patch:
+ *     summary: Atualizar status de usuário
+ *     tags: [Usuários - Admin]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: userId
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Status atualizado
+ */
 
 /**
  * Atualizar role de usuário
@@ -76,5 +154,23 @@ router.patch(
   supabaseAuthMiddleware(["ADMIN"]),
   adminController.atualizarRole
 );
+/**
+ * @openapi
+ * /api/v1/usuarios/admin/usuarios/{userId}/role:
+ *   patch:
+ *     summary: Atualizar role de usuário
+ *     tags: [Usuários - Admin]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: userId
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Role atualizada
+ */
 
 export { router as adminRoutes };

--- a/src/modules/usuarios/routes/password-recovery.ts
+++ b/src/modules/usuarios/routes/password-recovery.ts
@@ -15,11 +15,37 @@ const passwordRecoveryController = new PasswordRecoveryController();
  * Solicita recuperação de senha
  * POST /recuperar-senha
  */
+/**
+ * @openapi
+ * /api/v1/usuarios/recuperar-senha:
+ *   post:
+ *     summary: Solicitar recuperação de senha
+ *     tags: [Usuários]
+ *     responses:
+ *       200:
+ *         description: Solicitação enviada
+ */
 router.post("/", passwordRecoveryController.solicitarRecuperacao);
 
 /**
  * Valida token de recuperação - ROTA CORRIGIDA
  * GET /recuperar-senha/validar/:token
+ */
+/**
+ * @openapi
+ * /api/v1/usuarios/recuperar-senha/validar/{token}:
+ *   get:
+ *     summary: Validar token de recuperação
+ *     tags: [Usuários]
+ *     parameters:
+ *       - in: path
+ *         name: token
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Token válido
  */
 router.get(
   "/validar/:token([a-fA-F0-9]{64})",
@@ -29,6 +55,16 @@ router.get(
 /**
  * Redefine senha com token
  * POST /recuperar-senha/redefinir
+ */
+/**
+ * @openapi
+ * /api/v1/usuarios/recuperar-senha/redefinir:
+ *   post:
+ *     summary: Redefinir senha utilizando token
+ *     tags: [Usuários]
+ *     responses:
+ *       200:
+ *         description: Senha redefinida
  */
 router.post("/redefinir", passwordRecoveryController.redefinirSenha);
 

--- a/src/modules/usuarios/routes/payment-routes.ts
+++ b/src/modules/usuarios/routes/payment-routes.ts
@@ -29,11 +29,35 @@ router.use(supabaseAuthMiddleware());
  * Processar pagamento de curso individual
  * POST /pagamentos/curso
  */
+/**
+ * @openapi
+ * /api/v1/usuarios/pagamentos/curso:
+ *   post:
+ *     summary: Processar pagamento de curso
+ *     tags: [Usuários - Pagamentos]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Pagamento processado
+ */
 router.post("/curso", paymentController.processarPagamentoCurso);
 
 /**
  * Criar assinatura premium
  * POST /pagamentos/assinatura
+ */
+/**
+ * @openapi
+ * /api/v1/usuarios/pagamentos/assinatura:
+ *   post:
+ *     summary: Criar assinatura premium
+ *     tags: [Usuários - Pagamentos]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       201:
+ *         description: Assinatura criada
  */
 router.post("/assinatura", paymentController.criarAssinaturaPremium);
 
@@ -41,11 +65,35 @@ router.post("/assinatura", paymentController.criarAssinaturaPremium);
  * Cancelar assinatura
  * PUT /pagamentos/assinatura/cancelar
  */
+/**
+ * @openapi
+ * /api/v1/usuarios/pagamentos/assinatura/cancelar:
+ *   put:
+ *     summary: Cancelar assinatura
+ *     tags: [Usuários - Pagamentos]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Assinatura cancelada
+ */
 router.put("/assinatura/cancelar", paymentController.cancelarAssinatura);
 
 /**
  * Histórico de pagamentos do usuário logado
  * GET /pagamentos/historico
+ */
+/**
+ * @openapi
+ * /api/v1/usuarios/pagamentos/historico:
+ *   get:
+ *     summary: Listar histórico de pagamentos
+ *     tags: [Usuários - Pagamentos]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Histórico de pagamentos
  */
 router.get("/historico", paymentController.listarHistoricoPagamentos);
 

--- a/src/modules/usuarios/routes/stats-routes.ts
+++ b/src/modules/usuarios/routes/stats-routes.ts
@@ -29,17 +29,53 @@ router.use(supabaseAuthMiddleware(["ADMIN", "MODERADOR"]));
  * Dashboard principal - estatísticas gerais
  * GET /stats/dashboard
  */
+/**
+ * @openapi
+ * /api/v1/usuarios/stats/dashboard:
+ *   get:
+ *     summary: Estatísticas gerais do sistema
+ *     tags: [Usuários - Stats]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Dados de dashboard
+ */
 router.get("/dashboard", statsController.getDashboardStats);
 
 /**
  * Estatísticas de usuários
  * GET /stats/usuarios
  */
+/**
+ * @openapi
+ * /api/v1/usuarios/stats/usuarios:
+ *   get:
+ *     summary: Estatísticas de usuários
+ *     tags: [Usuários - Stats]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Estatísticas retornadas
+ */
 router.get("/usuarios", statsController.getUserStats);
 
 /**
  * Estatísticas de pagamentos
  * GET /stats/pagamentos
+ */
+/**
+ * @openapi
+ * /api/v1/usuarios/stats/pagamentos:
+ *   get:
+ *     summary: Estatísticas de pagamentos
+ *     tags: [Usuários - Stats]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Estatísticas de pagamentos
  */
 router.get(
   "/pagamentos",

--- a/src/modules/usuarios/routes/usuario-routes.ts
+++ b/src/modules/usuarios/routes/usuario-routes.ts
@@ -109,6 +109,16 @@ const createAuthRateLimit = (
  * Informações da API de usuários
  * GET /usuarios
  */
+/**
+ * @openapi
+ * /api/v1/usuarios:
+ *   get:
+ *     summary: Informações do módulo de usuários
+ *     tags: [Usuários]
+ *     responses:
+ *       200:
+ *         description: Detalhes do módulo
+ */
 router.get("/", (req, res) => {
   res.json({
     module: "Usuários API",
@@ -159,6 +169,16 @@ router.get("/", (req, res) => {
  * 4. Middleware de debug -> verifica dados
  * 5. WelcomeEmailMiddleware -> envia email/verificação de forma assíncrona
  */
+/**
+ * @openapi
+ * /api/v1/usuarios/registrar:
+ *   post:
+ *     summary: Registrar novo usuário
+ *     tags: [Usuários]
+ *     responses:
+ *       201:
+ *         description: Usuário criado
+ */
 router.post(
   "/registrar",
   createAuthRateLimit(3, 10), // 3 tentativas por 10 minutos
@@ -200,6 +220,16 @@ router.post(
  * Login de usuário
  * POST /login
  */
+/**
+ * @openapi
+ * /api/v1/usuarios/login:
+ *   post:
+ *     summary: Login de usuário
+ *     tags: [Usuários]
+ *     responses:
+ *       200:
+ *         description: Login realizado
+ */
 router.post(
   "/login",
   createAuthRateLimit(5, 15), // 5 tentativas por 15 minutos
@@ -219,6 +249,16 @@ router.post(
  * Refresh token
  * POST /refresh
  */
+/**
+ * @openapi
+ * /api/v1/usuarios/refresh:
+ *   post:
+ *     summary: Atualizar token JWT
+ *     tags: [Usuários]
+ *     responses:
+ *       200:
+ *         description: Token renovado
+ */
 router.post(
   "/refresh",
   createAuthRateLimit(10, 15), // 10 tentativas por 15 minutos
@@ -232,6 +272,18 @@ router.post(
 /**
  * Logout de usuário
  * POST /logout
+ */
+/**
+ * @openapi
+ * /api/v1/usuarios/logout:
+ *   post:
+ *     summary: Logout do usuário
+ *     tags: [Usuários]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Logout efetuado
  */
 router.post(
   "/logout",
@@ -251,6 +303,18 @@ router.post(
 /**
  * Perfil do usuário autenticado
  * GET /perfil
+ */
+/**
+ * @openapi
+ * /api/v1/usuarios/perfil:
+ *   get:
+ *     summary: Obter perfil do usuário autenticado
+ *     tags: [Usuários]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Perfil retornado
  */
 router.get(
   "/perfil",

--- a/src/modules/website/routes/banner.ts
+++ b/src/modules/website/routes/banner.ts
@@ -6,20 +6,98 @@ import { BannerController } from "../controllers/banner.controller";
 const router = Router();
 const upload = multer({ storage: multer.memoryStorage() });
 
+/**
+ * @openapi
+ * /api/v1/website/banner:
+ *   get:
+ *     summary: Listar banners
+ *     tags: [Website - Banner]
+ *     responses:
+ *       200:
+ *         description: Lista de banners
+ */
 router.get("/", BannerController.list);
+
+/**
+ * @openapi
+ * /api/v1/website/banner/{id}:
+ *   get:
+ *     summary: Obter banner por ID
+ *     tags: [Website - Banner]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Banner encontrado
+ */
 router.get("/:id", BannerController.get);
+
+/**
+ * @openapi
+ * /api/v1/website/banner:
+ *   post:
+ *     summary: Criar banner
+ *     tags: [Website - Banner]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       201:
+ *         description: Banner criado
+ */
 router.post(
   "/",
   supabaseAuthMiddleware(["ADMIN", "MODERADOR"]),
   upload.single("imagem"),
   BannerController.create
 );
+
+/**
+ * @openapi
+ * /api/v1/website/banner/{id}:
+ *   put:
+ *     summary: Atualizar banner
+ *     tags: [Website - Banner]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Banner atualizado
+ */
 router.put(
   "/:id",
   supabaseAuthMiddleware(["ADMIN", "MODERADOR"]),
   upload.single("imagem"),
   BannerController.update
 );
+
+/**
+ * @openapi
+ * /api/v1/website/banner/{id}:
+ *   delete:
+ *     summary: Remover banner
+ *     tags: [Website - Banner]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Banner removido
+ */
 router.delete(
   "/:id",
   supabaseAuthMiddleware(["ADMIN", "MODERADOR"]),

--- a/src/modules/website/routes/business-group-information.ts
+++ b/src/modules/website/routes/business-group-information.ts
@@ -6,20 +6,98 @@ import { BusinessGroupInformationController } from "../controllers/businessGroup
 const router = Router();
 const upload = multer({ storage: multer.memoryStorage() });
 
+/**
+ * @openapi
+ * /api/v1/website/business-group-information:
+ *   get:
+ *     summary: Listar informações de grupos empresariais
+ *     tags: [Website - BusinessGroupInformation]
+ *     responses:
+ *       200:
+ *         description: Lista de informações
+ */
 router.get("/", BusinessGroupInformationController.list);
+
+/**
+ * @openapi
+ * /api/v1/website/business-group-information/{id}:
+ *   get:
+ *     summary: Obter informação por ID
+ *     tags: [Website - BusinessGroupInformation]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Informação encontrada
+ */
 router.get("/:id", BusinessGroupInformationController.get);
+
+/**
+ * @openapi
+ * /api/v1/website/business-group-information:
+ *   post:
+ *     summary: Criar informação de grupo empresarial
+ *     tags: [Website - BusinessGroupInformation]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       201:
+ *         description: Informação criada
+ */
 router.post(
   "/",
   supabaseAuthMiddleware(["ADMIN", "MODERADOR"]),
   upload.single("imagem"),
   BusinessGroupInformationController.create
 );
+
+/**
+ * @openapi
+ * /api/v1/website/business-group-information/{id}:
+ *   put:
+ *     summary: Atualizar informação de grupo empresarial
+ *     tags: [Website - BusinessGroupInformation]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Informação atualizada
+ */
 router.put(
   "/:id",
   supabaseAuthMiddleware(["ADMIN", "MODERADOR"]),
   upload.single("imagem"),
   BusinessGroupInformationController.update
 );
+
+/**
+ * @openapi
+ * /api/v1/website/business-group-information/{id}:
+ *   delete:
+ *     summary: Remover informação de grupo empresarial
+ *     tags: [Website - BusinessGroupInformation]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Informação removida
+ */
 router.delete(
   "/:id",
   supabaseAuthMiddleware(["ADMIN", "MODERADOR"]),

--- a/src/modules/website/routes/index.ts
+++ b/src/modules/website/routes/index.ts
@@ -7,6 +7,16 @@ import { logoEnterpriseRoutes } from "./logo-enterprises";
 
 const router = Router();
 
+/**
+ * @openapi
+ * /api/v1/website:
+ *   get:
+ *     summary: Informações do módulo Website
+ *     tags: [Website]
+ *     responses:
+ *       200:
+ *         description: Detalhes do módulo
+ */
 router.get("/", (req, res) => {
   res.json({
     message: "Website Module API",

--- a/src/modules/website/routes/logo-enterprises.ts
+++ b/src/modules/website/routes/logo-enterprises.ts
@@ -6,20 +6,98 @@ import { LogoEnterpriseController } from "../controllers/logoEnterprise.controll
 const router = Router();
 const upload = multer({ storage: multer.memoryStorage() });
 
+/**
+ * @openapi
+ * /api/v1/website/logo-enterprises:
+ *   get:
+ *     summary: Listar logos de empresas
+ *     tags: [Website - LogoEnterprises]
+ *     responses:
+ *       200:
+ *         description: Lista de logos
+ */
 router.get("/", LogoEnterpriseController.list);
+
+/**
+ * @openapi
+ * /api/v1/website/logo-enterprises/{id}:
+ *   get:
+ *     summary: Obter logo por ID
+ *     tags: [Website - LogoEnterprises]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Logo encontrada
+ */
 router.get("/:id", LogoEnterpriseController.get);
+
+/**
+ * @openapi
+ * /api/v1/website/logo-enterprises:
+ *   post:
+ *     summary: Criar logo de empresa
+ *     tags: [Website - LogoEnterprises]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       201:
+ *         description: Logo criada
+ */
 router.post(
   "/",
   supabaseAuthMiddleware(["ADMIN", "MODERADOR"]),
   upload.single("imagem"),
   LogoEnterpriseController.create
 );
+
+/**
+ * @openapi
+ * /api/v1/website/logo-enterprises/{id}:
+ *   put:
+ *     summary: Atualizar logo de empresa
+ *     tags: [Website - LogoEnterprises]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Logo atualizada
+ */
 router.put(
   "/:id",
   supabaseAuthMiddleware(["ADMIN", "MODERADOR"]),
   upload.single("imagem"),
   LogoEnterpriseController.update
 );
+
+/**
+ * @openapi
+ * /api/v1/website/logo-enterprises/{id}:
+ *   delete:
+ *     summary: Remover logo de empresa
+ *     tags: [Website - LogoEnterprises]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Logo removida
+ */
 router.delete(
   "/:id",
   supabaseAuthMiddleware(["ADMIN", "MODERADOR"]),

--- a/src/modules/website/routes/slide.ts
+++ b/src/modules/website/routes/slide.ts
@@ -6,20 +6,98 @@ import { SlideController } from "../controllers/slide.controller";
 const router = Router();
 const upload = multer({ storage: multer.memoryStorage() });
 
+/**
+ * @openapi
+ * /api/v1/website/slide:
+ *   get:
+ *     summary: Listar slides
+ *     tags: [Website - Slide]
+ *     responses:
+ *       200:
+ *         description: Lista de slides
+ */
 router.get("/", SlideController.list);
+
+/**
+ * @openapi
+ * /api/v1/website/slide/{id}:
+ *   get:
+ *     summary: Obter slide por ID
+ *     tags: [Website - Slide]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Slide encontrado
+ */
 router.get("/:id", SlideController.get);
+
+/**
+ * @openapi
+ * /api/v1/website/slide:
+ *   post:
+ *     summary: Criar slide
+ *     tags: [Website - Slide]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       201:
+ *         description: Slide criado
+ */
 router.post(
   "/",
   supabaseAuthMiddleware(["ADMIN", "MODERADOR"]),
   upload.single("imagem"),
   SlideController.create
 );
+
+/**
+ * @openapi
+ * /api/v1/website/slide/{id}:
+ *   put:
+ *     summary: Atualizar slide
+ *     tags: [Website - Slide]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Slide atualizado
+ */
 router.put(
   "/:id",
   supabaseAuthMiddleware(["ADMIN", "MODERADOR"]),
   upload.single("imagem"),
   SlideController.update
 );
+
+/**
+ * @openapi
+ * /api/v1/website/slide/{id}:
+ *   delete:
+ *     summary: Remover slide
+ *     tags: [Website - Slide]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Slide removido
+ */
 router.delete(
   "/:id",
   supabaseAuthMiddleware(["ADMIN", "MODERADOR"]),
@@ -27,4 +105,3 @@ router.delete(
 );
 
 export { router as slideRoutes };
-

--- a/src/modules/website/routes/sobre.ts
+++ b/src/modules/website/routes/sobre.ts
@@ -6,20 +6,98 @@ import { SobreController } from "../controllers/sobre.controller";
 const router = Router();
 const upload = multer({ storage: multer.memoryStorage() });
 
+/**
+ * @openapi
+ * /api/v1/website/sobre:
+ *   get:
+ *     summary: Listar conteúdos "Sobre"
+ *     tags: [Website - Sobre]
+ *     responses:
+ *       200:
+ *         description: Lista de conteúdos
+ */
 router.get("/", SobreController.list);
+
+/**
+ * @openapi
+ * /api/v1/website/sobre/{id}:
+ *   get:
+ *     summary: Obter conteúdo por ID
+ *     tags: [Website - Sobre]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Conteúdo encontrado
+ */
 router.get("/:id", SobreController.get);
+
+/**
+ * @openapi
+ * /api/v1/website/sobre:
+ *   post:
+ *     summary: Criar conteúdo "Sobre"
+ *     tags: [Website - Sobre]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       201:
+ *         description: Conteúdo criado
+ */
 router.post(
   "/",
   supabaseAuthMiddleware(["ADMIN", "MODERADOR"]),
   upload.single("imagem"),
   SobreController.create
 );
+
+/**
+ * @openapi
+ * /api/v1/website/sobre/{id}:
+ *   put:
+ *     summary: Atualizar conteúdo "Sobre"
+ *     tags: [Website - Sobre]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Conteúdo atualizado
+ */
 router.put(
   "/:id",
   supabaseAuthMiddleware(["ADMIN", "MODERADOR"]),
   upload.single("imagem"),
   SobreController.update
 );
+
+/**
+ * @openapi
+ * /api/v1/website/sobre/{id}:
+ *   delete:
+ *     summary: Remover conteúdo "Sobre"
+ *     tags: [Website - Sobre]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Conteúdo removido
+ */
 router.delete(
   "/:id",
   supabaseAuthMiddleware(["ADMIN", "MODERADOR"]),

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -18,8 +18,13 @@ const router = Router();
 const emailVerificationController = new EmailVerificationController();
 
 /**
- * Rota raiz da API
- * GET /
+ * @openapi
+ * /:
+ *   get:
+ *     summary: Rota raiz da API
+ *     responses:
+ *       200:
+ *         description: Informações básicas e endpoints disponíveis
  */
 router.get("/", (req, res) => {
   const data = {
@@ -84,8 +89,13 @@ router.get("/", (req, res) => {
 });
 
 /**
- * Health check global
- * GET /health
+ * @openapi
+ * /health:
+ *   get:
+ *     summary: Health check global
+ *     responses:
+ *       200:
+ *         description: Status do servidor
  */
 router.get("/health", (req, res) => {
   res.json({


### PR DESCRIPTION
## Summary
- add bearer auth and dev server to Swagger config
- annotate all API modules with OpenAPI paths for GET, POST, PUT and DELETE operations
- document user auth, admin, payment and stats endpoints with role-based security

## Testing
- `pnpm test`
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_68a8dc20b4d08325a1aaae69d0fa6ba7