### PR TITLE
Allow ReDoc web workers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -63,6 +63,7 @@ app.use(
           "https://fonts.gstatic.com",
           "data:",
         ],
+        workerSrc: ["'self'", "blob:"],
       },
     },
   })


### PR DESCRIPTION
## Summary
- permit web workers in CSP so ReDoc can load without CSP violations

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa1944e9508325b1ee4793d2fb158e