### PR TITLE
fix: avoid redirect loop on docs login

### DIFF
--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -220,11 +220,22 @@ const options: Options = {
 const swaggerSpec = swaggerJsdoc(options);
 
 export function setupSwagger(app: Application): void {
+  const swaggerUiSetup = swaggerUi.setup(swaggerSpec);
+
   app.use(
     "/docs",
-    supabaseAuthMiddleware(["ADMIN"]),
-    swaggerUi.serve,
-    swaggerUi.setup(swaggerSpec)
+    (req, res, next) => {
+      if (req.path === "/login") return next();
+      return supabaseAuthMiddleware(["ADMIN"])(req, res, next);
+    },
+    (req, res, next) => {
+      if (req.path === "/login") return next();
+      return swaggerUi.serve(req, res, next);
+    },
+    (req, res, next) => {
+      if (req.path === "/login") return next();
+      return swaggerUiSetup(req, res, next);
+    }
   );
   app.get(
     "/docs.json",

--- a/src/modules/usuarios/auth/supabase-middleware.ts
+++ b/src/modules/usuarios/auth/supabase-middleware.ts
@@ -44,11 +44,15 @@ function getKey(header: any, callback: any) {
 export const supabaseAuthMiddleware =
   (roles?: string[]) =>
   async (req: Request, res: Response, next: NextFunction) => {
+    if (req.originalUrl.startsWith("/docs/login")) {
+      return next();
+    }
+
     const token =
       req.headers.authorization?.split(" ")[1] || req.cookies?.token;
 
     if (!token) {
-      if (req.originalUrl.startsWith("/docs")) {
+      if (req.originalUrl.startsWith("/docs") && !req.originalUrl.startsWith("/docs/login")) {
         return res.redirect("/docs/login");
       }
       return res


### PR DESCRIPTION
## Summary
- exclude `/docs/login` from Swagger auth middleware
- guard auth middleware against self-redirect loops on docs login

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a9ae6cd74c83259f50de6d0244ba9f