### PR TITLE
Prevent swagger-jsdoc undefined component error

### DIFF
--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -11,6 +11,12 @@ const options: Options = {
       description: "Documentação da API AdvanceMais",
     },
     components: {
+      schemas: {},
+      responses: {},
+      parameters: {},
+      examples: {},
+      requestBodies: {},
+      headers: {},
       securitySchemes: {
         bearerAuth: {
           type: "http",
@@ -18,6 +24,8 @@ const options: Options = {
           bearerFormat: "JWT",
         },
       },
+      links: {},
+      callbacks: {},
     },
     servers: [
       {


### PR DESCRIPTION
## Summary
- define empty Swagger component sections to satisfy swagger-jsdoc

## Testing
- `pnpm test`
- `pnpm run build`
- `node dist/index.js` *(fails: supabaseUrl is required)*

------
https://chatgpt.com/codex/tasks/task_e_68a8e3d21f988325bb47e74cd55e4d35