### PR TITLE
docs: expand swagger specs for MercadoPago, Audit, Brevo, Empresa, Website and Users

### DIFF
--- a/src/config/swagger-custom.js
+++ b/src/config/swagger-custom.js
@@ -1,36 +1,57 @@
 (function () {
   function hasToken() {
-    return document.cookie.split(';').some(function (c) {
-      return c.trim().startsWith('token=');
-    });
+    return document.cookie
+      .split(";")
+      .some(function (c) {
+        return c.trim().startsWith("token=");
+      });
   }
 
-  window.addEventListener('load', function () {
-    if (!hasToken()) return;
-    var btn = document.createElement('button');
-    btn.textContent = 'Logout';
-    btn.style.position = 'fixed';
-    btn.style.top = '10px';
-    btn.style.right = '10px';
-    btn.style.zIndex = '9999';
-    btn.style.background = '#d11124';
-    btn.style.color = '#fff';
-    btn.style.border = 'none';
-    btn.style.padding = '8px 12px';
-    btn.style.borderRadius = '4px';
-    btn.style.cursor = 'pointer';
+  function insertButton() {
+    var container = document.querySelector(
+      ".swagger-ui aside, .swagger-ui nav"
+    );
+    if (!container || container.querySelector(".logout-btn")) return false;
+
+    var btn = document.createElement("button");
+    btn.textContent = "Logout";
+    btn.className = "logout-btn";
+    btn.style.display = "block";
+    btn.style.margin = "1rem";
+    btn.style.padding = "8px 12px";
+    btn.style.width = "calc(100% - 2rem)";
+    btn.style.background = "#d11124";
+    btn.style.color = "#fff";
+    btn.style.border = "none";
+    btn.style.borderRadius = "4px";
+    btn.style.cursor = "pointer";
     btn.onclick = async function () {
       try {
-        await fetch('/api/v1/usuarios/logout', {
-          method: 'POST',
-          credentials: 'include',
+        await fetch("/api/v1/usuarios/logout", {
+          method: "POST",
+          credentials: "include",
         });
       } catch (e) {
-        console.error('Erro ao fazer logout', e);
+        console.error("Erro ao fazer logout", e);
       }
-      document.cookie = 'token=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT';
-      window.location.href = '/docs/login';
+      document.cookie =
+        "token=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT";
+      window.location.href = "/docs/login";
     };
-    document.body.appendChild(btn);
+
+    container.appendChild(btn);
+    return true;
+  }
+
+  window.addEventListener("load", function () {
+    if (!hasToken()) return;
+
+    if (!insertButton()) {
+      var observer = new MutationObserver(function () {
+        if (insertButton()) observer.disconnect();
+      });
+      observer.observe(document.body, { childList: true, subtree: true });
+    }
   });
 })();
+

--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -16,15 +16,39 @@ const options: Options = {
     },
     tags: [
       {
+        name: "Default",
+        description: "Endpoints públicos da API",
+      },
+      {
         name: "Usuários",
         description:
           "Gerenciamento de contas e autenticação: registro, login, refresh, logout, perfil e recuperação de senha",
+      },
+      {
+        name: "Usuários - Admin",
+        description: "Gestão administrativa de usuários",
+      },
+      {
+        name: "Usuários - Pagamentos",
+        description: "Operações de pagamento do usuário",
+      },
+      {
+        name: "Usuários - Stats",
+        description: "Métricas e relatórios de usuários",
       },
       { name: "MercadoPago", description: "Integração de pagamentos" },
       { name: "Audit", description: "Registros de auditoria" },
       { name: "Brevo", description: "Serviços de e-mail" },
       { name: "Empresa", description: "Gestão de planos de empresa" },
       { name: "Website", description: "Conteúdo público do site" },
+      { name: "Website - Banner", description: "Gestão de banners" },
+      {
+        name: "Website - BusinessGroupInformation",
+        description: "Informações de grupos empresariais",
+      },
+      { name: "Website - LogoEnterprises", description: "Logos de empresas" },
+      { name: "Website - Slide", description: "Gestão de slides" },
+      { name: "Website - Sobre", description: "Conteúdos \"Sobre\"" },
     ],
     components: {
       schemas: {
@@ -197,6 +221,1502 @@ const options: Options = {
             message: { type: "string", example: "OK" },
           },
         },
+        ApiRootInfo: {
+          type: "object",
+          properties: {
+            message: { type: "string", example: "Advance+ API" },
+            version: { type: "string", example: "v3.0.3" },
+            timestamp: {
+              type: "string",
+              format: "date-time",
+              example: "2024-01-01T12:00:00Z",
+            },
+            environment: { type: "string", example: "development" },
+            status: { type: "string", example: "operational" },
+            express_version: { type: "string", example: "4.x" },
+            endpoints: {
+              type: "object",
+              additionalProperties: { type: "string" },
+              example: {
+                usuarios: "/api/v1/usuarios",
+                mercadopago: "/api/v1/mercadopago",
+                brevo: "/api/v1/brevo",
+                website: "/api/v1/website",
+                empresa: "/api/v1/empresa",
+                audit: "/api/v1/audit",
+                health: "/health",
+              },
+            },
+          },
+        },
+        GlobalHealthStatus: {
+          type: "object",
+          properties: {
+            status: { type: "string", example: "OK" },
+            uptime: { type: "number", example: 1 },
+            version: { type: "string", example: "v3.0.3" },
+            timestamp: {
+              type: "string",
+              format: "date-time",
+              example: "2024-01-01T12:00:00Z",
+            },
+          },
+        },
+        AuditModuleInfo: {
+          type: "object",
+          properties: {
+            message: { type: "string", example: "Audit Module API" },
+            version: { type: "string", example: "v1" },
+            timestamp: {
+              type: "string",
+              format: "date-time",
+              example: "2024-01-01T12:00:00Z",
+            },
+            endpoints: {
+              type: "object",
+              properties: {
+                logs: { type: "string", example: "/logs" },
+              },
+            },
+            status: { type: "string", example: "operational" },
+          },
+        },
+        AuditLog: {
+          type: "object",
+          properties: {
+            id: {
+              type: "string",
+              example: "b9e1d9b0-7c9f-4d1a-8f2a-1234567890ab",
+            },
+            usuarioId: {
+              type: "string",
+              example: "usuario-uuid",
+            },
+            empresaId: {
+              type: "string",
+              nullable: true,
+              example: "empresa-uuid",
+            },
+            acao: { type: "string", example: "CREATE_ORDER" },
+            detalhes: {
+              type: "object",
+              nullable: true,
+              example: { campo: "valor" },
+            },
+            criadoEm: {
+              type: "string",
+              format: "date-time",
+              example: "2024-01-01T12:00:00Z",
+            },
+          },
+        },
+        AuditLogsResponse: {
+          type: "object",
+          properties: {
+            logs: {
+              type: "array",
+              items: { $ref: "#/components/schemas/AuditLog" },
+            },
+          },
+        },
+        MercadoPagoOrderRequest: {
+          type: "object",
+          properties: {
+            total_amount: { type: "number", example: 100 },
+            items: {
+              type: "array",
+              items: {
+                type: "object",
+                properties: {
+                  id: { type: "string", example: "1" },
+                  title: { type: "string", example: "Produto" },
+                  quantity: { type: "integer", example: 1 },
+                  unit_price: { type: "number", example: 100 },
+                  currency_id: { type: "string", example: "BRL" },
+                },
+              },
+            },
+            payments: {
+              type: "array",
+              items: {
+                type: "object",
+                properties: {
+                  payment_method_id: { type: "string", example: "pix" },
+                  payment_type_id: {
+                    type: "string",
+                    example: "instant_payment",
+                  },
+                  payer: {
+                    type: "object",
+                    properties: {
+                      email: { type: "string", example: "user@example.com" },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        MercadoPagoOrderResponse: {
+          type: "object",
+          properties: {
+            message: {
+              type: "string",
+              example: "Order criada com sucesso",
+            },
+            order: {
+              type: "object",
+              properties: {
+                id: { type: "string", example: "123456" },
+                status: { type: "string", example: "approved" },
+                total_amount: { type: "number", example: 100 },
+              },
+            },
+          },
+        },
+        MercadoPagoRefundRequest: {
+          type: "object",
+          properties: {
+            amount: { type: "number", example: 100 },
+            reason: { type: "string", example: "Produto defeituoso" },
+          },
+        },
+        MercadoPagoRefundResponse: {
+          type: "object",
+          properties: {
+            message: {
+              type: "string",
+              example: "Reembolso processado com sucesso",
+            },
+            refund: {
+              type: "object",
+              properties: {
+                id: { type: "string", example: "r123" },
+                amount: { type: "number", example: 100 },
+              },
+            },
+          },
+        },
+        MercadoPagoSubscriptionRequest: {
+          type: "object",
+          properties: {
+            reason: { type: "string", example: "Plano Mensal" },
+            payer_email: {
+              type: "string",
+              example: "user@example.com",
+            },
+            auto_recurring: {
+              type: "object",
+              properties: {
+                frequency: { type: "integer", example: 1 },
+                frequency_type: { type: "string", example: "months" },
+                transaction_amount: { type: "number", example: 50 },
+                currency_id: { type: "string", example: "BRL" },
+              },
+            },
+          },
+        },
+        MercadoPagoSubscription: {
+          type: "object",
+          properties: {
+            id: { type: "string", example: "sub_123" },
+            status: { type: "string", example: "authorized" },
+            reason: { type: "string", example: "Plano Mensal" },
+          },
+        },
+        MercadoPagoSubscriptionResponse: {
+          type: "object",
+          properties: {
+            message: {
+              type: "string",
+              example: "Assinatura criada com sucesso",
+            },
+            subscription: { $ref: "#/components/schemas/MercadoPagoSubscription" },
+          },
+        },
+        MercadoPagoSubscriptionListResponse: {
+          type: "object",
+          properties: {
+            message: {
+              type: "string",
+              example: "Lista de assinaturas",
+            },
+            subscriptions: {
+              type: "array",
+              items: { $ref: "#/components/schemas/MercadoPagoSubscription" },
+            },
+          },
+        },
+        MercadoPagoWebhookNotification: {
+          type: "object",
+          properties: {
+            id: { type: "string", example: "123456789" },
+            type: { type: "string", example: "payment" },
+            action: { type: "string", example: "payment.created" },
+            data: {
+              type: "object",
+              properties: {
+                id: { type: "string", example: "999999" },
+              },
+            },
+          },
+        },
+        BrevoModuleInfo: {
+          type: "object",
+          properties: {
+            module: {
+              type: "string",
+              example: "Brevo Communication Module",
+            },
+            version: { type: "string", example: "7.3.0" },
+            description: {
+              type: "string",
+              example: "Sistema completo de comunicação e verificação de email",
+            },
+            status: { type: "string", example: "active" },
+            configured: { type: "boolean", example: true },
+            simulated: { type: "boolean", example: false },
+            timestamp: {
+              type: "string",
+              format: "date-time",
+              example: "2024-01-01T12:00:00Z",
+            },
+          },
+        },
+        BrevoHealthResponse: {
+          type: "object",
+          properties: {
+            status: { type: "string", example: "healthy" },
+            module: { type: "string", example: "brevo" },
+            configured: { type: "boolean", example: true },
+            simulated: { type: "boolean", example: false },
+            operational: { type: "boolean", example: true },
+            timestamp: {
+              type: "string",
+              format: "date-time",
+              example: "2024-01-01T12:00:00Z",
+            },
+            services: {
+              type: "object",
+              properties: {
+                email: { type: "string", example: "operational" },
+                sms: { type: "string", example: "operational" },
+                client: { type: "string", example: "operational" },
+              },
+            },
+          },
+        },
+        BrevoConfigStatus: {
+          type: "object",
+          properties: {
+            module: { type: "string", example: "Brevo Configuration Status" },
+            timestamp: {
+              type: "string",
+              format: "date-time",
+              example: "2024-01-01T12:00:00Z",
+            },
+            configuration: {
+              type: "object",
+              properties: {
+                isConfigured: { type: "boolean", example: true },
+                environment: { type: "string", example: "development" },
+                apiKeyProvided: { type: "boolean", example: true },
+                fromEmailConfigured: { type: "boolean", example: true },
+                fromName: { type: "string", example: "Advance+" },
+              },
+            },
+            emailVerification: {
+              type: "object",
+              properties: {
+                enabled: { type: "boolean", example: true },
+                tokenExpirationHours: { type: "integer", example: 24 },
+              },
+            },
+            client: {
+              type: "object",
+              properties: {
+                operational: { type: "boolean", example: true },
+                simulated: { type: "boolean", example: false },
+              },
+            },
+          },
+        },
+        BrevoVerifyEmailResponse: {
+          type: "object",
+          properties: {
+            success: { type: "boolean", example: true },
+            message: {
+              type: "string",
+              example: "Email verificado com sucesso",
+            },
+            redirectUrl: {
+              type: "string",
+              example: "https://app.advance.com.br",
+            },
+            userId: {
+              type: "string",
+              example: "b9e1d9b0-7c9f-4d1a-8f2a-1234567890ab",
+            },
+          },
+        },
+        BrevoResendVerificationRequest: {
+          type: "object",
+          required: ["email"],
+          properties: {
+            email: {
+              type: "string",
+              format: "email",
+              example: "user@example.com",
+            },
+          },
+        },
+        BrevoResendVerificationResponse: {
+          type: "object",
+          properties: {
+            success: { type: "boolean", example: true },
+            message: {
+              type: "string",
+              example: "Email de verificação reenviado com sucesso",
+            },
+            simulated: { type: "boolean", example: false },
+            messageId: { type: "string", example: "msg_123" },
+          },
+        },
+        BrevoVerificationStatusResponse: {
+          type: "object",
+          properties: {
+            success: { type: "boolean", example: true },
+            data: {
+              type: "object",
+              properties: {
+                userId: {
+                  type: "string",
+                  example: "b9e1d9b0-7c9f-4d1a-8f2a-1234567890ab",
+                },
+                email: { type: "string", example: "user@example.com" },
+                emailVerified: { type: "boolean", example: false },
+                accountStatus: { type: "string", example: "ATIVO" },
+                hasValidToken: { type: "boolean", example: true },
+                tokenExpiration: {
+                  type: "string",
+                  format: "date-time",
+                  example: "2024-01-01T12:00:00Z",
+                },
+              },
+            },
+          },
+        },
+        BrevoTestEmailRequest: {
+          type: "object",
+          required: ["email"],
+          properties: {
+            email: {
+              type: "string",
+              format: "email",
+              example: "user@example.com",
+            },
+            name: { type: "string", example: "Usuário Teste" },
+            type: { type: "string", example: "welcome" },
+          },
+        },
+        BrevoTestEmailResponse: {
+          type: "object",
+          properties: {
+            success: { type: "boolean", example: true },
+            message: {
+              type: "string",
+              example: "Teste de email welcome executado",
+            },
+            data: {
+              type: "object",
+              properties: {
+                type: { type: "string", example: "welcome" },
+                recipient: { type: "string", example: "user@example.com" },
+                simulated: { type: "boolean", example: false },
+                messageId: { type: "string", example: "msg_123" },
+              },
+            },
+            timestamp: {
+              type: "string",
+              format: "date-time",
+              example: "2024-01-01T12:00:00Z",
+            },
+          },
+        },
+        BrevoTestSMSRequest: {
+          type: "object",
+          required: ["to"],
+          properties: {
+            to: { type: "string", example: "+55 11 99999-9999" },
+            message: {
+              type: "string",
+              example: "Teste de SMS do Advance+ - Sistema funcionando!",
+            },
+          },
+        },
+        BrevoTestSMSResponse: {
+          type: "object",
+          properties: {
+            success: { type: "boolean", example: true },
+            message: { type: "string", example: "Teste de SMS executado" },
+            data: {
+              type: "object",
+              properties: {
+                recipient: {
+                  type: "string",
+                  example: "+55 11 99999-9999",
+                },
+                message: {
+                  type: "string",
+                  example: "Teste de SMS do Advance+ - Sistema funcionando!",
+                },
+                simulated: { type: "boolean", example: false },
+                messageId: { type: "string", example: "sms_123" },
+              },
+            },
+            timestamp: {
+              type: "string",
+              format: "date-time",
+              example: "2024-01-01T12:00:00Z",
+            },
+          },
+        },
+        EmpresaPlan: {
+          type: "object",
+          properties: {
+            id: { type: "string", example: "plan-uuid" },
+            nome: { type: "string", example: "Plano Básico" },
+            valor: { type: "number", example: 49.9 },
+            descricao: { type: "string", example: "Acesso básico" },
+            recursos: {
+              type: "array",
+              items: { type: "string" },
+              example: ["feature1", "feature2"],
+            },
+            ativo: { type: "boolean", example: true },
+            mercadoPagoPlanId: {
+              type: "string",
+              nullable: true,
+              example: "mp-plan-123",
+            },
+            frequency: { type: "integer", example: 1 },
+            frequencyType: {
+              type: "string",
+              enum: ["DIAS", "MESES"],
+              example: "MESES",
+            },
+            repetitions: { type: "integer", nullable: true, example: null },
+            criadoEm: {
+              type: "string",
+              format: "date-time",
+              example: "2024-01-01T12:00:00Z",
+            },
+            atualizadoEm: {
+              type: "string",
+              format: "date-time",
+              example: "2024-01-01T12:00:00Z",
+            },
+          },
+        },
+        EmpresaPlanCreateRequest: {
+          type: "object",
+          required: [
+            "nome",
+            "valor",
+            "descricao",
+            "recursos",
+            "frequency",
+            "frequencyType",
+          ],
+          properties: {
+            nome: { type: "string", example: "Plano Básico" },
+            valor: { type: "number", example: 49.9 },
+            descricao: { type: "string", example: "Acesso básico" },
+            recursos: {
+              type: "array",
+              items: { type: "string" },
+              example: ["feature1", "feature2"],
+            },
+            mercadoPagoPlanId: {
+              type: "string",
+              nullable: true,
+              example: "mp-plan-123",
+            },
+            frequency: { type: "integer", example: 1 },
+            frequencyType: {
+              type: "string",
+              enum: ["DIAS", "MESES"],
+              example: "MESES",
+            },
+            repetitions: { type: "integer", nullable: true, example: null },
+          },
+        },
+        EmpresaPlanUpdateRequest: {
+          type: "object",
+          properties: {
+            nome: { type: "string", example: "Plano Atualizado" },
+            valor: { type: "number", example: 59.9 },
+            descricao: { type: "string", example: "Descrição" },
+            recursos: {
+              type: "array",
+              items: { type: "string" },
+            },
+            ativo: { type: "boolean", example: true },
+            mercadoPagoPlanId: {
+              type: "string",
+              nullable: true,
+              example: "mp-plan-123",
+            },
+            frequency: { type: "integer", example: 1 },
+            frequencyType: {
+              type: "string",
+              enum: ["DIAS", "MESES"],
+              example: "MESES",
+            },
+            repetitions: { type: "integer", nullable: true, example: null },
+          },
+        },
+        EmpresaPlanCreateResponse: {
+          type: "object",
+          properties: {
+            message: { type: "string", example: "Plano criado" },
+            plan: { $ref: "#/components/schemas/EmpresaPlan" },
+          },
+        },
+        EmpresaPlanUpdateResponse: {
+          type: "object",
+          properties: {
+            message: { type: "string", example: "Plano atualizado" },
+            plan: { $ref: "#/components/schemas/EmpresaPlan" },
+          },
+        },
+        EmpresaPlansResponse: {
+          type: "object",
+          properties: {
+            plans: {
+              type: "array",
+              items: { $ref: "#/components/schemas/EmpresaPlan" },
+            },
+          },
+        },
+        EmpresaPlanAssignRequest: {
+          type: "object",
+          required: ["empresaId", "metodoPagamento"],
+          properties: {
+            empresaId: { type: "string", example: "empresa-uuid" },
+            metodoPagamento: {
+              type: "string",
+              enum: [
+                "PIX",
+                "BOLETO",
+                "CARTAO_CREDITO",
+                "CARTAO_DEBITO",
+                "DINHEIRO",
+              ],
+              example: "PIX",
+            },
+            tipo: {
+              type: "string",
+              enum: ["STANDARD", "PARTNER"],
+              example: "STANDARD",
+            },
+            validade: {
+              type: "string",
+              enum: [
+                "DIAS_15",
+                "DIAS_30",
+                "DIAS_90",
+                "DIAS_120",
+                "SEM_VALIDADE",
+              ],
+              nullable: true,
+              example: "DIAS_30",
+            },
+          },
+        },
+        EmpresaPlanAssignment: {
+          type: "object",
+          properties: {
+            id: { type: "string", example: "assignment-uuid" },
+            empresaId: { type: "string", example: "empresa-uuid" },
+            planoId: { type: "string", example: "plan-uuid" },
+            metodoPagamento: {
+              type: "string",
+              enum: [
+                "PIX",
+                "BOLETO",
+                "CARTAO_CREDITO",
+                "CARTAO_DEBITO",
+                "DINHEIRO",
+              ],
+              example: "PIX",
+            },
+            tipo: {
+              type: "string",
+              enum: ["STANDARD", "PARTNER"],
+              example: "STANDARD",
+            },
+            validade: {
+              type: "string",
+              enum: [
+                "DIAS_15",
+                "DIAS_30",
+                "DIAS_90",
+                "DIAS_120",
+                "SEM_VALIDADE",
+              ],
+              nullable: true,
+              example: "DIAS_30",
+            },
+            inicio: {
+              type: "string",
+              format: "date-time",
+              example: "2024-01-01T12:00:00Z",
+            },
+            fim: {
+              type: "string",
+              format: "date-time",
+              nullable: true,
+              example: "2024-02-01T12:00:00Z",
+            },
+            criadoEm: {
+              type: "string",
+              format: "date-time",
+              example: "2024-01-01T12:00:00Z",
+            },
+            atualizadoEm: {
+              type: "string",
+              format: "date-time",
+              example: "2024-01-01T12:00:00Z",
+            },
+          },
+        },
+        EmpresaPlanAssignResponse: {
+          type: "object",
+          properties: {
+            message: {
+              type: "string",
+              example: "Plano vinculado à empresa",
+            },
+            empresaPlano: {
+              $ref: "#/components/schemas/EmpresaPlanAssignment",
+            },
+          },
+        },
+        EmpresaPlanUnassignResponse: {
+          type: "object",
+          properties: {
+            message: {
+              type: "string",
+              example: "Plano desvinculado da empresa",
+            },
+          },
+        },
+        WebsiteModuleInfo: {
+          type: "object",
+          properties: {
+            message: { type: "string", example: "Website Module API" },
+            version: { type: "string", example: "v1" },
+            timestamp: {
+              type: "string",
+              format: "date-time",
+              example: "2024-01-01T12:00:00Z",
+            },
+            endpoints: {
+              type: "object",
+              properties: {
+                sobre: { type: "string", example: "/sobre" },
+                slide: { type: "string", example: "/slide" },
+                banner: { type: "string", example: "/banner" },
+                businessGroupInformation: {
+                  type: "string",
+                  example: "/business-group-information",
+                },
+                logoEnterprises: {
+                  type: "string",
+                  example: "/logo-enterprises",
+                },
+              },
+            },
+            status: { type: "string", example: "operational" },
+          },
+        },
+        WebsiteBanner: {
+          type: "object",
+          properties: {
+            id: { type: "string", example: "banner-uuid" },
+            imagemUrl: {
+              type: "string",
+              format: "uri",
+              example: "https://cdn.example.com/banner.jpg",
+            },
+            imagemTitulo: { type: "string", example: "banner" },
+            link: {
+              type: "string",
+              nullable: true,
+              example: "https://example.com",
+            },
+            ordem: { type: "integer", example: 1 },
+            criadoEm: {
+              type: "string",
+              format: "date-time",
+              example: "2024-01-01T12:00:00Z",
+            },
+            atualizadoEm: {
+              type: "string",
+              format: "date-time",
+              example: "2024-01-01T12:00:00Z",
+            },
+          },
+        },
+        WebsiteBannerCreateInput: {
+          type: "object",
+          properties: {
+            imagem: {
+              type: "string",
+              format: "binary",
+              description: "Arquivo de imagem do banner",
+            },
+            imagemUrl: {
+              type: "string",
+              format: "uri",
+              description: "URL alternativa da imagem",
+              example: "https://cdn.example.com/banner.jpg",
+            },
+            link: {
+              type: "string",
+              description: "Link de redirecionamento",
+              example: "https://example.com",
+            },
+            ordem: {
+              type: "integer",
+              description: "Ordem de exibição",
+              example: 1,
+            },
+          },
+        },
+        WebsiteBannerUpdateInput: {
+          type: "object",
+          properties: {
+            imagem: { type: "string", format: "binary" },
+            imagemUrl: {
+              type: "string",
+              format: "uri",
+              example: "https://cdn.example.com/banner.jpg",
+            },
+            link: { type: "string", example: "https://example.com" },
+            ordem: { type: "integer", example: 2 },
+          },
+        },
+        WebsiteBusinessGroupInformation: {
+          type: "object",
+          properties: {
+            id: { type: "string", example: "info-uuid" },
+            slug: { type: "string", example: "grupo-x" },
+            titulo: { type: "string", example: "Grupo X" },
+            descricao: { type: "string", example: "Descrição do grupo" },
+            botaoLabel: { type: "string", example: "Saiba mais" },
+            botaoUrl: {
+              type: "string",
+              example: "https://example.com/grupo-x",
+            },
+            imagemUrl: {
+              type: "string",
+              format: "uri",
+              example: "https://cdn.example.com/grupo.png",
+            },
+            imagemAlt: { type: "string", example: "Imagem do grupo" },
+            reverse: { type: "boolean", example: false },
+            ordem: { type: "integer", example: 1 },
+            ativo: { type: "boolean", example: true },
+            criadoEm: {
+              type: "string",
+              format: "date-time",
+              example: "2024-01-01T12:00:00Z",
+            },
+            atualizadoEm: {
+              type: "string",
+              format: "date-time",
+              example: "2024-01-01T12:00:00Z",
+            },
+          },
+        },
+        WebsiteBusinessGroupInformationCreateInput: {
+          type: "object",
+          required: ["slug", "titulo", "descricao", "botaoLabel", "botaoUrl"],
+          properties: {
+            slug: { type: "string", example: "grupo-x" },
+            titulo: { type: "string", example: "Grupo X" },
+            descricao: { type: "string", example: "Descrição do grupo" },
+            botaoLabel: { type: "string", example: "Saiba mais" },
+            botaoUrl: {
+              type: "string",
+              example: "https://example.com/grupo-x",
+            },
+            imagem: {
+              type: "string",
+              format: "binary",
+              description: "Arquivo de imagem",
+            },
+            imagemUrl: {
+              type: "string",
+              format: "uri",
+              description: "URL da imagem",
+              example: "https://cdn.example.com/grupo.png",
+            },
+            imagemAlt: { type: "string", example: "Imagem do grupo" },
+            reverse: { type: "boolean", example: false },
+            ordem: { type: "integer", example: 1 },
+            ativo: { type: "boolean", example: true },
+          },
+        },
+        WebsiteBusinessGroupInformationUpdateInput: {
+          type: "object",
+          properties: {
+            slug: { type: "string", example: "grupo-x" },
+            titulo: { type: "string", example: "Grupo X" },
+            descricao: { type: "string", example: "Descrição do grupo" },
+            botaoLabel: { type: "string", example: "Saiba mais" },
+            botaoUrl: {
+              type: "string",
+              example: "https://example.com/grupo-x",
+            },
+            imagem: { type: "string", format: "binary" },
+            imagemUrl: {
+              type: "string",
+              format: "uri",
+              example: "https://cdn.example.com/grupo.png",
+            },
+            imagemAlt: { type: "string", example: "Imagem do grupo" },
+            reverse: { type: "boolean", example: false },
+            ordem: { type: "integer", example: 2 },
+            ativo: { type: "boolean", example: true },
+          },
+        },
+        WebsiteLogoEnterprise: {
+          type: "object",
+          properties: {
+            id: { type: "string", example: "logo-uuid" },
+            nome: { type: "string", example: "Empresa X" },
+            imagemUrl: {
+              type: "string",
+              format: "uri",
+              example: "https://cdn.example.com/logo.png",
+            },
+            imagemAlt: { type: "string", example: "Logo da Empresa X" },
+            website: { type: "string", example: "https://empresa.com" },
+            categoria: { type: "string", example: "tecnologia" },
+            ordem: { type: "integer", example: 1 },
+            ativo: { type: "boolean", example: true },
+            criadoEm: {
+              type: "string",
+              format: "date-time",
+              example: "2024-01-01T12:00:00Z",
+            },
+            atualizadoEm: {
+              type: "string",
+              format: "date-time",
+              example: "2024-01-01T12:00:00Z",
+            },
+          },
+        },
+        WebsiteLogoEnterpriseCreateInput: {
+          type: "object",
+          required: ["nome", "website", "categoria"],
+          properties: {
+            nome: { type: "string", example: "Empresa X" },
+            website: { type: "string", example: "https://empresa.com" },
+            categoria: { type: "string", example: "tecnologia" },
+            ordem: { type: "integer", example: 1 },
+            ativo: { type: "boolean", example: true },
+            imagemAlt: { type: "string", example: "Logo da Empresa X" },
+            imagem: {
+              type: "string",
+              format: "binary",
+              description: "Arquivo de imagem do logo",
+            },
+            imagemUrl: {
+              type: "string",
+              format: "uri",
+              description: "URL alternativa da imagem",
+              example: "https://cdn.example.com/logo.png",
+            },
+          },
+        },
+        WebsiteLogoEnterpriseUpdateInput: {
+          type: "object",
+          properties: {
+            nome: { type: "string", example: "Empresa X" },
+            website: { type: "string", example: "https://empresa.com" },
+            categoria: { type: "string", example: "tecnologia" },
+            ordem: { type: "integer", example: 2 },
+            ativo: { type: "boolean", example: true },
+            imagemAlt: { type: "string", example: "Logo da Empresa X" },
+            imagem: { type: "string", format: "binary" },
+            imagemUrl: {
+              type: "string",
+              format: "uri",
+              example: "https://cdn.example.com/logo.png",
+            },
+          },
+        },
+        WebsiteSlide: {
+          type: "object",
+          properties: {
+            id: { type: "string", example: "slide-uuid" },
+            imagemUrl: {
+              type: "string",
+              format: "uri",
+              example: "https://cdn.example.com/slide.jpg",
+            },
+            imagemTitulo: { type: "string", example: "slide" },
+            link: { type: "string", nullable: true, example: "https://example.com" },
+            ordem: { type: "integer", example: 1 },
+            criadoEm: {
+              type: "string",
+              format: "date-time",
+              example: "2024-01-01T12:00:00Z",
+            },
+            atualizadoEm: {
+              type: "string",
+              format: "date-time",
+              example: "2024-01-01T12:00:00Z",
+            },
+          },
+        },
+        WebsiteSlideCreateInput: {
+          type: "object",
+          properties: {
+            imagem: {
+              type: "string",
+              format: "binary",
+              description: "Arquivo de imagem do slide",
+            },
+            imagemUrl: {
+              type: "string",
+              format: "uri",
+              description: "URL alternativa da imagem",
+              example: "https://cdn.example.com/slide.jpg",
+            },
+            link: { type: "string", example: "https://example.com" },
+            ordem: { type: "integer", example: 1 },
+          },
+        },
+        WebsiteSlideUpdateInput: {
+          type: "object",
+          properties: {
+            imagem: { type: "string", format: "binary" },
+            imagemUrl: {
+              type: "string",
+              format: "uri",
+              example: "https://cdn.example.com/slide.jpg",
+            },
+            link: { type: "string", example: "https://example.com" },
+            ordem: { type: "integer", example: 2 },
+          },
+        },
+        WebsiteSobre: {
+          type: "object",
+          properties: {
+            id: { type: "string", example: "sobre-uuid" },
+            imagemUrl: {
+              type: "string",
+              format: "uri",
+              example: "https://cdn.example.com/sobre.jpg",
+            },
+            imagemTitulo: { type: "string", example: "sobre" },
+            titulo: { type: "string", example: "Quem somos" },
+            descricao: {
+              type: "string",
+              example: "Descrição sobre a empresa",
+            },
+            criadoEm: {
+              type: "string",
+              format: "date-time",
+              example: "2024-01-01T12:00:00Z",
+            },
+            atualizadoEm: {
+              type: "string",
+              format: "date-time",
+              example: "2024-01-01T12:00:00Z",
+            },
+          },
+        },
+        WebsiteSobreCreateInput: {
+          type: "object",
+          required: ["titulo", "descricao"],
+          properties: {
+            titulo: { type: "string", example: "Quem somos" },
+            descricao: {
+              type: "string",
+              example: "Descrição sobre a empresa",
+            },
+            imagem: {
+              type: "string",
+              format: "binary",
+              description: "Arquivo de imagem do conteúdo",
+            },
+            imagemUrl: {
+              type: "string",
+              format: "uri",
+              description: "URL alternativa da imagem",
+              example: "https://cdn.example.com/sobre.jpg",
+            },
+          },
+        },
+        WebsiteSobreUpdateInput: {
+          type: "object",
+          properties: {
+            titulo: { type: "string", example: "Quem somos" },
+            descricao: {
+              type: "string",
+              example: "Descrição atualizada",
+            },
+            imagem: { type: "string", format: "binary" },
+            imagemUrl: {
+              type: "string",
+              format: "uri",
+              example: "https://cdn.example.com/sobre.jpg",
+            },
+          },
+        },
+        AdminModuleInfo: {
+          type: "object",
+          properties: {
+            message: { type: "string", example: "Área administrativa" },
+            usuario: { $ref: "#/components/schemas/UserProfile" },
+            timestamp: {
+              type: "string",
+              format: "date-time",
+              example: "2024-01-01T12:00:00Z",
+            },
+            permissions: {
+              type: "array",
+              items: { type: "string" },
+              example: ["read", "write"],
+            },
+          },
+        },
+        AdminUserSummary: {
+          type: "object",
+          properties: {
+            id: { type: "string", example: "user-uuid" },
+            email: { type: "string", example: "user@example.com" },
+            nomeCompleto: { type: "string", example: "João da Silva" },
+            role: { type: "string", example: "ALUNO" },
+            status: { type: "string", example: "ATIVO" },
+            tipoUsuario: { type: "string", example: "ALUNO" },
+            criadoEm: {
+              type: "string",
+              format: "date-time",
+              example: "2024-01-01T12:00:00Z",
+            },
+            ultimoLogin: {
+              type: "string",
+              format: "date-time",
+              example: "2024-01-10T12:00:00Z",
+            },
+            _count: {
+              type: "object",
+              properties: {
+                mercadoPagoOrders: { type: "integer", example: 3 },
+                mercadoPagoSubscriptions: { type: "integer", example: 1 },
+              },
+            },
+          },
+        },
+        AdminUserListResponse: {
+          type: "object",
+          properties: {
+            message: { type: "string", example: "Lista de usuários" },
+            usuarios: {
+              type: "array",
+              items: { $ref: "#/components/schemas/AdminUserSummary" },
+            },
+            pagination: {
+              type: "object",
+              properties: {
+                page: { type: "integer", example: 1 },
+                limit: { type: "integer", example: 50 },
+                total: { type: "integer", example: 100 },
+                pages: { type: "integer", example: 2 },
+              },
+            },
+          },
+        },
+        AdminUserDetail: {
+          allOf: [
+            { $ref: "#/components/schemas/AdminUserSummary" },
+            {
+              type: "object",
+              properties: {
+                cpf: { type: "string", example: "12345678900" },
+                cnpj: { type: "string", example: "12345678000199" },
+                telefone: { type: "string", example: "+55 11 99999-0000" },
+                dataNasc: {
+                  type: "string",
+                  format: "date",
+                  example: "1990-01-01",
+                },
+                genero: { type: "string", example: "MASCULINO" },
+                matricula: { type: "string", example: "MAT123" },
+                supabaseId: { type: "string", example: "uuid-supabase" },
+                empresa: {
+                  type: "object",
+                  properties: {
+                    id: { type: "string", example: "emp-1" },
+                    nome: { type: "string", example: "Empresa XYZ" },
+                  },
+                },
+                enderecos: {
+                  type: "array",
+                  items: {
+                    type: "object",
+                    properties: {
+                      id: { type: "string", example: "end-1" },
+                      logradouro: { type: "string", example: "Rua A" },
+                      numero: { type: "string", example: "100" },
+                      bairro: { type: "string", example: "Centro" },
+                      cidade: { type: "string", example: "São Paulo" },
+                      estado: { type: "string", example: "SP" },
+                      cep: { type: "string", example: "01000-000" },
+                    },
+                  },
+                },
+                mercadoPagoOrders: {
+                  type: "array",
+                  items: {
+                    type: "object",
+                    properties: {
+                      id: { type: "string", example: "order-1" },
+                      mercadoPagoOrderId: {
+                        type: "string",
+                        example: "123456",
+                      },
+                      status: { type: "string", example: "paid" },
+                      totalAmount: { type: "number", example: 100 },
+                      paidAmount: { type: "number", example: 100 },
+                      criadoEm: {
+                        type: "string",
+                        format: "date-time",
+                        example: "2024-01-01T12:00:00Z",
+                      },
+                    },
+                  },
+                },
+                mercadoPagoSubscriptions: {
+                  type: "array",
+                  items: {
+                    type: "object",
+                    properties: {
+                      id: { type: "string", example: "sub-1" },
+                      mercadoPagoSubscriptionId: {
+                        type: "string",
+                        example: "7890",
+                      },
+                      status: { type: "string", example: "authorized" },
+                      reason: { type: "string", example: "Plano premium" },
+                      transactionAmount: { type: "number", example: 99.9 },
+                      criadoEm: {
+                        type: "string",
+                        format: "date-time",
+                        example: "2024-01-01T12:00:00Z",
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          ],
+        },
+        AdminUserDetailResponse: {
+          type: "object",
+          properties: {
+            message: { type: "string", example: "Usuário encontrado" },
+            usuario: { $ref: "#/components/schemas/AdminUserDetail" },
+          },
+        },
+        AdminPaymentHistoryResponse: {
+          type: "object",
+          properties: {
+            message: {
+              type: "string",
+              example: "Histórico de pagamentos do usuário",
+            },
+            data: {
+              type: "object",
+              properties: {
+                orders: {
+                  type: "array",
+                  items: {
+                    type: "object",
+                    properties: {
+                      id: { type: "string", example: "order-1" },
+                      status: { type: "string", example: "paid" },
+                      totalAmount: { type: "number", example: 100 },
+                      paidAmount: { type: "number", example: 100 },
+                      criadoEm: {
+                        type: "string",
+                        format: "date-time",
+                        example: "2024-01-01T12:00:00Z",
+                      },
+                    },
+                  },
+                },
+                subscriptions: {
+                  type: "array",
+                  items: {
+                    type: "object",
+                    properties: {
+                      id: { type: "string", example: "sub-1" },
+                      status: { type: "string", example: "authorized" },
+                      reason: { type: "string", example: "Plano premium" },
+                      transactionAmount: { type: "number", example: 99.9 },
+                      criadoEm: {
+                        type: "string",
+                        format: "date-time",
+                        example: "2024-01-01T12:00:00Z",
+                      },
+                    },
+                  },
+                },
+                refunds: {
+                  type: "array",
+                  items: {
+                    type: "object",
+                    properties: {
+                      id: { type: "string", example: "ref-1" },
+                      amount: { type: "number", example: 10 },
+                      status: { type: "string", example: "refunded" },
+                      reason: { type: "string", example: "Produto" },
+                      criadoEm: {
+                        type: "string",
+                        format: "date-time",
+                        example: "2024-01-01T12:00:00Z",
+                      },
+                    },
+                  },
+                },
+                summary: {
+                  type: "object",
+                  properties: {
+                    totalOrders: { type: "integer", example: 5 },
+                    totalSubscriptions: { type: "integer", example: 1 },
+                    totalRefunds: { type: "integer", example: 0 },
+                    totalPaid: { type: "number", example: 500 },
+                    totalRefunded: { type: "number", example: 0 },
+                  },
+                },
+                pagination: {
+                  type: "object",
+                  properties: {
+                    page: { type: "integer", example: 1 },
+                    limit: { type: "integer", example: 20 },
+                    total: { type: "integer", example: 20 },
+                    pages: { type: "integer", example: 1 },
+                  },
+                },
+              },
+            },
+          },
+        },
+        AdminStatusUpdateRequest: {
+          type: "object",
+          properties: {
+            status: { type: "string", example: "ATIVO" },
+            motivo: { type: "string", example: "Regularização" },
+          },
+          required: ["status"],
+        },
+        AdminStatusUpdateResponse: {
+          type: "object",
+          properties: {
+            message: {
+              type: "string",
+              example: "Status do usuário atualizado com sucesso",
+            },
+            usuario: { $ref: "#/components/schemas/AdminUserSummary" },
+            statusAnterior: { type: "string", example: "SUSPENSO" },
+          },
+        },
+        AdminRoleUpdateRequest: {
+          type: "object",
+          properties: {
+            role: { type: "string", example: "MODERADOR" },
+            motivo: { type: "string", example: "Promoção" },
+          },
+          required: ["role"],
+        },
+        AdminRoleUpdateResponse: {
+          type: "object",
+          properties: {
+            message: {
+              type: "string",
+              example: "Role do usuário atualizada com sucesso",
+            },
+            usuario: { $ref: "#/components/schemas/AdminUserSummary" },
+          },
+        },
+        UserCoursePaymentRequest: {
+          type: "object",
+          properties: {
+            cursoId: { type: "string", example: "curso-uuid" },
+            paymentToken: { type: "string", example: "tok_123" },
+            paymentMethodId: { type: "string", example: "visa" },
+            installments: { type: "integer", example: 1 },
+            issuerId: { type: "string", example: "issuer" },
+          },
+          required: ["cursoId", "paymentToken", "paymentMethodId"],
+        },
+        UserCoursePaymentResponse: {
+          type: "object",
+          properties: {
+            message: {
+              type: "string",
+              example: "Pagamento iniciado com sucesso",
+            },
+            order: {
+              type: "object",
+              properties: {
+                id: { type: "string", example: "123" },
+                status: { type: "string", example: "pending" },
+              },
+            },
+            curso: {
+              type: "object",
+              properties: {
+                id: { type: "string", example: "curso-uuid" },
+                titulo: { type: "string", example: "Curso X" },
+                preco: { type: "number", example: 100 },
+              },
+            },
+          },
+        },
+        UserSubscriptionCreateRequest: {
+          type: "object",
+          properties: {
+            plano: { type: "string", example: "plano-premium" },
+            cardToken: { type: "string", example: "tok_123" },
+            frequencia: { type: "integer", example: 1 },
+            periodo: { type: "string", example: "months" },
+          },
+          required: ["plano", "cardToken"],
+        },
+        UserSubscriptionCreateResponse: {
+          type: "object",
+          properties: {
+            message: { type: "string", example: "Assinatura criada" },
+            subscription: {
+              type: "object",
+              properties: {
+                id: { type: "string", example: "sub-123" },
+                status: { type: "string", example: "authorized" },
+              },
+            },
+          },
+        },
+        UserSubscriptionCancelRequest: {
+          type: "object",
+          properties: {
+            subscriptionId: { type: "string", example: "sub-123" },
+            motivo: { type: "string", example: "Opção do usuário" },
+          },
+          required: ["subscriptionId"],
+        },
+        UserSubscriptionCancelResponse: {
+          type: "object",
+          properties: {
+            message: { type: "string", example: "Assinatura cancelada" },
+          },
+        },
+        UserPaymentHistoryResponse: {
+          type: "object",
+          properties: {
+            message: { type: "string", example: "Histórico de pagamentos" },
+            orders: {
+              type: "array",
+              items: {
+                type: "object",
+                properties: {
+                  id: { type: "string", example: "order-1" },
+                  status: { type: "string", example: "paid" },
+                  totalAmount: { type: "number", example: 100 },
+                  criadoEm: {
+                    type: "string",
+                    format: "date-time",
+                    example: "2024-01-01T12:00:00Z",
+                  },
+                },
+              },
+            },
+            subscriptions: {
+              type: "array",
+              items: {
+                type: "object",
+                properties: {
+                  id: { type: "string", example: "sub-1" },
+                  status: { type: "string", example: "authorized" },
+                  transactionAmount: { type: "number", example: 99.9 },
+                  criadoEm: {
+                    type: "string",
+                    format: "date-time",
+                    example: "2024-01-01T12:00:00Z",
+                  },
+                },
+              },
+            },
+          },
+        },
+        DashboardStatsResponse: {
+          type: "object",
+          properties: {
+            message: { type: "string", example: "Estatísticas do dashboard" },
+            stats: {
+              type: "object",
+              additionalProperties: true,
+              example: { usuariosTotais: 100, receitaTotal: 1000 },
+            },
+            timestamp: {
+              type: "string",
+              format: "date-time",
+              example: "2024-01-01T12:00:00Z",
+            },
+          },
+        },
+        UserStatsResponse: {
+          type: "object",
+          properties: {
+            message: { type: "string", example: "Estatísticas de usuários" },
+            stats: {
+              type: "object",
+              additionalProperties: true,
+              example: { novosUsuarios: 10 },
+            },
+            periodo: { type: "string", example: "30d" },
+            timestamp: {
+              type: "string",
+              format: "date-time",
+              example: "2024-01-01T12:00:00Z",
+            },
+          },
+        },
+        PaymentStatsResponse: {
+          type: "object",
+          properties: {
+            message: { type: "string", example: "Estatísticas de pagamentos" },
+            stats: {
+              type: "object",
+              additionalProperties: true,
+              example: { totalPagamentos: 100, totalReceita: 5000 },
+            },
+            periodo: { type: "string", example: "30d" },
+            timestamp: {
+              type: "string",
+              format: "date-time",
+              example: "2024-01-01T12:00:00Z",
+            },
+          },
+        },
       },
       responses: {},
       parameters: {},
@@ -253,6 +1773,7 @@ export function setupSwagger(app: Application): void {
       if (req.path === "/login") return next();
       return swaggerUi.setup(swaggerSpec, {
         customJs: "/swagger-custom.js",
+        layout: "BaseLayout",
       })(req, res, next);
     }) as RequestHandler
   );

--- a/src/modules/audit/routes/index.ts
+++ b/src/modules/audit/routes/index.ts
@@ -12,6 +12,10 @@ const router = Router();
  *     responses:
  *       200:
  *         description: Detalhes do módulo
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/AuditModuleInfo'
  *     x-codeSamples:
  *       - lang: cURL
  *         label: Exemplo

--- a/src/modules/audit/routes/logs.ts
+++ b/src/modules/audit/routes/logs.ts
@@ -14,14 +14,36 @@ const controller = new AuditController();
  *     tags: [Audit]
  *     security:
  *       - bearerAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: empresaId
+ *         schema:
+ *           type: string
+ *         description: Filtrar logs por ID da empresa
  *     responses:
  *       200:
  *         description: Lista de logs
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/AuditLogsResponse'
+ *       400:
+ *         description: Erro ao buscar logs
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
  *     x-codeSamples:
  *       - lang: cURL
  *         label: Exemplo
  *         source: |
- *           curl -X GET "http://localhost:3000/api/v1/audit/logs" \\
+ *           curl -X GET "http://localhost:3000/api/v1/audit/logs?empresaId={empresaId}" \\
  *            -H "Authorization: Bearer <TOKEN>"
  */
 router.get("/", authMiddlewareWithDB([Role.ADMIN]), controller.getLogs);

--- a/src/modules/brevo/routes/index.ts
+++ b/src/modules/brevo/routes/index.ts
@@ -18,6 +18,10 @@ const emailVerificationController = new EmailVerificationController();
  *     responses:
  *       200:
  *         description: Detalhes do módulo
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: "#/components/schemas/BrevoModuleInfo"
  *     x-codeSamples:
  *       - lang: cURL
  *         label: Exemplo
@@ -35,6 +39,16 @@ router.get("/", brevoController.getModuleInfo);
  *     responses:
  *       200:
  *         description: Status de saúde
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: "#/components/schemas/BrevoHealthResponse"
+ *       503:
+ *         description: Serviço indisponível
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: "#/components/schemas/BrevoHealthResponse"
  *     x-codeSamples:
  *       - lang: cURL
  *         label: Exemplo
@@ -53,6 +67,16 @@ router.get("/health", brevoController.healthCheck);
  *     responses:
  *       200:
  *         description: Configurações do Brevo
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: "#/components/schemas/BrevoConfigStatus"
+ *       403:
+ *         description: Acesso negado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: "#/components/schemas/ErrorResponse"
  *     x-codeSamples:
  *       - lang: cURL
  *         label: Exemplo
@@ -76,9 +100,20 @@ router.get(
  *         name: token
  *         schema:
  *           type: string
+ *         required: true
  *     responses:
  *       200:
  *         description: Email verificado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: "#/components/schemas/BrevoVerifyEmailResponse"
+ *       400:
+ *         description: Token inválido ou ausente
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: "#/components/schemas/ErrorResponse"
  *     x-codeSamples:
  *       - lang: cURL
  *         label: Exemplo
@@ -92,9 +127,31 @@ router.get("/verificar-email", emailVerificationController.verifyEmail);
  *   post:
  *     summary: Reenviar email de verificação
  *     tags: [Brevo]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: "#/components/schemas/BrevoResendVerificationRequest"
  *     responses:
  *       200:
  *         description: Email reenviado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: "#/components/schemas/BrevoResendVerificationResponse"
+ *       400:
+ *         description: Requisição inválida
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: "#/components/schemas/ErrorResponse"
+ *       404:
+ *         description: Usuário não encontrado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: "#/components/schemas/ErrorResponse"
  *     x-codeSamples:
  *       - lang: cURL
  *         label: Exemplo
@@ -118,16 +175,31 @@ router.get(
  *   get:
  *     summary: Consultar status de verificação de email
  *     tags: [Brevo]
-  *     parameters:
-  *       - in: path
-  *         name: userId
-  *         required: true
-  *         schema:
-  *           type: string
-  *     responses:
-  *       200:
-  *         description: Status retornado
- */
+ *     parameters:
+ *       - in: path
+ *         name: userId
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Status retornado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: "#/components/schemas/BrevoVerificationStatusResponse"
+ *       404:
+ *         description: Usuário não encontrado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: "#/components/schemas/ErrorResponse"
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X GET "http://localhost:3000/api/v1/brevo/status-verificacao/USER_ID"
+*/
 
 router.get(
   "/status/:email",
@@ -207,7 +279,23 @@ router.get(
  *     responses:
  *       200:
  *         description: Status do usuário
- */
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: "#/components/schemas/BrevoVerificationStatusResponse"
+ *       404:
+ *         description: Usuário não encontrado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: "#/components/schemas/ErrorResponse"
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X GET "http://localhost:3000/api/v1/brevo/status/user%40example.com" \\
+ *            -H "Authorization: Bearer <TOKEN>"
+*/
 
 router.post(
   "/test/email",
@@ -223,10 +311,40 @@ router.post(
  *     tags: [Brevo]
  *     security:
  *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: "#/components/schemas/BrevoTestEmailRequest"
  *     responses:
  *       200:
  *         description: Email enviado
- */
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: "#/components/schemas/BrevoTestEmailResponse"
+ *       400:
+ *         description: Requisição inválida
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: "#/components/schemas/ErrorResponse"
+ *       403:
+ *         description: Bloqueado em produção
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: "#/components/schemas/ErrorResponse"
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X POST "http://localhost:3000/api/v1/brevo/test/email" \\
+ *            -H "Authorization: Bearer <TOKEN>" \\
+ *            -H "Content-Type: application/json" \\
+ *            -d '{"email":"user@example.com"}'
+*/
 router.post(
   "/test/sms",
   supabaseAuthMiddleware(["ADMIN", "MODERADOR"]),
@@ -241,10 +359,40 @@ router.post(
  *     tags: [Brevo]
  *     security:
  *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: "#/components/schemas/BrevoTestSMSRequest"
  *     responses:
  *       200:
  *         description: SMS enviado
- */
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: "#/components/schemas/BrevoTestSMSResponse"
+ *       400:
+ *         description: Requisição inválida
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: "#/components/schemas/ErrorResponse"
+ *       403:
+ *         description: Bloqueado em produção
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: "#/components/schemas/ErrorResponse"
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X POST "http://localhost:3000/api/v1/brevo/test/sms" \\
+ *            -H "Authorization: Bearer <TOKEN>" \\
+ *            -H "Content-Type: application/json" \\
+ *            -d '{"to":"+5511999999999"}'
+*/
 router.get("/verificar", emailVerificationController.verifyEmail);
 router.post("/reenviar", emailVerificationController.resendVerification);
 
@@ -257,18 +405,63 @@ router.post("/reenviar", emailVerificationController.resendVerification);
  *     parameters:
  *       - in: query
  *         name: token
+ *         required: true
  *         schema:
  *           type: string
  *     responses:
  *       200:
  *         description: Email verificado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: "#/components/schemas/BrevoVerifyEmailResponse"
+ *       400:
+ *         description: Token inválido ou ausente
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: "#/components/schemas/ErrorResponse"
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X GET "http://localhost:3000/api/v1/brevo/verificar?token=TOKEN"
  * /api/v1/brevo/reenviar:
  *   post:
  *     summary: Reenviar verificação (alias)
  *     tags: [Brevo]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: "#/components/schemas/BrevoResendVerificationRequest"
  *     responses:
  *       200:
  *         description: Reenvio realizado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: "#/components/schemas/BrevoResendVerificationResponse"
+ *       400:
+ *         description: Requisição inválida
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: "#/components/schemas/ErrorResponse"
+ *       404:
+ *         description: Usuário não encontrado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: "#/components/schemas/ErrorResponse"
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X POST "http://localhost:3000/api/v1/brevo/reenviar" \\
+ *            -H "Content-Type: application/json" \\
+ *            -d '{"email":"user@example.com"}'
  */
 
 router.use((err: any, req: any, res: any, next: any) => {

--- a/src/modules/empresa/routes/index.ts
+++ b/src/modules/empresa/routes/index.ts
@@ -12,12 +12,16 @@ const router = Router();
  *     responses:
  *       200:
  *         description: Detalhes do módulo
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/BasicMessage'
  *     x-codeSamples:
  *       - lang: cURL
  *         label: Exemplo
  *         source: |
  *           curl -X GET "http://localhost:3000/api/v1/empresa"
- */
+*/
 router.get("/", (req, res) => {
   res.json({
     message: "Empresa Module API",

--- a/src/modules/empresa/routes/plans.ts
+++ b/src/modules/empresa/routes/plans.ts
@@ -19,20 +19,26 @@ const controller = new PlanController();
  *       content:
  *         application/json:
  *           schema:
- *             type: object
- *             properties:
- *               nome: { type: string, example: "Plano Básico" }
- *               valor: { type: number, example: 49.9 }
- *               descricao: { type: string, example: "Acesso básico" }
- *               recursos:
- *                 type: array
- *                 items: { type: string }
- *               frequency: { type: number, example: 1 }
- *               frequencyType: { type: string, example: "months" }
- *               repetitions: { type: integer, nullable: true }
+ *             $ref: '#/components/schemas/EmpresaPlanCreateRequest'
  *     responses:
  *       201:
  *         description: Plano criado com sucesso
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/EmpresaPlanCreateResponse'
+ *       400:
+ *         description: Erro ao criar plano
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
  *     x-codeSamples:
  *       - lang: cURL
  *         label: Exemplo
@@ -40,8 +46,8 @@ const controller = new PlanController();
  *           curl -X POST "http://localhost:3000/api/v1/empresa/plans" \\
  *            -H "Authorization: Bearer <TOKEN>" \\
  *            -H "Content-Type: application/json" \\
- *            -d '{"nome":"Plano Básico","valor":49.9,"descricao":"Acesso básico","recursos":["feature"],"frequency":1,"frequencyType":"months"}'
- */
+ *            -d '{"nome":"Plano Básico","valor":49.9,"descricao":"Acesso básico","recursos":["feature"],"frequency":1,"frequencyType":"MESES"}'
+*/
 router.post("/", authMiddlewareWithDB([Role.ADMIN]), controller.createPlan);
 
 /**
@@ -53,6 +59,22 @@ router.post("/", authMiddlewareWithDB([Role.ADMIN]), controller.createPlan);
  *     responses:
  *       200:
  *         description: Lista de planos
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/EmpresaPlansResponse'
+ *       400:
+ *         description: Erro ao buscar planos
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
  *     x-codeSamples:
  *       - lang: cURL
  *         label: Exemplo
@@ -75,20 +97,32 @@ router.get("/", controller.getPlans);
  *         required: true
  *         schema:
  *           type: string
+ *         description: ID do plano
  *     requestBody:
  *       required: true
  *       content:
  *         application/json:
  *           schema:
- *             type: object
- *             properties:
- *               nome: { type: string, example: "Plano Atualizado" }
- *               valor: { type: number, example: 59.9 }
- *               descricao: { type: string, example: "Descrição" }
- *               ativo: { type: boolean, example: true }
+ *             $ref: '#/components/schemas/EmpresaPlanUpdateRequest'
  *     responses:
  *       200:
  *         description: Plano atualizado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/EmpresaPlanUpdateResponse'
+ *       400:
+ *         description: Erro ao atualizar plano
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
  *     x-codeSamples:
  *       - lang: cURL
  *         label: Exemplo
@@ -118,20 +152,32 @@ router.put(
  *         required: true
  *         schema:
  *           type: string
+ *         description: ID do plano
  *     requestBody:
  *       required: true
  *       content:
  *         application/json:
  *           schema:
- *             type: object
- *             properties:
- *               empresaId: { type: string, example: "empresa-uuid" }
- *               metodoPagamento: { type: string, example: "CREDIT" }
- *               tipo: { type: string, example: "STANDARD" }
- *               validade: { type: string, example: "DIAS_30" }
+ *             $ref: '#/components/schemas/EmpresaPlanAssignRequest'
  *     responses:
  *       200:
  *         description: Plano atribuído
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/EmpresaPlanAssignResponse'
+ *       400:
+ *         description: Erro ao atribuir plano
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
  *     x-codeSamples:
  *       - lang: cURL
  *         label: Exemplo
@@ -139,8 +185,8 @@ router.put(
  *           curl -X POST "http://localhost:3000/api/v1/empresa/plans/{planId}/assign" \\
  *            -H "Authorization: Bearer <TOKEN>" \\
  *            -H "Content-Type: application/json" \\
- *            -d '{"empresaId":"empresa-uuid","metodoPagamento":"CREDIT"}'
- */
+ *            -d '{"empresaId":"empresa-uuid","metodoPagamento":"PIX","tipo":"STANDARD","validade":"DIAS_30"}'
+*/
 router.post(
   "/:planId/assign",
   authMiddlewareWithDB([Role.ADMIN]),
@@ -161,9 +207,26 @@ router.post(
  *         required: true
  *         schema:
  *           type: string
+ *         description: ID da empresa
  *     responses:
  *       200:
  *         description: Plano removido
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/EmpresaPlanUnassignResponse'
+ *       400:
+ *         description: Erro ao remover plano
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
  *     x-codeSamples:
  *       - lang: cURL
  *         label: Exemplo

--- a/src/modules/mercadopago/routes/config.ts
+++ b/src/modules/mercadopago/routes/config.ts
@@ -25,6 +25,15 @@ const configController = new ConfigController();
  *     responses:
  *       200:
  *         description: Detalhes das rotas de configuração
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/BasicMessage'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X GET "http://localhost:3000/api/v1/mercadopago/config"
  */
 router.get("/", (req, res) => {
   res.json({
@@ -51,6 +60,19 @@ router.get("/", (req, res) => {
  *     responses:
  *       200:
  *         description: Chave pública retornada
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 publicKey:
+ *                   type: string
+ *                   example: "APP_USR-xxx"
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X GET "http://localhost:3000/api/v1/mercadopago/config/public-key"
  */
 router.get("/public-key", configController.getPublicKey);
 
@@ -67,6 +89,20 @@ router.get("/public-key", configController.getPublicKey);
  *     responses:
  *       200:
  *         description: Métodos de pagamento
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 type: object
+ *                 properties:
+ *                   id: { type: string, example: "pix" }
+ *                   name: { type: string, example: "Pix" }
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X GET "http://localhost:3000/api/v1/mercadopago/config/payment-methods"
  */
 router.get("/payment-methods", configController.getPaymentMethods);
 
@@ -90,6 +126,16 @@ router.get(
  *     responses:
  *       200:
  *         description: Informações da conta
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X GET "http://localhost:3000/api/v1/mercadopago/config/account-info" \\
+ *            -H "Authorization: Bearer <TOKEN>"
  */
 
 /**
@@ -112,6 +158,16 @@ router.get(
  *     responses:
  *       200:
  *         description: Conexão bem-sucedida
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/BasicMessage'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X GET "http://localhost:3000/api/v1/mercadopago/config/test-connection" \\
+ *            -H "Authorization: Bearer <TOKEN>"
  */
 
 export { router as configRoutes };

--- a/src/modules/mercadopago/routes/index.ts
+++ b/src/modules/mercadopago/routes/index.ts
@@ -26,6 +26,15 @@ const router = Router();
  *     responses:
  *       200:
  *         description: Detalhes do módulo
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/BasicMessage'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X GET "http://localhost:3000/api/v1/mercadopago"
  */
 router.get("/", (req, res) => {
   res.json({
@@ -55,6 +64,15 @@ router.get("/", (req, res) => {
  *     responses:
  *       200:
  *         description: Status de saúde
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/BasicMessage'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X GET "http://localhost:3000/api/v1/mercadopago/health"
  */
 router.get("/health", (req, res) => {
   res.json({

--- a/src/modules/mercadopago/routes/orders.ts
+++ b/src/modules/mercadopago/routes/orders.ts
@@ -60,35 +60,20 @@ router.get("/", (req, res) => {
  *       content:
  *         application/json:
  *           schema:
- *             type: object
- *             properties:
- *               total_amount:
- *                 type: number
- *                 example: 100
- *               items:
- *                 type: array
- *                 items:
- *                   type: object
- *                   properties:
- *                     id: { type: string, example: "1" }
- *                     title: { type: string, example: "Produto" }
- *                     quantity: { type: integer, example: 1 }
- *                     unit_price: { type: number, example: 100 }
- *                     currency_id: { type: string, example: "BRL" }
- *               payments:
- *                 type: array
- *                 items:
- *                   type: object
- *                   properties:
- *                     payment_method_id: { type: string, example: "pix" }
- *                     payment_type_id: { type: string, example: "instant_payment" }
- *                     payer:
- *                       type: object
- *                       properties:
- *                         email: { type: string, example: "user@example.com" }
+ *             $ref: '#/components/schemas/MercadoPagoOrderRequest'
  *     responses:
  *       201:
  *         description: Order criada
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/MercadoPagoOrderResponse'
+ *       400:
+ *         description: Erro de validação
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
  *     x-codeSamples:
  *       - lang: cURL
  *         label: Exemplo
@@ -121,6 +106,16 @@ router.post("/", supabaseAuthMiddleware(), ordersController.createOrder);
  *     responses:
  *       200:
  *         description: Dados da order
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/MercadoPagoOrderResponse'
+ *       404:
+ *         description: Order não encontrada
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
  *     x-codeSamples:
  *       - lang: cURL
  *         label: Exemplo
@@ -151,6 +146,16 @@ router.get("/:orderId", supabaseAuthMiddleware(), ordersController.getOrder);
  *     responses:
  *       200:
  *         description: Order cancelada
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/MercadoPagoOrderResponse'
+ *       400:
+ *         description: Erro ao cancelar
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
  *     x-codeSamples:
  *       - lang: cURL
  *         label: Exemplo
@@ -182,9 +187,25 @@ router.put(
  *         required: true
  *         schema:
  *           type: string
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/MercadoPagoRefundRequest'
  *     responses:
  *       200:
  *         description: Reembolso processado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/MercadoPagoRefundResponse'
+ *       400:
+ *         description: Erro no reembolso
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
  *     x-codeSamples:
  *       - lang: cURL
  *         label: Exemplo

--- a/src/modules/mercadopago/routes/subscriptions.ts
+++ b/src/modules/mercadopago/routes/subscriptions.ts
@@ -27,6 +27,16 @@ const subscriptionController = new SubscriptionController();
  *     responses:
  *       200:
  *         description: Lista de assinaturas
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/MercadoPagoSubscriptionListResponse'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X GET "http://localhost:3000/api/v1/mercadopago/subscriptions" \\
+ *            -H "Authorization: Bearer <TOKEN>"
  */
 router.get(
   "/",
@@ -46,9 +56,33 @@ router.get(
  *     tags: [MercadoPago]
  *     security:
  *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/MercadoPagoSubscriptionRequest'
  *     responses:
  *       201:
  *         description: Assinatura criada
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/MercadoPagoSubscriptionResponse'
+ *       400:
+ *         description: Erro de validação
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X POST "http://localhost:3000/api/v1/mercadopago/subscriptions" \\
+ *            -H "Authorization: Bearer <TOKEN>" \\
+ *            -H "Content-Type: application/json" \\
+ *            -d '{"reason":"Plano Mensal","payer_email":"user@example.com","auto_recurring":{"frequency":1,"frequency_type":"months","transaction_amount":50,"currency_id":"BRL"}}'
  */
 router.post(
   "/",
@@ -77,6 +111,22 @@ router.post(
  *     responses:
  *       200:
  *         description: Dados da assinatura
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/MercadoPagoSubscriptionResponse'
+ *       404:
+ *         description: Assinatura não encontrada
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X GET "http://localhost:3000/api/v1/mercadopago/subscriptions/{subscriptionId}" \\
+ *            -H "Authorization: Bearer <TOKEN>"
  */
 router.get(
   "/:subscriptionId",
@@ -105,6 +155,22 @@ router.get(
  *     responses:
  *       200:
  *         description: Assinatura pausada
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/MercadoPagoSubscriptionResponse'
+ *       400:
+ *         description: Erro ao pausar
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X PUT "http://localhost:3000/api/v1/mercadopago/subscriptions/{subscriptionId}/pause" \\
+ *            -H "Authorization: Bearer <TOKEN>"
  */
 router.put(
   "/:subscriptionId/pause",
@@ -133,6 +199,22 @@ router.put(
  *     responses:
  *       200:
  *         description: Assinatura cancelada
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/MercadoPagoSubscriptionResponse'
+ *       400:
+ *         description: Erro ao cancelar
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X PUT "http://localhost:3000/api/v1/mercadopago/subscriptions/{subscriptionId}/cancel" \\
+ *            -H "Authorization: Bearer <TOKEN>"
  */
 router.put(
   "/:subscriptionId/cancel",
@@ -161,6 +243,22 @@ router.put(
  *     responses:
  *       200:
  *         description: Assinatura reativada
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/MercadoPagoSubscriptionResponse'
+ *       400:
+ *         description: Erro ao reativar
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X PUT "http://localhost:3000/api/v1/mercadopago/subscriptions/{subscriptionId}/reactivate" \\
+ *            -H "Authorization: Bearer <TOKEN>"
  */
 router.put(
   "/:subscriptionId/reactivate",

--- a/src/modules/mercadopago/routes/webhooks.ts
+++ b/src/modules/mercadopago/routes/webhooks.ts
@@ -24,6 +24,15 @@ const webhookController = new WebhookController();
  *     responses:
  *       200:
  *         description: Detalhes dos webhooks
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/BasicMessage'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X GET "http://localhost:3000/api/v1/mercadopago/webhooks"
  */
 router.get("/", (req, res) => {
   res.json({
@@ -46,9 +55,26 @@ router.get("/", (req, res) => {
  *   post:
  *     summary: Receber notificações do MercadoPago
  *     tags: [MercadoPago]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/MercadoPagoWebhookNotification'
  *     responses:
  *       200:
  *         description: Notificação recebida
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/BasicMessage'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X POST "http://localhost:3000/api/v1/mercadopago/webhooks" \\
+ *            -H "Content-Type: application/json" \\
+ *            -d '{"id":"123","type":"payment","action":"payment.created","data":{"id":"999"}}'
  */
 router.post("/", webhookController.processWebhook);
 
@@ -65,6 +91,15 @@ router.post("/", webhookController.processWebhook);
  *     responses:
  *       200:
  *         description: Teste bem-sucedido
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/BasicMessage'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X GET "http://localhost:3000/api/v1/mercadopago/webhooks/test"
  */
 router.get("/test", webhookController.testWebhook);
 

--- a/src/modules/usuarios/routes/admin-routes.ts
+++ b/src/modules/usuarios/routes/admin-routes.ts
@@ -32,14 +32,24 @@ router.use(supabaseAuthMiddleware(["ADMIN", "MODERADOR"]));
 /**
  * @openapi
  * /api/v1/usuarios/admin:
- *   get:
- *     summary: Informações do painel administrativo
- *     tags: [Usuários - Admin]
- *     security:
- *       - bearerAuth: []
- *     responses:
- *       200:
- *         description: Detalhes do painel
+  *   get:
+  *     summary: Informações do painel administrativo
+  *     tags: [Usuários - Admin]
+  *     security:
+  *       - bearerAuth: []
+  *     responses:
+  *       200:
+  *         description: Detalhes do painel
+  *         content:
+  *           application/json:
+  *             schema:
+  *               $ref: '#/components/schemas/AdminModuleInfo'
+  *       500:
+  *         description: Erro interno
+  *         content:
+  *           application/json:
+  *             schema:
+  *               $ref: '#/components/schemas/ErrorResponse'
  *     x-codeSamples:
  *       - lang: cURL
  *         label: Exemplo
@@ -56,14 +66,50 @@ router.get("/", adminController.getAdminInfo);
 /**
  * @openapi
  * /api/v1/usuarios/admin/usuarios:
- *   get:
- *     summary: Listar usuários
- *     tags: [Usuários - Admin]
- *     security:
- *       - bearerAuth: []
- *     responses:
- *       200:
- *         description: Lista de usuários
+  *   get:
+  *     summary: Listar usuários
+  *     tags: [Usuários - Admin]
+  *     security:
+  *       - bearerAuth: []
+  *     parameters:
+  *       - in: query
+  *         name: page
+  *         schema:
+  *           type: integer
+  *           example: 1
+  *       - in: query
+  *         name: limit
+  *         schema:
+  *           type: integer
+  *           example: 50
+  *       - in: query
+  *         name: status
+  *         schema:
+  *           type: string
+  *           example: ATIVO
+  *       - in: query
+  *         name: role
+  *         schema:
+  *           type: string
+  *           example: ADMIN
+  *       - in: query
+  *         name: tipoUsuario
+  *         schema:
+  *           type: string
+  *           example: PESSOA_FISICA
+  *     responses:
+  *       200:
+  *         description: Lista de usuários
+  *         content:
+  *           application/json:
+  *             schema:
+  *               $ref: '#/components/schemas/AdminUserListResponse'
+  *       500:
+  *         description: Erro ao listar usuários
+  *         content:
+  *           application/json:
+  *             schema:
+  *               $ref: '#/components/schemas/ErrorResponse'
  *     x-codeSamples:
  *       - lang: cURL
  *         label: Exemplo
@@ -79,21 +125,37 @@ router.get("/usuarios", adminController.listarUsuarios);
  */
 /**
  * @openapi
- * /api/v1/usuarios/admin/usuarios/{userId}:
- *   get:
- *     summary: Buscar usuário por ID
- *     tags: [Usuários - Admin]
- *     security:
- *       - bearerAuth: []
- *     parameters:
- *       - in: path
- *         name: userId
- *         required: true
- *         schema:
- *           type: string
- *     responses:
- *       200:
- *         description: Usuário encontrado
+  * /api/v1/usuarios/admin/usuarios/{userId}:
+  *   get:
+  *     summary: Buscar usuário por ID
+  *     tags: [Usuários - Admin]
+  *     security:
+  *       - bearerAuth: []
+  *     parameters:
+  *       - in: path
+  *         name: userId
+  *         required: true
+  *         schema:
+  *           type: string
+  *     responses:
+  *       200:
+  *         description: Usuário encontrado
+  *         content:
+  *           application/json:
+  *             schema:
+  *               $ref: '#/components/schemas/AdminUserDetailResponse'
+  *       404:
+  *         description: Usuário não encontrado
+  *         content:
+  *           application/json:
+  *             schema:
+  *               $ref: '#/components/schemas/ErrorResponse'
+  *       500:
+  *         description: Erro interno
+  *         content:
+  *           application/json:
+  *             schema:
+  *               $ref: '#/components/schemas/ErrorResponse'
  *     x-codeSamples:
  *       - lang: cURL
  *         label: Exemplo
@@ -107,11 +169,6 @@ router.get("/usuarios/:userId", adminController.buscarUsuario);
  * Histórico de pagamentos de usuário
  * GET /admin/usuarios/:userId/pagamentos
  */
-router.get(
-  "/usuarios/:userId/pagamentos",
-  supabaseAuthMiddleware(["ADMIN", "MODERADOR", "FINANCEIRO"]),
-  adminController.historicoPagamentosUsuario
-);
 /**
  * @openapi
  * /api/v1/usuarios/admin/usuarios/{userId}/pagamentos:
@@ -126,16 +183,47 @@ router.get(
  *         required: true
  *         schema:
  *           type: string
+ *       - in: query
+ *         name: page
+ *         schema:
+ *           type: integer
+ *           example: 1
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *           example: 20
  *     responses:
  *       200:
  *         description: Histórico retornado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/AdminPaymentHistoryResponse'
+ *       404:
+ *         description: Usuário não encontrado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro ao buscar histórico
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
  *     x-codeSamples:
  *       - lang: cURL
  *         label: Exemplo
  *         source: |
- *           curl -X GET "http://localhost:3000/api/v1/usuarios/admin/usuarios/{userId}/pagamentos" \\
+ *           curl -X GET "http://localhost:3000/api/v1/usuarios/admin/usuarios/{userId}/pagamentos?page=1&limit=20" \\
  *            -H "Authorization: Bearer <TOKEN>"
  */
+router.get(
+  "/usuarios/:userId/pagamentos",
+  supabaseAuthMiddleware(["ADMIN", "MODERADOR", "FINANCEIRO"]),
+  adminController.historicoPagamentosUsuario
+);
 
 // =============================================
 // ROTAS DE MODIFICAÇÃO (APENAS ADMIN)
@@ -145,11 +233,6 @@ router.get(
  * Atualizar status de usuário
  * PATCH /admin/usuarios/:userId/status
  */
-router.patch(
-  "/usuarios/:userId/status",
-  supabaseAuthMiddleware(["ADMIN"]),
-  adminController.atualizarStatus
-);
 /**
  * @openapi
  * /api/v1/usuarios/admin/usuarios/{userId}/status:
@@ -164,9 +247,31 @@ router.patch(
  *         required: true
  *         schema:
  *           type: string
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/AdminStatusUpdateRequest'
  *     responses:
  *       200:
  *         description: Status atualizado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/AdminStatusUpdateResponse'
+ *       400:
+ *         description: Erro de validação
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       404:
+ *         description: Usuário não encontrado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
  *     x-codeSamples:
  *       - lang: cURL
  *         label: Exemplo
@@ -176,16 +281,16 @@ router.patch(
  *            -H "Content-Type: application/json" \\
  *            -d '{"status":"ATIVO"}'
  */
+router.patch(
+  "/usuarios/:userId/status",
+  supabaseAuthMiddleware(["ADMIN"]),
+  adminController.atualizarStatus
+);
 
 /**
  * Atualizar role de usuário
  * PATCH /admin/usuarios/:userId/role
  */
-router.patch(
-  "/usuarios/:userId/role",
-  supabaseAuthMiddleware(["ADMIN"]),
-  adminController.atualizarRole
-);
 /**
  * @openapi
  * /api/v1/usuarios/admin/usuarios/{userId}/role:
@@ -200,9 +305,31 @@ router.patch(
  *         required: true
  *         schema:
  *           type: string
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/AdminRoleUpdateRequest'
  *     responses:
  *       200:
  *         description: Role atualizada
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/AdminRoleUpdateResponse'
+ *       400:
+ *         description: Erro de validação
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       404:
+ *         description: Usuário não encontrado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
  *     x-codeSamples:
  *       - lang: cURL
  *         label: Exemplo
@@ -212,5 +339,10 @@ router.patch(
  *            -H "Content-Type: application/json" \\
  *            -d '{"role":"MODERADOR"}'
  */
+router.patch(
+  "/usuarios/:userId/role",
+  supabaseAuthMiddleware(["ADMIN"]),
+  adminController.atualizarRole
+);
 
 export { router as adminRoutes };

--- a/src/modules/usuarios/routes/payment-routes.ts
+++ b/src/modules/usuarios/routes/payment-routes.ts
@@ -32,26 +32,30 @@ router.use(supabaseAuthMiddleware());
 /**
  * @openapi
  * /api/v1/usuarios/pagamentos/curso:
- *   post:
- *     summary: Processar pagamento de curso
- *     tags: [Usuários - Pagamentos]
- *     security:
- *       - bearerAuth: []
- *     requestBody:
- *       required: true
- *       content:
- *         application/json:
- *           schema:
- *             type: object
- *             properties:
- *               cursoId: { type: string, example: "curso-uuid" }
- *               paymentToken: { type: string, example: "tok_123" }
- *               paymentMethodId: { type: string, example: "visa" }
- *               installments: { type: integer, example: 1 }
- *               issuerId: { type: string, example: "issuer" }
- *     responses:
- *       200:
- *         description: Pagamento processado
+  *   post:
+  *     summary: Processar pagamento de curso
+  *     tags: [Usuários - Pagamentos]
+  *     security:
+  *       - bearerAuth: []
+  *     requestBody:
+  *       required: true
+  *       content:
+  *         application/json:
+  *           schema:
+  *             $ref: '#/components/schemas/UserCoursePaymentRequest'
+  *     responses:
+  *       201:
+  *         description: Pagamento processado
+  *         content:
+  *           application/json:
+  *             schema:
+  *               $ref: '#/components/schemas/UserCoursePaymentResponse'
+  *       400:
+  *         description: Erro ao processar pagamento
+  *         content:
+  *           application/json:
+  *             schema:
+  *               $ref: '#/components/schemas/ErrorResponse'
  *     x-codeSamples:
  *       - lang: cURL
  *         label: Exemplo
@@ -70,25 +74,30 @@ router.post("/curso", paymentController.processarPagamentoCurso);
 /**
  * @openapi
  * /api/v1/usuarios/pagamentos/assinatura:
- *   post:
- *     summary: Criar assinatura premium
- *     tags: [Usuários - Pagamentos]
- *     security:
- *       - bearerAuth: []
- *     requestBody:
- *       required: true
- *       content:
- *         application/json:
- *           schema:
- *             type: object
- *             properties:
- *               plano: { type: string, example: "plano-premium" }
- *               cardToken: { type: string, example: "tok_123" }
- *               frequencia: { type: integer, example: 1 }
- *               periodo: { type: string, example: "months" }
- *     responses:
- *       201:
- *         description: Assinatura criada
+  *   post:
+  *     summary: Criar assinatura premium
+  *     tags: [Usuários - Pagamentos]
+  *     security:
+  *       - bearerAuth: []
+  *     requestBody:
+  *       required: true
+  *       content:
+  *         application/json:
+  *           schema:
+  *             $ref: '#/components/schemas/UserSubscriptionCreateRequest'
+  *     responses:
+  *       201:
+  *         description: Assinatura criada
+  *         content:
+  *           application/json:
+  *             schema:
+  *               $ref: '#/components/schemas/UserSubscriptionCreateResponse'
+  *       400:
+  *         description: Erro ao criar assinatura
+  *         content:
+  *           application/json:
+  *             schema:
+  *               $ref: '#/components/schemas/ErrorResponse'
  *     x-codeSamples:
  *       - lang: cURL
  *         label: Exemplo
@@ -107,23 +116,30 @@ router.post("/assinatura", paymentController.criarAssinaturaPremium);
 /**
  * @openapi
  * /api/v1/usuarios/pagamentos/assinatura/cancelar:
- *   put:
- *     summary: Cancelar assinatura
- *     tags: [Usuários - Pagamentos]
- *     security:
- *       - bearerAuth: []
- *     requestBody:
- *       required: true
- *       content:
- *         application/json:
- *           schema:
- *             type: object
- *             properties:
- *               subscriptionId: { type: string, example: "sub-123" }
- *               motivo: { type: string, example: "Opção" }
- *     responses:
- *       200:
- *         description: Assinatura cancelada
+  *   put:
+  *     summary: Cancelar assinatura
+  *     tags: [Usuários - Pagamentos]
+  *     security:
+  *       - bearerAuth: []
+  *     requestBody:
+  *       required: true
+  *       content:
+  *         application/json:
+  *           schema:
+  *             $ref: '#/components/schemas/UserSubscriptionCancelRequest'
+  *     responses:
+  *       200:
+  *         description: Assinatura cancelada
+  *         content:
+  *           application/json:
+  *             schema:
+  *               $ref: '#/components/schemas/UserSubscriptionCancelResponse'
+  *       404:
+  *         description: Assinatura não encontrada
+  *         content:
+  *           application/json:
+  *             schema:
+  *               $ref: '#/components/schemas/ErrorResponse'
  *     x-codeSamples:
  *       - lang: cURL
  *         label: Exemplo
@@ -142,14 +158,24 @@ router.put("/assinatura/cancelar", paymentController.cancelarAssinatura);
 /**
  * @openapi
  * /api/v1/usuarios/pagamentos/historico:
- *   get:
- *     summary: Listar histórico de pagamentos
- *     tags: [Usuários - Pagamentos]
- *     security:
- *       - bearerAuth: []
- *     responses:
- *       200:
- *         description: Histórico de pagamentos
+  *   get:
+  *     summary: Listar histórico de pagamentos
+  *     tags: [Usuários - Pagamentos]
+  *     security:
+  *       - bearerAuth: []
+  *     responses:
+  *       200:
+  *         description: Histórico de pagamentos
+  *         content:
+  *           application/json:
+  *             schema:
+  *               $ref: '#/components/schemas/UserPaymentHistoryResponse'
+  *       500:
+  *         description: Erro ao listar histórico
+  *         content:
+  *           application/json:
+  *             schema:
+  *               $ref: '#/components/schemas/ErrorResponse'
  *     x-codeSamples:
  *       - lang: cURL
  *         label: Exemplo

--- a/src/modules/usuarios/routes/stats-routes.ts
+++ b/src/modules/usuarios/routes/stats-routes.ts
@@ -32,14 +32,24 @@ router.use(supabaseAuthMiddleware(["ADMIN", "MODERADOR"]));
 /**
  * @openapi
  * /api/v1/usuarios/stats/dashboard:
- *   get:
- *     summary: Estatísticas gerais do sistema
- *     tags: [Usuários - Stats]
- *     security:
- *       - bearerAuth: []
- *     responses:
- *       200:
- *         description: Dados de dashboard
+  *   get:
+  *     summary: Estatísticas gerais do sistema
+  *     tags: [Usuários - Stats]
+  *     security:
+  *       - bearerAuth: []
+  *     responses:
+  *       200:
+  *         description: Dados de dashboard
+  *         content:
+  *           application/json:
+  *             schema:
+  *               $ref: '#/components/schemas/DashboardStatsResponse'
+  *       500:
+  *         description: Erro ao obter estatísticas
+  *         content:
+  *           application/json:
+  *             schema:
+  *               $ref: '#/components/schemas/ErrorResponse'
  *     x-codeSamples:
  *       - lang: cURL
  *         label: Exemplo
@@ -56,14 +66,30 @@ router.get("/dashboard", statsController.getDashboardStats);
 /**
  * @openapi
  * /api/v1/usuarios/stats/usuarios:
- *   get:
- *     summary: Estatísticas de usuários
- *     tags: [Usuários - Stats]
- *     security:
- *       - bearerAuth: []
- *     responses:
- *       200:
- *         description: Estatísticas retornadas
+  *   get:
+  *     summary: Estatísticas de usuários
+  *     tags: [Usuários - Stats]
+  *     security:
+  *       - bearerAuth: []
+  *     parameters:
+  *       - in: query
+  *         name: periodo
+  *         schema:
+  *           type: string
+  *           example: 30d
+  *     responses:
+  *       200:
+  *         description: Estatísticas retornadas
+  *         content:
+  *           application/json:
+  *             schema:
+  *               $ref: '#/components/schemas/UserStatsResponse'
+  *       500:
+  *         description: Erro ao obter estatísticas
+  *         content:
+  *           application/json:
+  *             schema:
+  *               $ref: '#/components/schemas/ErrorResponse'
  *     x-codeSamples:
  *       - lang: cURL
  *         label: Exemplo
@@ -80,14 +106,30 @@ router.get("/usuarios", statsController.getUserStats);
 /**
  * @openapi
  * /api/v1/usuarios/stats/pagamentos:
- *   get:
- *     summary: Estatísticas de pagamentos
- *     tags: [Usuários - Stats]
- *     security:
- *       - bearerAuth: []
- *     responses:
- *       200:
- *         description: Estatísticas de pagamentos
+  *   get:
+  *     summary: Estatísticas de pagamentos
+  *     tags: [Usuários - Stats]
+  *     security:
+  *       - bearerAuth: []
+  *     parameters:
+  *       - in: query
+  *         name: periodo
+  *         schema:
+  *           type: string
+  *           example: 30d
+  *     responses:
+  *       200:
+  *         description: Estatísticas de pagamentos
+  *         content:
+  *           application/json:
+  *             schema:
+  *               $ref: '#/components/schemas/PaymentStatsResponse'
+  *       500:
+  *         description: Erro ao obter estatísticas
+  *         content:
+  *           application/json:
+  *             schema:
+  *               $ref: '#/components/schemas/ErrorResponse'
  *     x-codeSamples:
  *       - lang: cURL
  *         label: Exemplo

--- a/src/modules/website/routes/banner.ts
+++ b/src/modules/website/routes/banner.ts
@@ -15,6 +15,18 @@ const upload = multer({ storage: multer.memoryStorage() });
  *     responses:
  *       200:
  *         description: Lista de banners
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 $ref: '#/components/schemas/WebsiteBanner'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
  *     x-codeSamples:
  *       - lang: cURL
  *         label: Exemplo
@@ -38,6 +50,22 @@ router.get("/", BannerController.list);
  *     responses:
  *       200:
  *         description: Banner encontrado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/WebsiteBanner'
+ *       404:
+ *         description: Banner não encontrado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
  *     x-codeSamples:
  *       - lang: cURL
  *         label: Exemplo
@@ -54,9 +82,25 @@ router.get("/:id", BannerController.get);
  *     tags: [Website - Banner]
  *     security:
  *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         multipart/form-data:
+ *           schema:
+ *             $ref: '#/components/schemas/WebsiteBannerCreateInput'
  *     responses:
  *       201:
  *         description: Banner criado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/WebsiteBanner'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
  *     x-codeSamples:
  *       - lang: cURL
  *         label: Exemplo
@@ -64,7 +108,8 @@ router.get("/:id", BannerController.get);
  *           curl -X POST "http://localhost:3000/api/v1/website/banner" \\
  *            -H "Authorization: Bearer <TOKEN>" \\
  *            -F "imagem=@banner.png" \\
- *            -F "titulo=Novo Banner"
+ *            -F "link=https://example.com" \\
+ *            -F "ordem=1"
  */
 router.post(
   "/",
@@ -87,17 +132,39 @@ router.post(
  *         required: true
  *         schema:
  *           type: string
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         multipart/form-data:
+ *           schema:
+ *             $ref: '#/components/schemas/WebsiteBannerUpdateInput'
  *     responses:
  *       200:
  *         description: Banner atualizado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/WebsiteBanner'
+ *       404:
+ *         description: Banner não encontrado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
  *     x-codeSamples:
  *       - lang: cURL
  *         label: Exemplo
  *         source: |
  *           curl -X PUT "http://localhost:3000/api/v1/website/banner/{id}" \\
  *            -H "Authorization: Bearer <TOKEN>" \\
- *            -F "imagem=@banner.png" \\
- *            -F "titulo=Atualizado"
+ *            -F "link=https://example.com" \\
+ *            -F "ordem=2"
  */
 router.put(
   "/:id",
@@ -121,8 +188,20 @@ router.put(
  *         schema:
  *           type: string
  *     responses:
- *       200:
+ *       204:
  *         description: Banner removido
+ *       404:
+ *         description: Banner não encontrado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
  *     x-codeSamples:
  *       - lang: cURL
  *         label: Exemplo

--- a/src/modules/website/routes/business-group-information.ts
+++ b/src/modules/website/routes/business-group-information.ts
@@ -15,6 +15,18 @@ const upload = multer({ storage: multer.memoryStorage() });
  *     responses:
  *       200:
  *         description: Lista de informações
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 $ref: '#/components/schemas/WebsiteBusinessGroupInformation'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
  *     x-codeSamples:
  *       - lang: cURL
  *         label: Exemplo
@@ -38,6 +50,22 @@ router.get("/", BusinessGroupInformationController.list);
  *     responses:
  *       200:
  *         description: Informação encontrada
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/WebsiteBusinessGroupInformation'
+ *       404:
+ *         description: Informação não encontrada
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
  *     x-codeSamples:
  *       - lang: cURL
  *         label: Exemplo
@@ -54,17 +82,37 @@ router.get("/:id", BusinessGroupInformationController.get);
  *     tags: [Website - BusinessGroupInformation]
  *     security:
  *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         multipart/form-data:
+ *           schema:
+ *             $ref: '#/components/schemas/WebsiteBusinessGroupInformationCreateInput'
  *     responses:
  *       201:
  *         description: Informação criada
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/WebsiteBusinessGroupInformation'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
  *     x-codeSamples:
  *       - lang: cURL
  *         label: Exemplo
  *         source: |
  *           curl -X POST "http://localhost:3000/api/v1/website/business-group-information" \\
  *            -H "Authorization: Bearer <TOKEN>" \\
- *            -F "imagem=@info.png" \\
- *            -F "titulo=Novo"
+ *            -F "slug=grupo-x" \\
+ *            -F "titulo=Grupo X" \\
+ *            -F "descricao=Descricao" \\
+ *            -F "botaoLabel=Saiba mais" \\
+ *            -F "botaoUrl=https://example.com" \\
+ *            -F "imagem=@info.png"
  */
 router.post(
   "/",
@@ -87,16 +135,37 @@ router.post(
  *         required: true
  *         schema:
  *           type: string
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         multipart/form-data:
+ *           schema:
+ *             $ref: '#/components/schemas/WebsiteBusinessGroupInformationUpdateInput'
  *     responses:
  *       200:
  *         description: Informação atualizada
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/WebsiteBusinessGroupInformation'
+ *       404:
+ *         description: Informação não encontrada
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
  *     x-codeSamples:
  *       - lang: cURL
  *         label: Exemplo
  *         source: |
  *           curl -X PUT "http://localhost:3000/api/v1/website/business-group-information/{id}" \\
  *            -H "Authorization: Bearer <TOKEN>" \\
- *            -F "imagem=@info.png" \\
  *            -F "titulo=Atualizado"
  */
 router.put(
@@ -121,8 +190,20 @@ router.put(
  *         schema:
  *           type: string
  *     responses:
- *       200:
+ *       204:
  *         description: Informação removida
+ *       404:
+ *         description: Informação não encontrada
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
  *     x-codeSamples:
  *       - lang: cURL
  *         label: Exemplo

--- a/src/modules/website/routes/index.ts
+++ b/src/modules/website/routes/index.ts
@@ -16,6 +16,16 @@ const router = Router();
  *     responses:
  *       200:
  *         description: Detalhes do módulo
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/WebsiteModuleInfo'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
  *     x-codeSamples:
  *       - lang: cURL
  *         label: Exemplo

--- a/src/modules/website/routes/logo-enterprises.ts
+++ b/src/modules/website/routes/logo-enterprises.ts
@@ -15,6 +15,18 @@ const upload = multer({ storage: multer.memoryStorage() });
  *     responses:
  *       200:
  *         description: Lista de logos
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 $ref: '#/components/schemas/WebsiteLogoEnterprise'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
  *     x-codeSamples:
  *       - lang: cURL
  *         label: Exemplo
@@ -38,6 +50,22 @@ router.get("/", LogoEnterpriseController.list);
  *     responses:
  *       200:
  *         description: Logo encontrada
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/WebsiteLogoEnterprise'
+ *       404:
+ *         description: Logo não encontrada
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
  *     x-codeSamples:
  *       - lang: cURL
  *         label: Exemplo
@@ -54,9 +82,25 @@ router.get("/:id", LogoEnterpriseController.get);
  *     tags: [Website - LogoEnterprises]
  *     security:
  *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         multipart/form-data:
+ *           schema:
+ *             $ref: '#/components/schemas/WebsiteLogoEnterpriseCreateInput'
  *     responses:
  *       201:
  *         description: Logo criada
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/WebsiteLogoEnterprise'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
  *     x-codeSamples:
  *       - lang: cURL
  *         label: Exemplo
@@ -64,8 +108,11 @@ router.get("/:id", LogoEnterpriseController.get);
  *           curl -X POST "http://localhost:3000/api/v1/website/logo-enterprises" \\
  *            -H "Authorization: Bearer <TOKEN>" \\
  *            -F "imagem=@logo.png" \\
- *            -F "empresa=Minha Empresa"
- */
+ *            -F "nome=Minha Empresa" \\
+ *            -F "website=https://empresa.com" \\
+ *            -F "categoria=tech" \\
+ *            -F "ordem=1"
+*/
 router.post(
   "/",
   supabaseAuthMiddleware(["ADMIN", "MODERADOR"]),
@@ -87,9 +134,31 @@ router.post(
  *         required: true
  *         schema:
  *           type: string
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         multipart/form-data:
+ *           schema:
+ *             $ref: '#/components/schemas/WebsiteLogoEnterpriseUpdateInput'
  *     responses:
  *       200:
  *         description: Logo atualizada
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/WebsiteLogoEnterprise'
+ *       404:
+ *         description: Logo não encontrada
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
  *     x-codeSamples:
  *       - lang: cURL
  *         label: Exemplo
@@ -97,8 +166,11 @@ router.post(
  *           curl -X PUT "http://localhost:3000/api/v1/website/logo-enterprises/{id}" \\
  *            -H "Authorization: Bearer <TOKEN>" \\
  *            -F "imagem=@logo.png" \\
- *            -F "empresa=Atualizada"
- */
+ *            -F "nome=Atualizada" \\
+ *            -F "website=https://empresa.com" \\
+ *            -F "categoria=tech" \\
+ *            -F "ordem=2"
+*/
 router.put(
   "/:id",
   supabaseAuthMiddleware(["ADMIN", "MODERADOR"]),
@@ -121,15 +193,27 @@ router.put(
  *         schema:
  *           type: string
  *     responses:
- *       200:
+ *       204:
  *         description: Logo removida
+ *       404:
+ *         description: Logo não encontrada
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
  *     x-codeSamples:
  *       - lang: cURL
  *         label: Exemplo
  *         source: |
  *           curl -X DELETE "http://localhost:3000/api/v1/website/logo-enterprises/{id}" \\
  *            -H "Authorization: Bearer <TOKEN>"
- */
+*/
 router.delete(
   "/:id",
   supabaseAuthMiddleware(["ADMIN", "MODERADOR"]),

--- a/src/modules/website/routes/slide.ts
+++ b/src/modules/website/routes/slide.ts
@@ -15,6 +15,18 @@ const upload = multer({ storage: multer.memoryStorage() });
  *     responses:
  *       200:
  *         description: Lista de slides
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 $ref: '#/components/schemas/WebsiteSlide'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
  *     x-codeSamples:
  *       - lang: cURL
  *         label: Exemplo
@@ -38,6 +50,22 @@ router.get("/", SlideController.list);
  *     responses:
  *       200:
  *         description: Slide encontrado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/WebsiteSlide'
+ *       404:
+ *         description: Slide não encontrado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
  *     x-codeSamples:
  *       - lang: cURL
  *         label: Exemplo
@@ -54,9 +82,25 @@ router.get("/:id", SlideController.get);
  *     tags: [Website - Slide]
  *     security:
  *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         multipart/form-data:
+ *           schema:
+ *             $ref: '#/components/schemas/WebsiteSlideCreateInput'
  *     responses:
  *       201:
  *         description: Slide criado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/WebsiteSlide'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
  *     x-codeSamples:
  *       - lang: cURL
  *         label: Exemplo
@@ -64,8 +108,9 @@ router.get("/:id", SlideController.get);
  *           curl -X POST "http://localhost:3000/api/v1/website/slide" \\
  *            -H "Authorization: Bearer <TOKEN>" \\
  *            -F "imagem=@slide.png" \\
- *            -F "titulo=Novo Slide"
- */
+ *            -F "link=https://example.com" \\
+ *            -F "ordem=1"
+*/
 router.post(
   "/",
   supabaseAuthMiddleware(["ADMIN", "MODERADOR"]),
@@ -87,9 +132,31 @@ router.post(
  *         required: true
  *         schema:
  *           type: string
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         multipart/form-data:
+ *           schema:
+ *             $ref: '#/components/schemas/WebsiteSlideUpdateInput'
  *     responses:
  *       200:
  *         description: Slide atualizado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/WebsiteSlide'
+ *       404:
+ *         description: Slide não encontrado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
  *     x-codeSamples:
  *       - lang: cURL
  *         label: Exemplo
@@ -97,8 +164,9 @@ router.post(
  *           curl -X PUT "http://localhost:3000/api/v1/website/slide/{id}" \\
  *            -H "Authorization: Bearer <TOKEN>" \\
  *            -F "imagem=@slide.png" \\
- *            -F "titulo=Atualizado"
- */
+ *            -F "link=https://example.com" \\
+ *            -F "ordem=2"
+*/
 router.put(
   "/:id",
   supabaseAuthMiddleware(["ADMIN", "MODERADOR"]),
@@ -121,15 +189,27 @@ router.put(
  *         schema:
  *           type: string
  *     responses:
- *       200:
+ *       204:
  *         description: Slide removido
+ *       404:
+ *         description: Slide não encontrado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
  *     x-codeSamples:
  *       - lang: cURL
  *         label: Exemplo
  *         source: |
  *           curl -X DELETE "http://localhost:3000/api/v1/website/slide/{id}" \\
  *            -H "Authorization: Bearer <TOKEN>"
- */
+*/
 router.delete(
   "/:id",
   supabaseAuthMiddleware(["ADMIN", "MODERADOR"]),

--- a/src/modules/website/routes/sobre.ts
+++ b/src/modules/website/routes/sobre.ts
@@ -15,6 +15,18 @@ const upload = multer({ storage: multer.memoryStorage() });
  *     responses:
  *       200:
  *         description: Lista de conteúdos
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 $ref: '#/components/schemas/WebsiteSobre'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
  *     x-codeSamples:
  *       - lang: cURL
  *         label: Exemplo
@@ -38,6 +50,22 @@ router.get("/", SobreController.list);
  *     responses:
  *       200:
  *         description: Conteúdo encontrado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/WebsiteSobre'
+ *       404:
+ *         description: Conteúdo não encontrado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
  *     x-codeSamples:
  *       - lang: cURL
  *         label: Exemplo
@@ -54,9 +82,25 @@ router.get("/:id", SobreController.get);
  *     tags: [Website - Sobre]
  *     security:
  *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         multipart/form-data:
+ *           schema:
+ *             $ref: '#/components/schemas/WebsiteSobreCreateInput'
  *     responses:
  *       201:
  *         description: Conteúdo criado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/WebsiteSobre'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
  *     x-codeSamples:
  *       - lang: cURL
  *         label: Exemplo
@@ -64,8 +108,9 @@ router.get("/:id", SobreController.get);
  *           curl -X POST "http://localhost:3000/api/v1/website/sobre" \\
  *            -H "Authorization: Bearer <TOKEN>" \\
  *            -F "imagem=@sobre.png" \\
- *            -F "titulo=Novo"
- */
+ *            -F "titulo=Novo" \\
+ *            -F "descricao=Conteudo"
+*/
 router.post(
   "/",
   supabaseAuthMiddleware(["ADMIN", "MODERADOR"]),
@@ -87,9 +132,31 @@ router.post(
  *         required: true
  *         schema:
  *           type: string
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         multipart/form-data:
+ *           schema:
+ *             $ref: '#/components/schemas/WebsiteSobreUpdateInput'
  *     responses:
  *       200:
  *         description: Conteúdo atualizado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/WebsiteSobre'
+ *       404:
+ *         description: Conteúdo não encontrado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
  *     x-codeSamples:
  *       - lang: cURL
  *         label: Exemplo
@@ -97,8 +164,9 @@ router.post(
  *           curl -X PUT "http://localhost:3000/api/v1/website/sobre/{id}" \\
  *            -H "Authorization: Bearer <TOKEN>" \\
  *            -F "imagem=@sobre.png" \\
- *            -F "titulo=Atualizado"
- */
+ *            -F "titulo=Atualizado" \\
+ *            -F "descricao=Atualizada"
+*/
 router.put(
   "/:id",
   supabaseAuthMiddleware(["ADMIN", "MODERADOR"]),
@@ -121,15 +189,27 @@ router.put(
  *         schema:
  *           type: string
  *     responses:
- *       200:
+ *       204:
  *         description: Conteúdo removido
+ *       404:
+ *         description: Conteúdo não encontrado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
  *     x-codeSamples:
  *       - lang: cURL
  *         label: Exemplo
  *         source: |
  *           curl -X DELETE "http://localhost:3000/api/v1/website/sobre/{id}" \\
  *            -H "Authorization: Bearer <TOKEN>"
- */
+*/
 router.delete(
   "/:id",
   supabaseAuthMiddleware(["ADMIN", "MODERADOR"]),

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -23,17 +23,20 @@ const emailVerificationController = new EmailVerificationController();
  * /:
  *   get:
  *     summary: Rota raiz da API
+ *     tags: [Default]
  *     responses:
  *       200:
  *         description: Informações básicas e endpoints disponíveis
  *         content:
  *           application/json:
- *             example:
- *               message: "Advance+ API"
- *               version: "v3.0.3"
- *               status: "operational"
- *               endpoints:
- *                 usuarios: "/api/v1/usuarios"
+ *             schema:
+ *               $ref: '#/components/schemas/ApiRootInfo'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
  *     x-codeSamples:
  *       - lang: cURL
  *         label: Exemplo
@@ -107,15 +110,20 @@ router.get("/", (req, res) => {
  * /health:
  *   get:
  *     summary: Health check global
+ *     tags: [Default]
  *     responses:
  *       200:
  *         description: Status do servidor
  *         content:
  *           application/json:
- *             example:
- *               status: "OK"
- *               uptime: 1
- *               version: "v3.0.3"
+ *             schema:
+ *               $ref: '#/components/schemas/GlobalHealthStatus'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
  *     x-codeSamples:
  *       - lang: cURL
  *         label: Exemplo


### PR DESCRIPTION
## Summary
- ensure swagger UI uses BaseLayout with sidebar and includes logout button
- document MercadoPago routes with schemas, parameters, and cURL examples
- add Audit module schemas and enrich its route documentation with parameters and error responses
- add Brevo module schemas and expand its route documentation with parameters, request bodies, and cURL examples
- add Empresa module schemas and detail its plan management endpoints with request bodies, responses, and cURL samples
- add Default tag and reusable schemas for API root, global health and Website module info
- document API root, health check and Website module root with structured responses and error examples
- add user admin, payment and stats tags and schemas for Swagger
- expand user admin, payment and stats routes with detailed parameters, request bodies, responses and cURL examples
- add Website banner and business-group-information tags and schemas and document their routes with structured request/response bodies
- add Website logo-enterprises, slide and sobre tags and schemas and document their routes with structured request/response bodies

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9c53861e88325810f1eba0c06773f