### PR TITLE
fix: permit redoc script under CSP

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -47,9 +47,22 @@ app.use(
     contentSecurityPolicy: {
       directives: {
         defaultSrc: ["'self'"],
-        scriptSrc: ["'self'", "'unsafe-inline'"],
-        styleSrc: ["'self'", "'unsafe-inline'"],
+        scriptSrc: [
+          "'self'",
+          "'unsafe-inline'",
+          "https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js",
+        ],
+        styleSrc: [
+          "'self'",
+          "'unsafe-inline'",
+          "https://fonts.googleapis.com",
+        ],
         imgSrc: ["'self'", "data:", "https:"],
+        fontSrc: [
+          "'self'",
+          "https://fonts.gstatic.com",
+          "data:",
+        ],
       },
     },
   })


### PR DESCRIPTION
## Summary
- allow Redoc CDN script and fonts through Content Security Policy

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa168c9e1483258ef143d26a0ef655