### PR TITLE
docs: secure swagger and enrich api docs

### DIFF
--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -1,6 +1,7 @@
 import type { Application } from "express";
 import swaggerJsdoc, { Options } from "swagger-jsdoc";
 import swaggerUi from "swagger-ui-express";
+import { supabaseAuthMiddleware } from "../modules/usuarios/auth";
 
 const options: Options = {
   definition: {
@@ -8,10 +9,189 @@ const options: Options = {
     info: {
       title: "AdvanceMais API",
       version: "1.0.0",
-      description: "Documentação da API AdvanceMais",
+      description:
+        "Documentação detalhada da API AdvanceMais. Todas as rotas protegidas exigem o header `Authorization: Bearer <token>` obtido via login. O acesso ao Swagger é restrito a administradores.",
     },
+    tags: [
+      { name: "Usuários", description: "Gerenciamento de contas e autenticação" },
+      { name: "MercadoPago", description: "Integração de pagamentos" },
+      { name: "Audit", description: "Registros de auditoria" },
+      { name: "Brevo", description: "Serviços de e-mail" },
+      { name: "Empresa", description: "Gestão de planos de empresa" },
+      { name: "Website", description: "Conteúdo público do site" },
+    ],
     components: {
-      schemas: {},
+      schemas: {
+        ErrorResponse: {
+          type: "object",
+          properties: {
+            success: { type: "boolean", example: false },
+            message: { type: "string", example: "Erro de validação" },
+            code: { type: "string", example: "VALIDATION_ERROR" },
+          },
+        },
+        UserLoginRequest: {
+          type: "object",
+          required: ["documento", "senha"],
+          properties: {
+            documento: {
+              type: "string",
+              description: "CPF ou CNPJ do usuário",
+              example: "12345678900",
+            },
+            senha: {
+              type: "string",
+              format: "password",
+              example: "senha123",
+            },
+          },
+        },
+        UserLoginResponse: {
+          type: "object",
+          properties: {
+            success: { type: "boolean", example: true },
+            token: {
+              type: "string",
+              description: "JWT de acesso",
+              example: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+            },
+            refreshToken: {
+              type: "string",
+              description: "Token para renovação de sessão",
+              example: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+            },
+          },
+        },
+        UserRegisterRequest: {
+          type: "object",
+          required: [
+            "nomeCompleto",
+            "documento",
+            "telefone",
+            "email",
+            "senha",
+            "confirmarSenha",
+            "aceitarTermos",
+            "supabaseId",
+            "tipoUsuario",
+          ],
+          properties: {
+            nomeCompleto: { type: "string", example: "João da Silva" },
+            documento: {
+              type: "string",
+              description: "CPF ou CNPJ",
+              example: "12345678900",
+            },
+            telefone: {
+              type: "string",
+              example: "+55 11 99999-9999",
+            },
+            email: {
+              type: "string",
+              format: "email",
+              example: "joao@example.com",
+            },
+            senha: { type: "string", format: "password", example: "senha123" },
+            confirmarSenha: {
+              type: "string",
+              format: "password",
+              example: "senha123",
+            },
+            aceitarTermos: { type: "boolean", example: true },
+            supabaseId: {
+              type: "string",
+              description: "Identificador do usuário no Supabase",
+              example: "uuid-supabase",
+            },
+            tipoUsuario: {
+              type: "string",
+              description: "Tipo do usuário",
+              enum: ["PESSOA_FISICA", "PESSOA_JURIDICA"],
+              example: "PESSOA_FISICA",
+            },
+          },
+        },
+        UserRegisterResponse: {
+          type: "object",
+          properties: {
+            success: { type: "boolean", example: true },
+            usuario: {
+              type: "object",
+              properties: {
+                id: {
+                  type: "string",
+                  example: "b9e1d9b0-7c9f-4d1a-8f2a-1234567890ab",
+                },
+                email: {
+                  type: "string",
+                  format: "email",
+                  example: "joao@example.com",
+                },
+                nomeCompleto: {
+                  type: "string",
+                  example: "João da Silva",
+                },
+              },
+            },
+          },
+        },
+        RefreshTokenRequest: {
+          type: "object",
+          required: ["refreshToken"],
+          properties: {
+            refreshToken: {
+              type: "string",
+              description: "Token de renovação válido",
+              example: "<refresh-token>",
+            },
+          },
+        },
+        UserProfile: {
+          type: "object",
+          properties: {
+            id: { type: "string", example: "b9e1d9b0-7c9f-4d1a-8f2a-1234567890ab" },
+            email: { type: "string", example: "joao@example.com" },
+            nomeCompleto: { type: "string", example: "João da Silva" },
+            role: {
+              type: "string",
+              description: "Role do usuário",
+              example: "ADMIN",
+            },
+            tipoUsuario: {
+              type: "string",
+              example: "PESSOA_FISICA",
+            },
+            supabaseId: { type: "string", example: "uuid-supabase" },
+            emailVerificado: { type: "boolean", example: true },
+            ultimoLogin: {
+              type: "string",
+              format: "date-time",
+              example: "2024-01-01T12:00:00Z",
+            },
+          },
+        },
+        RefreshTokenResponse: {
+          type: "object",
+          properties: {
+            success: { type: "boolean", example: true },
+            message: { type: "string", example: "Token renovado com sucesso" },
+            usuario: { $ref: "#/components/schemas/UserProfile" },
+          },
+        },
+        LogoutResponse: {
+          type: "object",
+          properties: {
+            success: { type: "boolean", example: true },
+            message: { type: "string", example: "Logout realizado" },
+          },
+        },
+        BasicMessage: {
+          type: "object",
+          properties: {
+            message: { type: "string", example: "OK" },
+          },
+        },
+      },
       responses: {},
       parameters: {},
       examples: {},
@@ -40,5 +220,15 @@ const options: Options = {
 const swaggerSpec = swaggerJsdoc(options);
 
 export function setupSwagger(app: Application): void {
-  app.use("/docs", swaggerUi.serve, swaggerUi.setup(swaggerSpec));
+  app.use(
+    "/docs",
+    supabaseAuthMiddleware(["ADMIN"]),
+    swaggerUi.serve,
+    swaggerUi.setup(swaggerSpec)
+  );
+  app.get(
+    "/docs.json",
+    supabaseAuthMiddleware(["ADMIN"]),
+    (req, res) => res.json(swaggerSpec)
+  );
 }

--- a/src/modules/audit/routes/index.ts
+++ b/src/modules/audit/routes/index.ts
@@ -12,6 +12,11 @@ const router = Router();
  *     responses:
  *       200:
  *         description: Detalhes do módulo
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X GET "http://localhost:3000/api/v1/audit"
  */
 router.get("/", (req, res) => {
   res.json({

--- a/src/modules/audit/routes/logs.ts
+++ b/src/modules/audit/routes/logs.ts
@@ -17,6 +17,12 @@ const controller = new AuditController();
  *     responses:
  *       200:
  *         description: Lista de logs
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X GET "http://localhost:3000/api/v1/audit/logs" \\
+ *            -H "Authorization: Bearer <TOKEN>"
  */
 router.get("/", authMiddlewareWithDB([Role.ADMIN]), controller.getLogs);
 

--- a/src/modules/brevo/routes/index.ts
+++ b/src/modules/brevo/routes/index.ts
@@ -18,6 +18,11 @@ const emailVerificationController = new EmailVerificationController();
  *     responses:
  *       200:
  *         description: Detalhes do módulo
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X GET "http://localhost:3000/api/v1/brevo"
  */
 router.get("/", brevoController.getModuleInfo);
 
@@ -30,6 +35,11 @@ router.get("/", brevoController.getModuleInfo);
  *     responses:
  *       200:
  *         description: Status de saúde
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X GET "http://localhost:3000/api/v1/brevo/health"
  */
 router.get("/health", brevoController.healthCheck);
 /**
@@ -43,6 +53,12 @@ router.get("/health", brevoController.healthCheck);
  *     responses:
  *       200:
  *         description: Configurações do Brevo
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X GET "http://localhost:3000/api/v1/brevo/config" \\
+ *            -H "Authorization: Bearer <TOKEN>"
  */
 router.get(
   "/config",
@@ -63,6 +79,11 @@ router.get(
  *     responses:
  *       200:
  *         description: Email verificado
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X GET "http://localhost:3000/api/v1/brevo/verificar-email?token=TOKEN"
  */
 router.get("/verificar-email", emailVerificationController.verifyEmail);
 /**
@@ -74,6 +95,13 @@ router.get("/verificar-email", emailVerificationController.verifyEmail);
  *     responses:
  *       200:
  *         description: Email reenviado
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X POST "http://localhost:3000/api/v1/brevo/reenviar-verificacao" \\
+ *            -H "Content-Type: application/json" \\
+ *            -d '{"email":"user@example.com"}'
  */
 router.post(
   "/reenviar-verificacao",

--- a/src/modules/empresa/routes/index.ts
+++ b/src/modules/empresa/routes/index.ts
@@ -12,6 +12,11 @@ const router = Router();
  *     responses:
  *       200:
  *         description: Detalhes do módulo
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X GET "http://localhost:3000/api/v1/empresa"
  */
 router.get("/", (req, res) => {
   res.json({

--- a/src/modules/empresa/routes/plans.ts
+++ b/src/modules/empresa/routes/plans.ts
@@ -14,9 +14,33 @@ const controller = new PlanController();
  *     tags: [Empresa]
  *     security:
  *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               nome: { type: string, example: "Plano Básico" }
+ *               valor: { type: number, example: 49.9 }
+ *               descricao: { type: string, example: "Acesso básico" }
+ *               recursos:
+ *                 type: array
+ *                 items: { type: string }
+ *               frequency: { type: number, example: 1 }
+ *               frequencyType: { type: string, example: "months" }
+ *               repetitions: { type: integer, nullable: true }
  *     responses:
  *       201:
  *         description: Plano criado com sucesso
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X POST "http://localhost:3000/api/v1/empresa/plans" \\
+ *            -H "Authorization: Bearer <TOKEN>" \\
+ *            -H "Content-Type: application/json" \\
+ *            -d '{"nome":"Plano Básico","valor":49.9,"descricao":"Acesso básico","recursos":["feature"],"frequency":1,"frequencyType":"months"}'
  */
 router.post("/", authMiddlewareWithDB([Role.ADMIN]), controller.createPlan);
 
@@ -29,6 +53,11 @@ router.post("/", authMiddlewareWithDB([Role.ADMIN]), controller.createPlan);
  *     responses:
  *       200:
  *         description: Lista de planos
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X GET "http://localhost:3000/api/v1/empresa/plans"
  */
 router.get("/", controller.getPlans);
 
@@ -46,9 +75,28 @@ router.get("/", controller.getPlans);
  *         required: true
  *         schema:
  *           type: string
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               nome: { type: string, example: "Plano Atualizado" }
+ *               valor: { type: number, example: 59.9 }
+ *               descricao: { type: string, example: "Descrição" }
+ *               ativo: { type: boolean, example: true }
  *     responses:
  *       200:
  *         description: Plano atualizado
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X PUT "http://localhost:3000/api/v1/empresa/plans/{planId}" \\
+ *            -H "Authorization: Bearer <TOKEN>" \\
+ *            -H "Content-Type: application/json" \\
+ *            -d '{"nome":"Plano Atualizado"}'
  */
 router.put(
   "/:planId",
@@ -70,9 +118,28 @@ router.put(
  *         required: true
  *         schema:
  *           type: string
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               empresaId: { type: string, example: "empresa-uuid" }
+ *               metodoPagamento: { type: string, example: "CREDIT" }
+ *               tipo: { type: string, example: "STANDARD" }
+ *               validade: { type: string, example: "DIAS_30" }
  *     responses:
  *       200:
  *         description: Plano atribuído
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X POST "http://localhost:3000/api/v1/empresa/plans/{planId}/assign" \\
+ *            -H "Authorization: Bearer <TOKEN>" \\
+ *            -H "Content-Type: application/json" \\
+ *            -d '{"empresaId":"empresa-uuid","metodoPagamento":"CREDIT"}'
  */
 router.post(
   "/:planId/assign",
@@ -97,6 +164,12 @@ router.post(
  *     responses:
  *       200:
  *         description: Plano removido
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X DELETE "http://localhost:3000/api/v1/empresa/plans/companies/{empresaId}/plan" \\
+ *            -H "Authorization: Bearer <TOKEN>"
  */
 router.delete(
   "/companies/:empresaId/plan",

--- a/src/modules/mercadopago/routes/orders.ts
+++ b/src/modules/mercadopago/routes/orders.ts
@@ -25,6 +25,11 @@ const ordersController = new OrdersController();
  *     responses:
  *       200:
  *         description: Detalhes das rotas de orders
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X GET "http://localhost:3000/api/v1/mercadopago/orders"
  */
 router.get("/", (req, res) => {
   res.json({
@@ -50,9 +55,48 @@ router.get("/", (req, res) => {
  *     tags: [MercadoPago]
  *     security:
  *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               total_amount:
+ *                 type: number
+ *                 example: 100
+ *               items:
+ *                 type: array
+ *                 items:
+ *                   type: object
+ *                   properties:
+ *                     id: { type: string, example: "1" }
+ *                     title: { type: string, example: "Produto" }
+ *                     quantity: { type: integer, example: 1 }
+ *                     unit_price: { type: number, example: 100 }
+ *                     currency_id: { type: string, example: "BRL" }
+ *               payments:
+ *                 type: array
+ *                 items:
+ *                   type: object
+ *                   properties:
+ *                     payment_method_id: { type: string, example: "pix" }
+ *                     payment_type_id: { type: string, example: "instant_payment" }
+ *                     payer:
+ *                       type: object
+ *                       properties:
+ *                         email: { type: string, example: "user@example.com" }
  *     responses:
  *       201:
  *         description: Order criada
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X POST "http://localhost:3000/api/v1/mercadopago/orders" \\
+ *            -H "Authorization: Bearer <TOKEN>" \\
+ *            -H "Content-Type: application/json" \\
+ *            -d '{"total_amount":100,"items":[{"id":"1","title":"Produto","quantity":1,"unit_price":100,"currency_id":"BRL"}],"payments":[{"payment_method_id":"pix","payment_type_id":"instant_payment","payer":{"email":"user@example.com"}}]}'
  */
 router.post("/", supabaseAuthMiddleware(), ordersController.createOrder);
 
@@ -77,6 +121,12 @@ router.post("/", supabaseAuthMiddleware(), ordersController.createOrder);
  *     responses:
  *       200:
  *         description: Dados da order
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X GET "http://localhost:3000/api/v1/mercadopago/orders/{orderId}" \\
+ *            -H "Authorization: Bearer <TOKEN>"
  */
 router.get("/:orderId", supabaseAuthMiddleware(), ordersController.getOrder);
 
@@ -101,6 +151,12 @@ router.get("/:orderId", supabaseAuthMiddleware(), ordersController.getOrder);
  *     responses:
  *       200:
  *         description: Order cancelada
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X PUT "http://localhost:3000/api/v1/mercadopago/orders/{orderId}/cancel" \\
+ *            -H "Authorization: Bearer <TOKEN>"
  */
 router.put(
   "/:orderId/cancel",
@@ -129,6 +185,14 @@ router.put(
  *     responses:
  *       200:
  *         description: Reembolso processado
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X POST "http://localhost:3000/api/v1/mercadopago/orders/{orderId}/refund" \\
+ *            -H "Authorization: Bearer <TOKEN>" \\
+ *            -H "Content-Type: application/json" \\
+ *            -d '{"amount":100}'
  */
 router.post(
   "/:orderId/refund",

--- a/src/modules/usuarios/routes/admin-routes.ts
+++ b/src/modules/usuarios/routes/admin-routes.ts
@@ -40,6 +40,12 @@ router.use(supabaseAuthMiddleware(["ADMIN", "MODERADOR"]));
  *     responses:
  *       200:
  *         description: Detalhes do painel
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X GET "http://localhost:3000/api/v1/usuarios/admin" \\
+ *            -H "Authorization: Bearer <TOKEN>"
  */
 router.get("/", adminController.getAdminInfo);
 
@@ -58,6 +64,12 @@ router.get("/", adminController.getAdminInfo);
  *     responses:
  *       200:
  *         description: Lista de usuários
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X GET "http://localhost:3000/api/v1/usuarios/admin/usuarios" \\
+ *            -H "Authorization: Bearer <TOKEN>"
  */
 router.get("/usuarios", adminController.listarUsuarios);
 
@@ -82,6 +94,12 @@ router.get("/usuarios", adminController.listarUsuarios);
  *     responses:
  *       200:
  *         description: Usuário encontrado
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X GET "http://localhost:3000/api/v1/usuarios/admin/usuarios/{userId}" \\
+ *            -H "Authorization: Bearer <TOKEN>"
  */
 router.get("/usuarios/:userId", adminController.buscarUsuario);
 
@@ -111,6 +129,12 @@ router.get(
  *     responses:
  *       200:
  *         description: Histórico retornado
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X GET "http://localhost:3000/api/v1/usuarios/admin/usuarios/{userId}/pagamentos" \\
+ *            -H "Authorization: Bearer <TOKEN>"
  */
 
 // =============================================
@@ -143,6 +167,14 @@ router.patch(
  *     responses:
  *       200:
  *         description: Status atualizado
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X PATCH "http://localhost:3000/api/v1/usuarios/admin/usuarios/{userId}/status" \\
+ *            -H "Authorization: Bearer <TOKEN>" \\
+ *            -H "Content-Type: application/json" \\
+ *            -d '{"status":"ATIVO"}'
  */
 
 /**
@@ -171,6 +203,14 @@ router.patch(
  *     responses:
  *       200:
  *         description: Role atualizada
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X PATCH "http://localhost:3000/api/v1/usuarios/admin/usuarios/{userId}/role" \\
+ *            -H "Authorization: Bearer <TOKEN>" \\
+ *            -H "Content-Type: application/json" \\
+ *            -d '{"role":"MODERADOR"}'
  */
 
 export { router as adminRoutes };

--- a/src/modules/usuarios/routes/password-recovery.ts
+++ b/src/modules/usuarios/routes/password-recovery.ts
@@ -21,9 +21,24 @@ const passwordRecoveryController = new PasswordRecoveryController();
  *   post:
  *     summary: Solicitar recuperação de senha
  *     tags: [Usuários]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               email: { type: string, example: "user@example.com" }
  *     responses:
  *       200:
  *         description: Solicitação enviada
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X POST "http://localhost:3000/api/v1/usuarios/recuperar-senha" \\
+ *            -H "Content-Type: application/json" \\
+ *            -d '{"email":"user@example.com"}'
  */
 router.post("/", passwordRecoveryController.solicitarRecuperacao);
 
@@ -46,6 +61,11 @@ router.post("/", passwordRecoveryController.solicitarRecuperacao);
  *     responses:
  *       200:
  *         description: Token válido
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X GET "http://localhost:3000/api/v1/usuarios/recuperar-senha/validar/{token}"
  */
 router.get(
   "/validar/:token([a-fA-F0-9]{64})",
@@ -62,9 +82,25 @@ router.get(
  *   post:
  *     summary: Redefinir senha utilizando token
  *     tags: [Usuários]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               token: { type: string, example: "<token>" }
+ *               novaSenha: { type: string, example: "senha123" }
  *     responses:
  *       200:
  *         description: Senha redefinida
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X POST "http://localhost:3000/api/v1/usuarios/recuperar-senha/redefinir" \\
+ *            -H "Content-Type: application/json" \\
+ *            -d '{"token":"<token>","novaSenha":"senha123"}'
  */
 router.post("/redefinir", passwordRecoveryController.redefinirSenha);
 

--- a/src/modules/usuarios/routes/payment-routes.ts
+++ b/src/modules/usuarios/routes/payment-routes.ts
@@ -37,9 +37,29 @@ router.use(supabaseAuthMiddleware());
  *     tags: [Usuários - Pagamentos]
  *     security:
  *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               cursoId: { type: string, example: "curso-uuid" }
+ *               paymentToken: { type: string, example: "tok_123" }
+ *               paymentMethodId: { type: string, example: "visa" }
+ *               installments: { type: integer, example: 1 }
+ *               issuerId: { type: string, example: "issuer" }
  *     responses:
  *       200:
  *         description: Pagamento processado
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X POST "http://localhost:3000/api/v1/usuarios/pagamentos/curso" \\
+ *            -H "Authorization: Bearer <TOKEN>" \\
+ *            -H "Content-Type: application/json" \\
+ *            -d '{"cursoId":"curso-uuid","paymentToken":"tok_123","paymentMethodId":"visa"}'
  */
 router.post("/curso", paymentController.processarPagamentoCurso);
 
@@ -55,9 +75,28 @@ router.post("/curso", paymentController.processarPagamentoCurso);
  *     tags: [Usuários - Pagamentos]
  *     security:
  *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               plano: { type: string, example: "plano-premium" }
+ *               cardToken: { type: string, example: "tok_123" }
+ *               frequencia: { type: integer, example: 1 }
+ *               periodo: { type: string, example: "months" }
  *     responses:
  *       201:
  *         description: Assinatura criada
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X POST "http://localhost:3000/api/v1/usuarios/pagamentos/assinatura" \\
+ *            -H "Authorization: Bearer <TOKEN>" \\
+ *            -H "Content-Type: application/json" \\
+ *            -d '{"plano":"plano-premium","cardToken":"tok_123"}'
  */
 router.post("/assinatura", paymentController.criarAssinaturaPremium);
 
@@ -73,9 +112,26 @@ router.post("/assinatura", paymentController.criarAssinaturaPremium);
  *     tags: [Usuários - Pagamentos]
  *     security:
  *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               subscriptionId: { type: string, example: "sub-123" }
+ *               motivo: { type: string, example: "Opção" }
  *     responses:
  *       200:
  *         description: Assinatura cancelada
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X PUT "http://localhost:3000/api/v1/usuarios/pagamentos/assinatura/cancelar" \\
+ *            -H "Authorization: Bearer <TOKEN>" \\
+ *            -H "Content-Type: application/json" \\
+ *            -d '{"subscriptionId":"sub-123"}'
  */
 router.put("/assinatura/cancelar", paymentController.cancelarAssinatura);
 
@@ -94,6 +150,12 @@ router.put("/assinatura/cancelar", paymentController.cancelarAssinatura);
  *     responses:
  *       200:
  *         description: Histórico de pagamentos
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X GET "http://localhost:3000/api/v1/usuarios/pagamentos/historico" \\
+ *            -H "Authorization: Bearer <TOKEN>"
  */
 router.get("/historico", paymentController.listarHistoricoPagamentos);
 

--- a/src/modules/usuarios/routes/stats-routes.ts
+++ b/src/modules/usuarios/routes/stats-routes.ts
@@ -40,6 +40,12 @@ router.use(supabaseAuthMiddleware(["ADMIN", "MODERADOR"]));
  *     responses:
  *       200:
  *         description: Dados de dashboard
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X GET "http://localhost:3000/api/v1/usuarios/stats/dashboard" \\
+ *            -H "Authorization: Bearer <TOKEN>"
  */
 router.get("/dashboard", statsController.getDashboardStats);
 
@@ -58,6 +64,12 @@ router.get("/dashboard", statsController.getDashboardStats);
  *     responses:
  *       200:
  *         description: Estatísticas retornadas
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X GET "http://localhost:3000/api/v1/usuarios/stats/usuarios" \\
+ *            -H "Authorization: Bearer <TOKEN>"
  */
 router.get("/usuarios", statsController.getUserStats);
 
@@ -76,6 +88,12 @@ router.get("/usuarios", statsController.getUserStats);
  *     responses:
  *       200:
  *         description: Estatísticas de pagamentos
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X GET "http://localhost:3000/api/v1/usuarios/stats/pagamentos" \\
+ *            -H "Authorization: Bearer <TOKEN>"
  */
 router.get(
   "/pagamentos",

--- a/src/modules/usuarios/routes/usuario-routes.ts
+++ b/src/modules/usuarios/routes/usuario-routes.ts
@@ -175,9 +175,32 @@ router.get("/", (req, res) => {
  *   post:
  *     summary: Registrar novo usuário
  *     tags: [Usuários]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/UserRegisterRequest'
  *     responses:
  *       201:
  *         description: Usuário criado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/UserRegisterResponse'
+ *       400:
+ *         description: Dados inválidos
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X POST "http://localhost:3000/api/v1/usuarios/registrar" \
+ *            -H "Content-Type: application/json" \
+ *            -d '{"nomeCompleto":"João da Silva","documento":"12345678900","telefone":"11999999999","email":"joao@example.com","senha":"senha123","confirmarSenha":"senha123","aceitarTermos":true,"supabaseId":"uuid","tipoUsuario":"PESSOA_FISICA"}'
  */
 router.post(
   "/registrar",
@@ -226,9 +249,32 @@ router.post(
  *   post:
  *     summary: Login de usuário
  *     tags: [Usuários]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/UserLoginRequest'
  *     responses:
  *       200:
  *         description: Login realizado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/UserLoginResponse'
+ *       401:
+ *         description: Credenciais inválidas
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X POST "http://localhost:3000/api/v1/usuarios/login" \
+ *            -H "Content-Type: application/json" \
+ *            -d '{"documento":"12345678900","senha":"senha123"}'
  */
 router.post(
   "/login",
@@ -255,9 +301,32 @@ router.post(
  *   post:
  *     summary: Atualizar token JWT
  *     tags: [Usuários]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/RefreshTokenRequest'
  *     responses:
  *       200:
  *         description: Token renovado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/RefreshTokenResponse'
+ *       400:
+ *         description: Refresh token ausente
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X POST "http://localhost:3000/api/v1/usuarios/refresh" \\
+ *            -H "Content-Type: application/json" \\
+ *            -d '{"refreshToken":"<TOKEN>"}'
  */
 router.post(
   "/refresh",
@@ -284,6 +353,16 @@ router.post(
  *     responses:
  *       200:
  *         description: Logout efetuado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/LogoutResponse'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X POST "http://localhost:3000/api/v1/usuarios/logout" \\
+ *            -H "Authorization: Bearer <TOKEN>"
  */
 router.post(
   "/logout",
@@ -315,6 +394,16 @@ router.post(
  *     responses:
  *       200:
  *         description: Perfil retornado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/UserProfile'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X GET "http://localhost:3000/api/v1/usuarios/perfil" \\
+ *            -H "Authorization: Bearer <TOKEN>"
  */
 router.get(
   "/perfil",

--- a/src/modules/website/routes/banner.ts
+++ b/src/modules/website/routes/banner.ts
@@ -15,6 +15,11 @@ const upload = multer({ storage: multer.memoryStorage() });
  *     responses:
  *       200:
  *         description: Lista de banners
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X GET "http://localhost:3000/api/v1/website/banner"
  */
 router.get("/", BannerController.list);
 
@@ -33,6 +38,11 @@ router.get("/", BannerController.list);
  *     responses:
  *       200:
  *         description: Banner encontrado
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X GET "http://localhost:3000/api/v1/website/banner/{id}"
  */
 router.get("/:id", BannerController.get);
 
@@ -47,6 +57,14 @@ router.get("/:id", BannerController.get);
  *     responses:
  *       201:
  *         description: Banner criado
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X POST "http://localhost:3000/api/v1/website/banner" \\
+ *            -H "Authorization: Bearer <TOKEN>" \\
+ *            -F "imagem=@banner.png" \\
+ *            -F "titulo=Novo Banner"
  */
 router.post(
   "/",
@@ -72,6 +90,14 @@ router.post(
  *     responses:
  *       200:
  *         description: Banner atualizado
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X PUT "http://localhost:3000/api/v1/website/banner/{id}" \\
+ *            -H "Authorization: Bearer <TOKEN>" \\
+ *            -F "imagem=@banner.png" \\
+ *            -F "titulo=Atualizado"
  */
 router.put(
   "/:id",
@@ -97,6 +123,12 @@ router.put(
  *     responses:
  *       200:
  *         description: Banner removido
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X DELETE "http://localhost:3000/api/v1/website/banner/{id}" \\
+ *            -H "Authorization: Bearer <TOKEN>"
  */
 router.delete(
   "/:id",

--- a/src/modules/website/routes/business-group-information.ts
+++ b/src/modules/website/routes/business-group-information.ts
@@ -15,6 +15,11 @@ const upload = multer({ storage: multer.memoryStorage() });
  *     responses:
  *       200:
  *         description: Lista de informações
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X GET "http://localhost:3000/api/v1/website/business-group-information"
  */
 router.get("/", BusinessGroupInformationController.list);
 
@@ -33,6 +38,11 @@ router.get("/", BusinessGroupInformationController.list);
  *     responses:
  *       200:
  *         description: Informação encontrada
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X GET "http://localhost:3000/api/v1/website/business-group-information/{id}"
  */
 router.get("/:id", BusinessGroupInformationController.get);
 
@@ -47,6 +57,14 @@ router.get("/:id", BusinessGroupInformationController.get);
  *     responses:
  *       201:
  *         description: Informação criada
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X POST "http://localhost:3000/api/v1/website/business-group-information" \\
+ *            -H "Authorization: Bearer <TOKEN>" \\
+ *            -F "imagem=@info.png" \\
+ *            -F "titulo=Novo"
  */
 router.post(
   "/",
@@ -72,6 +90,14 @@ router.post(
  *     responses:
  *       200:
  *         description: Informação atualizada
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X PUT "http://localhost:3000/api/v1/website/business-group-information/{id}" \\
+ *            -H "Authorization: Bearer <TOKEN>" \\
+ *            -F "imagem=@info.png" \\
+ *            -F "titulo=Atualizado"
  */
 router.put(
   "/:id",
@@ -97,6 +123,12 @@ router.put(
  *     responses:
  *       200:
  *         description: Informação removida
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X DELETE "http://localhost:3000/api/v1/website/business-group-information/{id}" \\
+ *            -H "Authorization: Bearer <TOKEN>"
  */
 router.delete(
   "/:id",

--- a/src/modules/website/routes/index.ts
+++ b/src/modules/website/routes/index.ts
@@ -16,6 +16,11 @@ const router = Router();
  *     responses:
  *       200:
  *         description: Detalhes do módulo
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X GET "http://localhost:3000/api/v1/website"
  */
 router.get("/", (req, res) => {
   res.json({

--- a/src/modules/website/routes/logo-enterprises.ts
+++ b/src/modules/website/routes/logo-enterprises.ts
@@ -15,6 +15,11 @@ const upload = multer({ storage: multer.memoryStorage() });
  *     responses:
  *       200:
  *         description: Lista de logos
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X GET "http://localhost:3000/api/v1/website/logo-enterprises"
  */
 router.get("/", LogoEnterpriseController.list);
 
@@ -33,6 +38,11 @@ router.get("/", LogoEnterpriseController.list);
  *     responses:
  *       200:
  *         description: Logo encontrada
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X GET "http://localhost:3000/api/v1/website/logo-enterprises/{id}"
  */
 router.get("/:id", LogoEnterpriseController.get);
 
@@ -47,6 +57,14 @@ router.get("/:id", LogoEnterpriseController.get);
  *     responses:
  *       201:
  *         description: Logo criada
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X POST "http://localhost:3000/api/v1/website/logo-enterprises" \\
+ *            -H "Authorization: Bearer <TOKEN>" \\
+ *            -F "imagem=@logo.png" \\
+ *            -F "empresa=Minha Empresa"
  */
 router.post(
   "/",
@@ -72,6 +90,14 @@ router.post(
  *     responses:
  *       200:
  *         description: Logo atualizada
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X PUT "http://localhost:3000/api/v1/website/logo-enterprises/{id}" \\
+ *            -H "Authorization: Bearer <TOKEN>" \\
+ *            -F "imagem=@logo.png" \\
+ *            -F "empresa=Atualizada"
  */
 router.put(
   "/:id",
@@ -97,6 +123,12 @@ router.put(
  *     responses:
  *       200:
  *         description: Logo removida
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X DELETE "http://localhost:3000/api/v1/website/logo-enterprises/{id}" \\
+ *            -H "Authorization: Bearer <TOKEN>"
  */
 router.delete(
   "/:id",

--- a/src/modules/website/routes/slide.ts
+++ b/src/modules/website/routes/slide.ts
@@ -15,6 +15,11 @@ const upload = multer({ storage: multer.memoryStorage() });
  *     responses:
  *       200:
  *         description: Lista de slides
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X GET "http://localhost:3000/api/v1/website/slide"
  */
 router.get("/", SlideController.list);
 
@@ -33,6 +38,11 @@ router.get("/", SlideController.list);
  *     responses:
  *       200:
  *         description: Slide encontrado
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X GET "http://localhost:3000/api/v1/website/slide/{id}"
  */
 router.get("/:id", SlideController.get);
 
@@ -47,6 +57,14 @@ router.get("/:id", SlideController.get);
  *     responses:
  *       201:
  *         description: Slide criado
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X POST "http://localhost:3000/api/v1/website/slide" \\
+ *            -H "Authorization: Bearer <TOKEN>" \\
+ *            -F "imagem=@slide.png" \\
+ *            -F "titulo=Novo Slide"
  */
 router.post(
   "/",
@@ -72,6 +90,14 @@ router.post(
  *     responses:
  *       200:
  *         description: Slide atualizado
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X PUT "http://localhost:3000/api/v1/website/slide/{id}" \\
+ *            -H "Authorization: Bearer <TOKEN>" \\
+ *            -F "imagem=@slide.png" \\
+ *            -F "titulo=Atualizado"
  */
 router.put(
   "/:id",
@@ -97,6 +123,12 @@ router.put(
  *     responses:
  *       200:
  *         description: Slide removido
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X DELETE "http://localhost:3000/api/v1/website/slide/{id}" \\
+ *            -H "Authorization: Bearer <TOKEN>"
  */
 router.delete(
   "/:id",

--- a/src/modules/website/routes/sobre.ts
+++ b/src/modules/website/routes/sobre.ts
@@ -15,6 +15,11 @@ const upload = multer({ storage: multer.memoryStorage() });
  *     responses:
  *       200:
  *         description: Lista de conteúdos
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X GET "http://localhost:3000/api/v1/website/sobre"
  */
 router.get("/", SobreController.list);
 
@@ -33,6 +38,11 @@ router.get("/", SobreController.list);
  *     responses:
  *       200:
  *         description: Conteúdo encontrado
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X GET "http://localhost:3000/api/v1/website/sobre/{id}"
  */
 router.get("/:id", SobreController.get);
 
@@ -47,6 +57,14 @@ router.get("/:id", SobreController.get);
  *     responses:
  *       201:
  *         description: Conteúdo criado
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X POST "http://localhost:3000/api/v1/website/sobre" \\
+ *            -H "Authorization: Bearer <TOKEN>" \\
+ *            -F "imagem=@sobre.png" \\
+ *            -F "titulo=Novo"
  */
 router.post(
   "/",
@@ -72,6 +90,14 @@ router.post(
  *     responses:
  *       200:
  *         description: Conteúdo atualizado
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X PUT "http://localhost:3000/api/v1/website/sobre/{id}" \\
+ *            -H "Authorization: Bearer <TOKEN>" \\
+ *            -F "imagem=@sobre.png" \\
+ *            -F "titulo=Atualizado"
  */
 router.put(
   "/:id",
@@ -97,6 +123,12 @@ router.put(
  *     responses:
  *       200:
  *         description: Conteúdo removido
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X DELETE "http://localhost:3000/api/v1/website/sobre/{id}" \\
+ *            -H "Authorization: Bearer <TOKEN>"
  */
 router.delete(
   "/:id",

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -25,6 +25,19 @@ const emailVerificationController = new EmailVerificationController();
  *     responses:
  *       200:
  *         description: Informações básicas e endpoints disponíveis
+ *         content:
+ *           application/json:
+ *             example:
+ *               message: "AdvanceMais API"
+ *               version: "v3.0.3"
+ *               status: "operational"
+ *               endpoints:
+ *                 usuarios: "/api/v1/usuarios"
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X GET "http://localhost:3000/"
  */
 router.get("/", (req, res) => {
   const data = {
@@ -96,6 +109,17 @@ router.get("/", (req, res) => {
  *     responses:
  *       200:
  *         description: Status do servidor
+ *         content:
+ *           application/json:
+ *             example:
+ *               status: "OK"
+ *               uptime: 1
+ *               version: "v3.0.3"
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X GET "http://localhost:3000/health"
  */
 router.get("/health", (req, res) => {
   res.json({


### PR DESCRIPTION
## Summary
- protect swagger UI with admin authentication and add comprehensive token and profile schemas
- provide detailed request/response docs with curl samples for users, payments, audit logs and other modules
- expand MercadoPago and empresa endpoints with explicit bodies and examples

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8edfcb4608325af9f8f20a75bb7db