### PR TITLE
Redirect docs session to login when token expires

### DIFF
--- a/src/modules/usuarios/auth/supabase-middleware.ts
+++ b/src/modules/usuarios/auth/supabase-middleware.ts
@@ -66,6 +66,14 @@ export const supabaseAuthMiddleware =
       { algorithms: ["RS256", "ES256", "HS256"] },
       async (err: any, decoded: any) => {
         if (err) {
+          if (
+            req.originalUrl.startsWith("/docs") &&
+            !req.originalUrl.startsWith("/docs/login")
+          ) {
+            res.clearCookie("token");
+            return res.redirect("/docs/login");
+          }
+
           return res.status(401).json({
             message: "Token inválido ou expirado",
             error: err.message,


### PR DESCRIPTION
## Summary
- redirect expired/invalid tokens on docs routes to login page
- clear stale auth cookie before redirecting

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a9d73bf03083259823231eaeb1ace7