### PR TITLE
fix docs login template causing build errors

### DIFF
--- a/src/modules/docs/routes/index.ts
+++ b/src/modules/docs/routes/index.ts
@@ -40,7 +40,7 @@ router.get("/docs/login", (req, res) => {
     });
     const data = await res.json();
     if (res.ok && data.token) {
-      document.cookie = `token=${data.token}; path=/`;
+      document.cookie = 'token=' + data.token + '; path=/';
       window.location.href = '/docs';
     } else {
       document.getElementById('error').textContent = data.message || 'Falha no login';


### PR DESCRIPTION
## Summary
- correct nested template string in docs login route that broke TypeScript compilation

## Testing
- `pnpm run build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9ac4ac4a88325a82e94c617507abb