### PR TITLE
feat: add docs logout and expand user auth docs

### DIFF
--- a/src/config/swagger-custom.js
+++ b/src/config/swagger-custom.js
@@ -1,5 +1,12 @@
 (function () {
+  function hasToken() {
+    return document.cookie.split(';').some(function (c) {
+      return c.trim().startsWith('token=');
+    });
+  }
+
   window.addEventListener('load', function () {
+    if (!hasToken()) return;
     var btn = document.createElement('button');
     btn.textContent = 'Logout';
     btn.style.position = 'fixed';
@@ -14,7 +21,10 @@
     btn.style.cursor = 'pointer';
     btn.onclick = async function () {
       try {
-        await fetch('/api/v1/usuarios/logout', { method: 'POST', credentials: 'include' });
+        await fetch('/api/v1/usuarios/logout', {
+          method: 'POST',
+          credentials: 'include',
+        });
       } catch (e) {
         console.error('Erro ao fazer logout', e);
       }

--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -15,7 +15,11 @@ const options: Options = {
         "Documentação detalhada da API Advance+. Todas as rotas protegidas exigem o header `Authorization: Bearer <token>` obtido via login. O acesso ao Swagger é restrito a administradores.",
     },
     tags: [
-      { name: "Usuários", description: "Gerenciamento de contas e autenticação" },
+      {
+        name: "Usuários",
+        description:
+          "Gerenciamento de contas e autenticação: registro, login, refresh, logout, perfil e recuperação de senha",
+      },
       { name: "MercadoPago", description: "Integração de pagamentos" },
       { name: "Audit", description: "Registros de auditoria" },
       { name: "Brevo", description: "Serviços de e-mail" },
@@ -257,5 +261,25 @@ export function setupSwagger(app: Application): void {
     "/docs.json",
     supabaseAuthMiddleware(["ADMIN"]),
     (req, res) => res.json(swaggerSpec)
+  );
+
+  app.get(
+    "/redoc",
+    supabaseAuthMiddleware(["ADMIN"]),
+    (req, res) => {
+      res.send(`<!DOCTYPE html>
+<html>
+  <head>
+    <title>Advance+ API - ReDoc</title>
+    <meta charset="utf-8" />
+    <style>body { margin: 0; padding: 0; }</style>
+    <link rel="icon" href="data:," />
+  </head>
+  <body>
+    <redoc spec-url="/docs.json"></redoc>
+    <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"></script>
+  </body>
+</html>`);
+    }
   );
 }

--- a/src/modules/usuarios/routes/password-recovery.ts
+++ b/src/modules/usuarios/routes/password-recovery.ts
@@ -27,11 +27,66 @@ const passwordRecoveryController = new PasswordRecoveryController();
  *         application/json:
  *           schema:
  *             type: object
+ *             required:
+ *               - email
  *             properties:
- *               email: { type: string, example: "user@example.com" }
+ *               email:
+ *                 type: string
+ *                 format: email
+ *                 example: "user@example.com"
  *     responses:
  *       200:
  *         description: Solicitação enviada
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success: { type: boolean, example: true }
+ *                 message: {
+ *                   type: string,
+ *                   example: "E-mail de recuperação enviado"
+ *                 }
+ *       400:
+ *         description: Dados inválidos
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *             example:
+ *               success: false
+ *               message: "E-mail inválido"
+ *               code: "VALIDATION_ERROR"
+ *       404:
+ *         description: Usuário não encontrado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *             example:
+ *               success: false
+ *               message: "Usuário não encontrado"
+ *               code: "NOT_FOUND"
+ *       429:
+ *         description: Muitas tentativas
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *             example:
+ *               success: false
+ *               message: "Muitas tentativas. Tente novamente mais tarde"
+ *               code: "RATE_LIMIT_EXCEEDED"
+ *       500:
+ *         description: Erro interno
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *             example:
+ *               success: false
+ *               message: "Erro interno do servidor"
+ *               code: "INTERNAL_ERROR"
  *     x-codeSamples:
  *       - lang: cURL
  *         label: Exemplo
@@ -58,9 +113,47 @@ router.post("/", passwordRecoveryController.solicitarRecuperacao);
  *         required: true
  *         schema:
  *           type: string
+ *         example: "<token>"
  *     responses:
  *       200:
  *         description: Token válido
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success: { type: boolean, example: true }
+ *                 message: { type: string, example: "Token válido" }
+ *       400:
+ *         description: Token em formato inválido
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *             example:
+ *               success: false
+ *               message: "Token inválido"
+ *               code: "VALIDATION_ERROR"
+ *       404:
+ *         description: Token não encontrado ou expirado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *             example:
+ *               success: false
+ *               message: "Token não encontrado"
+ *               code: "NOT_FOUND"
+ *       500:
+ *         description: Erro interno
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *             example:
+ *               success: false
+ *               message: "Erro interno do servidor"
+ *               code: "INTERNAL_ERROR"
  *     x-codeSamples:
  *       - lang: cURL
  *         label: Exemplo
@@ -88,12 +181,57 @@ router.get(
  *         application/json:
  *           schema:
  *             type: object
+ *             required:
+ *               - token
+ *               - novaSenha
  *             properties:
- *               token: { type: string, example: "<token>" }
- *               novaSenha: { type: string, example: "senha123" }
+ *               token:
+ *                 type: string
+ *                 example: "<token>"
+ *               novaSenha:
+ *                 type: string
+ *                 format: password
+ *                 example: "senha123"
  *     responses:
  *       200:
  *         description: Senha redefinida
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success: { type: boolean, example: true }
+ *                 message: { type: string, example: "Senha alterada com sucesso" }
+ *       400:
+ *         description: Dados inválidos ou token incorreto
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *             example:
+ *               success: false
+ *               message: "Token inválido"
+ *               code: "VALIDATION_ERROR"
+ *       404:
+ *         description: Token não encontrado ou expirado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *             example:
+ *               success: false
+ *               message: "Token não encontrado"
+ *               code: "NOT_FOUND"
+ *       500:
+ *         description: Erro interno
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *             example:
+ *               success: false
+ *               message: "Erro interno do servidor"
+ *               code: "INTERNAL_ERROR"
  *     x-codeSamples:
  *       - lang: cURL
  *         label: Exemplo

--- a/src/modules/usuarios/routes/usuario-routes.ts
+++ b/src/modules/usuarios/routes/usuario-routes.ts
@@ -118,6 +118,63 @@ const createAuthRateLimit = (
  *     responses:
  *       200:
  *         description: Detalhes do módulo
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 module: { type: string, example: "Usuários API" }
+ *                 version: { type: string, example: "7.0.0" }
+ *                 timestamp:
+ *                   type: string
+ *                   format: date-time
+ *                   example: "2024-01-01T12:00:00Z"
+ *                 environment: { type: string, example: "development" }
+ *                 features:
+ *                   type: object
+ *                   properties:
+ *                     emailVerification: { type: boolean, example: true }
+ *                     registration: { type: boolean, example: true }
+ *                     authentication: { type: boolean, example: true }
+ *                     profileManagement: { type: boolean, example: true }
+ *                     passwordRecovery: { type: boolean, example: true }
+ *                 endpoints:
+ *                   type: object
+ *                   properties:
+ *                     auth:
+ *                       type: object
+ *                       properties:
+ *                         register: { type: string, example: "POST /registrar" }
+ *                         login: { type: string, example: "POST /login" }
+ *                         logout: { type: string, example: "POST /logout" }
+ *                         refresh: { type: string, example: "POST /refresh" }
+ *                     profile:
+ *                       type: object
+ *                       properties:
+ *                         get: { type: string, example: "GET /perfil" }
+ *                         update: { type: string, example: "PUT /perfil" }
+ *                     recovery:
+ *                       type: object
+ *                       properties:
+ *                         request: { type: string, example: "POST /recuperar-senha" }
+ *                         validate: { type: string, example: "GET /recuperar-senha/validar/:token" }
+ *                         reset: { type: string, example: "POST /recuperar-senha/redefinir" }
+ *                     verification:
+ *                       type: object
+ *                       properties:
+ *                         verify: { type: string, example: "GET /verificar-email?token=xxx" }
+ *                         resend: { type: string, example: "POST /reenviar-verificacao" }
+ *                         status: { type: string, example: "GET /status-verificacao/:userId" }
+ *       500:
+ *         description: Erro interno
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *             example:
+ *               success: false
+ *               message: "Erro interno do servidor"
+ *               code: "INTERNAL_ERROR"
  */
 router.get("/", (req, res) => {
   res.json({
@@ -188,12 +245,52 @@ router.get("/", (req, res) => {
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/UserRegisterResponse'
+ *             example:
+ *               success: true
+ *               usuario:
+ *                 id: "b9e1d9b0-7c9f-4d1a-8f2a-1234567890ab"
+ *                 email: "joao@example.com"
+ *                 nomeCompleto: "João da Silva"
  *       400:
  *         description: Dados inválidos
  *         content:
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
+  *             example:
+  *               success: false
+  *               message: "Dados inválidos fornecidos"
+  *               code: "VALIDATION_ERROR"
+  *       409:
+  *         description: Usuário já existe
+  *         content:
+  *           application/json:
+  *             schema:
+  *               $ref: '#/components/schemas/ErrorResponse'
+  *             example:
+  *               success: false
+  *               message: "Usuário já cadastrado"
+  *               code: "DUPLICATE_ERROR"
+  *       429:
+  *         description: Muitas tentativas
+  *         content:
+  *           application/json:
+  *             schema:
+  *               $ref: '#/components/schemas/ErrorResponse'
+  *             example:
+  *               success: false
+  *               message: "Muitas tentativas. Tente novamente mais tarde"
+  *               code: "RATE_LIMIT_EXCEEDED"
+  *       500:
+  *         description: Erro interno
+  *         content:
+  *           application/json:
+  *             schema:
+  *               $ref: '#/components/schemas/ErrorResponse'
+  *             example:
+  *               success: false
+  *               message: "Erro interno do servidor"
+  *               code: "INTERNAL_ERROR"
  *     x-codeSamples:
  *       - lang: cURL
  *         label: Exemplo
@@ -262,12 +359,50 @@ router.post(
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/UserLoginResponse'
- *       401:
- *         description: Credenciais inválidas
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ErrorResponse'
+ *             example:
+ *               success: true
+ *               token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+ *               refreshToken: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+  *       400:
+  *         description: Dados ausentes ou inválidos
+  *         content:
+  *           application/json:
+  *             schema:
+  *               $ref: '#/components/schemas/ErrorResponse'
+  *             example:
+  *               success: false
+  *               message: "Documento ou senha inválidos"
+  *               code: "VALIDATION_ERROR"
+  *       401:
+  *         description: Credenciais inválidas
+  *         content:
+  *           application/json:
+  *             schema:
+  *               $ref: '#/components/schemas/ErrorResponse'
+  *             example:
+  *               success: false
+  *               message: "Credenciais inválidas"
+  *               code: "UNAUTHORIZED"
+  *       429:
+  *         description: Muitas tentativas
+  *         content:
+  *           application/json:
+  *             schema:
+  *               $ref: '#/components/schemas/ErrorResponse'
+  *             example:
+  *               success: false
+  *               message: "Muitas tentativas. Tente novamente mais tarde"
+  *               code: "RATE_LIMIT_EXCEEDED"
+  *       500:
+  *         description: Erro interno
+  *         content:
+  *           application/json:
+  *             schema:
+  *               $ref: '#/components/schemas/ErrorResponse'
+  *             example:
+  *               success: false
+  *               message: "Erro interno do servidor"
+  *               code: "INTERNAL_ERROR"
  *     x-codeSamples:
  *       - lang: cURL
  *         label: Exemplo
@@ -314,12 +449,53 @@ router.post(
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/RefreshTokenResponse'
+ *             example:
+ *               success: true
+ *               message: "Token renovado com sucesso"
+ *               usuario:
+ *                 id: "b9e1d9b0-7c9f-4d1a-8f2a-1234567890ab"
+ *                 email: "joao@example.com"
+ *                 nomeCompleto: "João da Silva"
  *       400:
  *         description: Refresh token ausente
  *         content:
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
+  *             example:
+  *               success: false
+  *               message: "Refresh token não informado"
+  *               code: "VALIDATION_ERROR"
+  *       401:
+  *         description: Refresh token inválido ou expirado
+  *         content:
+  *           application/json:
+  *             schema:
+  *               $ref: '#/components/schemas/ErrorResponse'
+  *             example:
+  *               success: false
+  *               message: "Token inválido"
+  *               code: "UNAUTHORIZED"
+  *       429:
+  *         description: Muitas tentativas
+  *         content:
+  *           application/json:
+  *             schema:
+  *               $ref: '#/components/schemas/ErrorResponse'
+  *             example:
+  *               success: false
+  *               message: "Muitas tentativas. Tente novamente mais tarde"
+  *               code: "RATE_LIMIT_EXCEEDED"
+  *       500:
+  *         description: Erro interno
+  *         content:
+  *           application/json:
+  *             schema:
+  *               $ref: '#/components/schemas/ErrorResponse'
+  *             example:
+  *               success: false
+  *               message: "Erro interno do servidor"
+  *               code: "INTERNAL_ERROR"
  *     x-codeSamples:
  *       - lang: cURL
  *         label: Exemplo
@@ -357,6 +533,29 @@ router.post(
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/LogoutResponse'
+ *             example:
+ *               success: true
+ *               message: "Logout realizado"
+  *       401:
+  *         description: Não autenticado
+  *         content:
+  *           application/json:
+  *             schema:
+  *               $ref: '#/components/schemas/ErrorResponse'
+  *             example:
+  *               success: false
+  *               message: "Token inválido ou ausente"
+  *               code: "UNAUTHORIZED"
+  *       500:
+  *         description: Erro interno
+  *         content:
+  *           application/json:
+  *             schema:
+  *               $ref: '#/components/schemas/ErrorResponse'
+  *             example:
+  *               success: false
+  *               message: "Erro interno do servidor"
+  *               code: "INTERNAL_ERROR"
  *     x-codeSamples:
  *       - lang: cURL
  *         label: Exemplo
@@ -398,6 +597,35 @@ router.post(
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/UserProfile'
+ *             example:
+ *               id: "b9e1d9b0-7c9f-4d1a-8f2a-1234567890ab"
+ *               email: "joao@example.com"
+ *               nomeCompleto: "João da Silva"
+ *               role: "ADMIN"
+ *               tipoUsuario: "PESSOA_FISICA"
+ *               supabaseId: "uuid-supabase"
+ *               emailVerificado: true
+ *               ultimoLogin: "2024-01-01T12:00:00Z"
+  *       401:
+  *         description: Não autenticado
+  *         content:
+  *           application/json:
+  *             schema:
+  *               $ref: '#/components/schemas/ErrorResponse'
+  *             example:
+  *               success: false
+  *               message: "Token inválido ou ausente"
+  *               code: "UNAUTHORIZED"
+  *       500:
+  *         description: Erro interno
+  *         content:
+  *           application/json:
+  *             schema:
+  *               $ref: '#/components/schemas/ErrorResponse'
+  *             example:
+  *               success: false
+  *               message: "Erro interno do servidor"
+  *               code: "INTERNAL_ERROR"
  *     x-codeSamples:
  *       - lang: cURL
  *         label: Exemplo


### PR DESCRIPTION
## Summary
- add conditional logout button for authenticated /docs sessions
- expand user tag description and enrich auth endpoints with complete examples and error responses
- add admin-protected Redoc route for sidebar-based docs using existing swagger spec

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9be0f5dbc8325b029b99ab26ffcad