### PR TITLE
fix(swagger): repair Brevo status-verification docs

### DIFF
--- a/src/modules/brevo/routes/index.ts
+++ b/src/modules/brevo/routes/index.ts
@@ -90,15 +90,15 @@ router.get(
  *   get:
  *     summary: Consultar status de verificação de email
  *     tags: [Brevo]
-     parameters:
-       - in: path
-         name: userId
-         required: true
-         schema:
-           type: string
-     responses:
-       200:
-         description: Status retornado
+  *     parameters:
+  *       - in: path
+  *         name: userId
+  *         required: true
+  *         schema:
+  *           type: string
+  *     responses:
+  *       200:
+  *         description: Status retornado
  */
 
 router.get(


### PR DESCRIPTION
## Summary
- fix swagger annotation for Brevo status verification route

## Testing
- `pnpm lint`
- `pnpm test`
- `node dist/config/swagger.js`

------
https://chatgpt.com/codex/tasks/task_e_68a8e761cac883259ef2fac302d1eb9e