### PR TITLE
Allow inline scripts for Swagger by customizing CSP

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,18 @@ app.use(
  * Middleware de segurança Helmet
  * Adiciona headers de segurança às respostas
  */
-app.use(helmet());
+app.use(
+  helmet({
+    contentSecurityPolicy: {
+      directives: {
+        defaultSrc: ["'self'"],
+        scriptSrc: ["'self'", "'unsafe-inline'"],
+        styleSrc: ["'self'", "'unsafe-inline'"],
+        imgSrc: ["'self'", "data:", "https:"],
+      },
+    },
+  })
+);
 
 /**
  * Parser de JSON com limite configurável


### PR DESCRIPTION
## Summary
- customize helmet Content Security Policy to permit inline scripts and styles for Swagger UI

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a9b4aeefdc8325b5b5e5c668148815