### PR TITLE
feat: add login screen for swagger docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "packageManager": "pnpm@10.14.0",
   "devDependencies": {
     "@types/bcrypt": "^6.0.0",
+    "@types/cookie-parser": "^1.4.9",
     "@types/cors": "^2.8.19",
     "@types/express": "^4.17.21",
     "@types/jest": "^29.5.11",
@@ -61,6 +62,7 @@
     "@prisma/client": "^6.13.0",
     "@supabase/supabase-js": "^2.53.0",
     "bcrypt": "^6.0.0",
+    "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
     "dotenv": "^17.2.1",
     "express": "^4.19.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       bcrypt:
         specifier: ^6.0.0
         version: 6.0.0
+      cookie-parser:
+        specifier: ^1.4.7
+        version: 1.4.7
       cors:
         specifier: ^2.8.5
         version: 2.8.5
@@ -60,6 +63,9 @@ importers:
       '@types/bcrypt':
         specifier: ^6.0.0
         version: 6.0.0
+      '@types/cookie-parser':
+        specifier: ^1.4.9
+        version: 1.4.9(@types/express@4.17.23)
       '@types/cors':
         specifier: ^2.8.19
         version: 2.8.19
@@ -542,6 +548,11 @@ packages:
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
+  '@types/cookie-parser@1.4.9':
+    resolution: {integrity: sha512-tGZiZ2Gtc4m3wIdLkZ8mkj1T6CEHb35+VApbL2T14Dew8HA7c+04dmKqsKRNC+8RJPm16JEK0tFSwdZqubfc4g==}
+    peerDependencies:
+      '@types/express': '*'
+
   '@types/cookiejar@2.1.5':
     resolution: {integrity: sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==}
 
@@ -919,11 +930,19 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  cookie-parser@1.4.7:
+    resolution: {integrity: sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==}
+    engines: {node: '>= 0.8.0'}
+
   cookie-signature@1.0.6:
     resolution: {integrity: sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==}
 
   cookie@0.7.1:
     resolution: {integrity: sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==}
+    engines: {node: '>= 0.6'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
 
   cookiejar@2.1.4:
@@ -3213,6 +3232,10 @@ snapshots:
     dependencies:
       '@types/node': 24.2.0
 
+  '@types/cookie-parser@1.4.9(@types/express@4.17.23)':
+    dependencies:
+      '@types/express': 4.17.23
+
   '@types/cookiejar@2.1.5': {}
 
   '@types/cors@2.8.19':
@@ -3632,9 +3655,16 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
+  cookie-parser@1.4.7:
+    dependencies:
+      cookie: 0.7.2
+      cookie-signature: 1.0.6
+
   cookie-signature@1.0.6: {}
 
   cookie@0.7.1: {}
+
+  cookie@0.7.2: {}
 
   cookiejar@2.1.4: {}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import "./config/env";
 import express from "express";
 import cors from "cors";
 import helmet from "helmet";
+import cookieParser from "cookie-parser";
 import { serverConfig } from "./config/env";
 import { appRoutes } from "./routes";
 import { startExpiredUserCleanupJob } from "./modules/usuarios/services/user-cleanup-service";
@@ -54,6 +55,12 @@ app.use(express.json({ limit: "10mb" }));
  * Para formulários HTML tradicionais
  */
 app.use(express.urlencoded({ extended: true }));
+
+/**
+ * Parser de cookies
+ * Necessário para autenticação via cookies no Swagger
+ */
+app.use(cookieParser());
 
 // =============================================
 // SWAGGER DOCS

--- a/src/modules/docs/index.ts
+++ b/src/modules/docs/index.ts
@@ -1,0 +1,1 @@
+export { docsRoutes } from "./routes";

--- a/src/modules/docs/routes/index.ts
+++ b/src/modules/docs/routes/index.ts
@@ -1,0 +1,54 @@
+import { Router } from "express";
+
+const router = Router();
+
+router.get("/docs/login", (req, res) => {
+  res.send(`<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+<meta charset="UTF-8" />
+<title>Login - AdvanceMais</title>
+<style>
+  body { font-family: Arial, sans-serif; background:#f3f2ef; display:flex; justify-content:center; align-items:center; height:100vh; margin:0; }
+  .container { background:#fff; padding:2rem; border-radius:8px; box-shadow:0 4px 12px rgba(0,0,0,0.1); width:300px; }
+  h1 { color:#0a66c2; font-size:1.5rem; text-align:center; margin-bottom:1rem; }
+  input { width:100%; padding:0.5rem; margin:0.5rem 0; border:1px solid #ccc; border-radius:4px; }
+  button { width:100%; padding:0.5rem; background:#0a66c2; color:#fff; border:none; border-radius:4px; cursor:pointer; }
+  .error { color:#d11124; margin-top:0.5rem; text-align:center; }
+</style>
+</head>
+<body>
+<div class="container">
+  <h1>AdvanceMais</h1>
+  <form id="loginForm">
+    <input type="text" id="documento" placeholder="CPF ou CNPJ" required />
+    <input type="password" id="senha" placeholder="Senha" required />
+    <button type="submit">Entrar</button>
+    <p class="error" id="error"></p>
+  </form>
+</div>
+<script>
+  const form = document.getElementById('loginForm');
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const documento = document.getElementById('documento').value;
+    const senha = document.getElementById('senha').value;
+    const res = await fetch('/api/v1/usuarios/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ documento, senha })
+    });
+    const data = await res.json();
+    if (res.ok && data.token) {
+      document.cookie = `token=${data.token}; path=/`;
+      window.location.href = '/docs';
+    } else {
+      document.getElementById('error').textContent = data.message || 'Falha no login';
+    }
+  });
+</script>
+</body>
+</html>`);
+});
+
+export { router as docsRoutes };

--- a/src/modules/usuarios/auth/supabase-middleware.ts
+++ b/src/modules/usuarios/auth/supabase-middleware.ts
@@ -44,9 +44,13 @@ function getKey(header: any, callback: any) {
 export const supabaseAuthMiddleware =
   (roles?: string[]) =>
   async (req: Request, res: Response, next: NextFunction) => {
-    const token = req.headers.authorization?.split(" ")[1];
+    const token =
+      req.headers.authorization?.split(" ")[1] || req.cookies?.token;
 
     if (!token) {
+      if (req.originalUrl.startsWith("/docs")) {
+        return res.redirect("/docs/login");
+      }
       return res
         .status(401)
         .json({ message: "Token de autorização necessário" });

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -5,6 +5,7 @@ import { brevoRoutes } from "../modules/brevo/routes";
 import { websiteRoutes } from "../modules/website";
 import { empresaRoutes } from "../modules/empresa";
 import { auditRoutes } from "../modules/audit";
+import { docsRoutes } from "../modules/docs";
 import { EmailVerificationController } from "../modules/brevo/controllers/email-verification-controller";
 
 /**
@@ -238,6 +239,21 @@ if (auditRoutes) {
   }
 } else {
   console.error("❌ auditRoutes não está definido");
+}
+
+/**
+ * Módulo de Documentação - COM VALIDAÇÃO
+ * /docs/login
+ */
+if (docsRoutes) {
+  try {
+    router.use("/", docsRoutes);
+    console.log("✅ Módulo Documentação registrado com sucesso");
+  } catch (error) {
+    console.error("❌ ERRO - Módulo Documentação:", error);
+  }
+} else {
+  console.error("❌ docsRoutes não está definido");
 }
 
 /**


### PR DESCRIPTION
## Summary
- add simple LinkedIn-style login page to access Swagger docs
- authenticate Swagger using cookies and redirect to login when token missing
- enable cookie parsing and register documentation module

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9a972489c8325a93ab7fb2471ecb3