### PR TITLE
feat(website): add consultoria, recrutamento, sobre empresa, team and diferenciais sections

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -421,6 +421,69 @@ model WebsiteSobre {
   atualizadoEm DateTime @updatedAt
 }
 
+model WebsiteConsultoria {
+  id           String   @id @default(uuid())
+  imagemUrl    String
+  imagemTitulo String
+  titulo       String
+  descricao    String
+  criadoEm     DateTime @default(now())
+  atualizadoEm DateTime @updatedAt
+}
+
+model WebsiteRecrutamento {
+  id           String   @id @default(uuid())
+  imagemUrl    String
+  imagemTitulo String
+  titulo       String
+  descricao    String
+  criadoEm     DateTime @default(now())
+  atualizadoEm DateTime @updatedAt
+}
+
+model WebsiteSobreEmpresa {
+  id               String   @id @default(uuid())
+  titulo           String
+  descricao        String
+  descricaoVisao   String
+  descricaoMissao  String
+  descricaoValores String
+  videoUrl         String
+  criadoEm         DateTime @default(now())
+  atualizadoEm     DateTime @updatedAt
+}
+
+model WebsiteTeam {
+  id        String   @id @default(uuid())
+  photoUrl  String
+  nome      String
+  cargo     String
+  criadoEm  DateTime @default(now())
+  atualizadoEm DateTime @updatedAt
+}
+
+model WebsiteDiferenciais {
+  id           String   @id @default(uuid())
+  icone1       String
+  titulo1      String
+  descricao1   String
+  icone2       String
+  titulo2      String
+  descricao2   String
+  icone3       String
+  titulo3      String
+  descricao3   String
+  icone4       String
+  titulo4      String
+  descricao4   String
+  titulo       String
+  descricao    String
+  botaoUrl     String
+  botaoLabel   String
+  criadoEm     DateTime @default(now())
+  atualizadoEm DateTime @updatedAt
+}
+
 model WebsiteSlider {
   id          String   @id @default(uuid())
   sliderName  String

--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -45,6 +45,26 @@ const options: Options = {
       { name: "Website - LogoEnterprises", description: "Logos de empresas" },
       { name: "Website - Slider", description: "Gestão de sliders" },
       { name: "Website - Sobre", description: "Conteúdos \"Sobre\"" },
+      {
+        name: "Website - Consultoria",
+        description: "Conteúdos \"Consultoria\"",
+      },
+      {
+        name: "Website - Recrutamento",
+        description: "Conteúdos \"Recrutamento\"",
+      },
+      {
+        name: "Website - SobreEmpresa",
+        description: "Conteúdos \"Sobre Empresa\"",
+      },
+      {
+        name: "Website - Team",
+        description: "Conteúdos \"Team\"",
+      },
+      {
+        name: "Website - Diferenciais",
+        description: "Conteúdos \"Diferenciais\"",
+      },
     ],
     components: {
       schemas: {
@@ -928,6 +948,11 @@ const options: Options = {
                   type: "string",
                   example: "/logo-enterprises",
                 },
+                consultoria: { type: "string", example: "/consultoria" },
+                recrutamento: { type: "string", example: "/recrutamento" },
+                sobreEmpresa: { type: "string", example: "/sobre-empresa" },
+                team: { type: "string", example: "/team" },
+                diferenciais: { type: "string", example: "/diferenciais" },
               },
             },
             status: { type: "string", example: "operational" },
@@ -1227,6 +1252,410 @@ const options: Options = {
               format: "uri",
               example: "https://cdn.example.com/sobre.jpg",
             },
+          },
+        },
+        WebsiteConsultoria: {
+          type: "object",
+          properties: {
+            id: { type: "string", example: "consultoria-uuid" },
+            imagemUrl: {
+              type: "string",
+              format: "uri",
+              example: "https://cdn.example.com/consultoria.jpg",
+            },
+            imagemTitulo: { type: "string", example: "consultoria" },
+            titulo: { type: "string", example: "Serviços de Consultoria" },
+            descricao: {
+              type: "string",
+              example: "Descrição sobre consultoria",
+            },
+            criadoEm: {
+              type: "string",
+              format: "date-time",
+              example: "2024-01-01T12:00:00Z",
+            },
+            atualizadoEm: {
+              type: "string",
+              format: "date-time",
+              example: "2024-01-01T12:00:00Z",
+            },
+          },
+        },
+        WebsiteConsultoriaCreateInput: {
+          type: "object",
+          required: ["titulo", "descricao"],
+          properties: {
+            titulo: {
+              type: "string",
+              example: "Serviços de Consultoria",
+            },
+            descricao: {
+              type: "string",
+              example: "Descrição sobre consultoria",
+            },
+            imagem: {
+              type: "string",
+              format: "binary",
+              description: "Arquivo de imagem do conteúdo",
+            },
+            imagemUrl: {
+              type: "string",
+              format: "uri",
+              description: "URL alternativa da imagem",
+              example: "https://cdn.example.com/consultoria.jpg",
+            },
+          },
+        },
+        WebsiteConsultoriaUpdateInput: {
+          type: "object",
+          properties: {
+            titulo: {
+              type: "string",
+              example: "Serviços de Consultoria",
+            },
+            descricao: {
+              type: "string",
+              example: "Descrição atualizada",
+            },
+            imagem: { type: "string", format: "binary" },
+            imagemUrl: {
+              type: "string",
+              format: "uri",
+              example: "https://cdn.example.com/consultoria.jpg",
+            },
+          },
+        },
+        WebsiteRecrutamento: {
+          type: "object",
+          properties: {
+            id: { type: "string", example: "recrutamento-uuid" },
+            imagemUrl: {
+              type: "string",
+              format: "uri",
+              example: "https://cdn.example.com/recrutamento.jpg",
+            },
+            imagemTitulo: { type: "string", example: "recrutamento" },
+            titulo: { type: "string", example: "Serviços de Recrutamento" },
+            descricao: {
+              type: "string",
+              example: "Descrição sobre recrutamento",
+            },
+            criadoEm: {
+              type: "string",
+              format: "date-time",
+              example: "2024-01-01T12:00:00Z",
+            },
+            atualizadoEm: {
+              type: "string",
+              format: "date-time",
+              example: "2024-01-01T12:00:00Z",
+            },
+          },
+        },
+        WebsiteRecrutamentoCreateInput: {
+          type: "object",
+          required: ["titulo", "descricao"],
+          properties: {
+            titulo: {
+              type: "string",
+              example: "Serviços de Recrutamento",
+            },
+            descricao: {
+              type: "string",
+              example: "Descrição sobre recrutamento",
+            },
+            imagem: {
+              type: "string",
+              format: "binary",
+              description: "Arquivo de imagem do conteúdo",
+            },
+            imagemUrl: {
+              type: "string",
+              format: "uri",
+              description: "URL alternativa da imagem",
+              example: "https://cdn.example.com/recrutamento.jpg",
+            },
+          },
+        },
+        WebsiteRecrutamentoUpdateInput: {
+          type: "object",
+          properties: {
+            titulo: {
+              type: "string",
+              example: "Serviços de Recrutamento",
+            },
+            descricao: {
+              type: "string",
+              example: "Descrição atualizada",
+            },
+            imagem: { type: "string", format: "binary" },
+            imagemUrl: {
+              type: "string",
+              format: "uri",
+              example: "https://cdn.example.com/recrutamento.jpg",
+            },
+          },
+        },
+        WebsiteSobreEmpresa: {
+          type: "object",
+          properties: {
+            id: { type: "string", example: "sobreempresa-uuid" },
+            titulo: { type: "string", example: "Sobre a Empresa" },
+            descricao: {
+              type: "string",
+              example: "Descrição sobre a empresa",
+            },
+            descricaoVisao: {
+              type: "string",
+              example: "Nossa visão",
+            },
+            descricaoMissao: {
+              type: "string",
+              example: "Nossa missão",
+            },
+            descricaoValores: {
+              type: "string",
+              example: "Nossos valores",
+            },
+            videoUrl: {
+              type: "string",
+              format: "uri",
+              example: "https://example.com/video",
+            },
+            criadoEm: {
+              type: "string",
+              format: "date-time",
+              example: "2024-01-01T12:00:00Z",
+            },
+            atualizadoEm: {
+              type: "string",
+              format: "date-time",
+              example: "2024-01-01T12:00:00Z",
+            },
+          },
+        },
+        WebsiteSobreEmpresaCreateInput: {
+          type: "object",
+          required: [
+            "titulo",
+            "descricao",
+            "descricaoVisao",
+            "descricaoMissao",
+            "descricaoValores",
+            "videoUrl",
+          ],
+          properties: {
+            titulo: { type: "string", example: "Sobre a Empresa" },
+            descricao: {
+              type: "string",
+              example: "Descrição sobre a empresa",
+            },
+            descricaoVisao: {
+              type: "string",
+              example: "Nossa visão",
+            },
+            descricaoMissao: {
+              type: "string",
+              example: "Nossa missão",
+            },
+            descricaoValores: {
+              type: "string",
+              example: "Nossos valores",
+            },
+            videoUrl: {
+              type: "string",
+              format: "uri",
+              example: "https://example.com/video",
+            },
+          },
+        },
+        WebsiteSobreEmpresaUpdateInput: {
+          type: "object",
+          properties: {
+            titulo: { type: "string", example: "Sobre a Empresa" },
+            descricao: {
+              type: "string",
+              example: "Descrição sobre a empresa",
+            },
+            descricaoVisao: {
+              type: "string",
+              example: "Nossa visão",
+            },
+            descricaoMissao: {
+              type: "string",
+              example: "Nossa missão",
+            },
+            descricaoValores: {
+              type: "string",
+              example: "Nossos valores",
+            },
+            videoUrl: {
+              type: "string",
+              format: "uri",
+              example: "https://example.com/video",
+            },
+          },
+        },
+        WebsiteTeam: {
+          type: "object",
+          properties: {
+            id: { type: "string", example: "team-uuid" },
+            photoUrl: {
+              type: "string",
+              format: "uri",
+              example: "https://cdn.example.com/team.jpg",
+            },
+            nome: { type: "string", example: "Fulano" },
+            cargo: { type: "string", example: "Desenvolvedor" },
+            criadoEm: {
+              type: "string",
+              format: "date-time",
+              example: "2024-01-01T12:00:00Z",
+            },
+            atualizadoEm: {
+              type: "string",
+              format: "date-time",
+              example: "2024-01-01T12:00:00Z",
+            },
+          },
+        },
+        WebsiteTeamCreateInput: {
+          type: "object",
+          required: ["nome", "cargo"],
+          properties: {
+            nome: { type: "string", example: "Fulano" },
+            cargo: { type: "string", example: "Desenvolvedor" },
+            photo: {
+              type: "string",
+              format: "binary",
+              description: "Arquivo de imagem do membro",
+            },
+            photoUrl: {
+              type: "string",
+              format: "uri",
+              description: "URL alternativa da imagem",
+              example: "https://cdn.example.com/team.jpg",
+            },
+          },
+        },
+        WebsiteTeamUpdateInput: {
+          type: "object",
+          properties: {
+            nome: { type: "string", example: "Fulano" },
+            cargo: { type: "string", example: "Desenvolvedor" },
+            photo: { type: "string", format: "binary" },
+            photoUrl: {
+              type: "string",
+              format: "uri",
+              example: "https://cdn.example.com/team.jpg",
+            },
+          },
+        },
+        WebsiteDiferenciais: {
+          type: "object",
+          properties: {
+            id: { type: "string", example: "diferenciais-uuid" },
+            icone1: { type: "string", example: "icon1" },
+            titulo1: { type: "string", example: "Título 1" },
+            descricao1: { type: "string", example: "Descrição 1" },
+            icone2: { type: "string", example: "icon2" },
+            titulo2: { type: "string", example: "Título 2" },
+            descricao2: { type: "string", example: "Descrição 2" },
+            icone3: { type: "string", example: "icon3" },
+            titulo3: { type: "string", example: "Título 3" },
+            descricao3: { type: "string", example: "Descrição 3" },
+            icone4: { type: "string", example: "icon4" },
+            titulo4: { type: "string", example: "Título 4" },
+            descricao4: { type: "string", example: "Descrição 4" },
+            titulo: { type: "string", example: "Nossos Diferenciais" },
+            descricao: {
+              type: "string",
+              example: "Texto geral dos diferenciais",
+            },
+            botaoUrl: {
+              type: "string",
+              format: "uri",
+              example: "https://example.com",
+            },
+            botaoLabel: { type: "string", example: "Saiba mais" },
+            criadoEm: {
+              type: "string",
+              format: "date-time",
+              example: "2024-01-01T12:00:00Z",
+            },
+            atualizadoEm: {
+              type: "string",
+              format: "date-time",
+              example: "2024-01-01T12:00:00Z",
+            },
+          },
+        },
+        WebsiteDiferenciaisCreateInput: {
+          type: "object",
+          required: [
+            "icone1",
+            "titulo1",
+            "descricao1",
+            "icone2",
+            "titulo2",
+            "descricao2",
+            "icone3",
+            "titulo3",
+            "descricao3",
+            "icone4",
+            "titulo4",
+            "descricao4",
+            "titulo",
+            "descricao",
+            "botaoUrl",
+            "botaoLabel",
+          ],
+          properties: {
+            icone1: { type: "string", example: "icon1" },
+            titulo1: { type: "string", example: "Título 1" },
+            descricao1: { type: "string", example: "Descrição 1" },
+            icone2: { type: "string", example: "icon2" },
+            titulo2: { type: "string", example: "Título 2" },
+            descricao2: { type: "string", example: "Descrição 2" },
+            icone3: { type: "string", example: "icon3" },
+            titulo3: { type: "string", example: "Título 3" },
+            descricao3: { type: "string", example: "Descrição 3" },
+            icone4: { type: "string", example: "icon4" },
+            titulo4: { type: "string", example: "Título 4" },
+            descricao4: { type: "string", example: "Descrição 4" },
+            titulo: { type: "string", example: "Nossos Diferenciais" },
+            descricao: { type: "string", example: "Texto geral" },
+            botaoUrl: {
+              type: "string",
+              format: "uri",
+              example: "https://example.com",
+            },
+            botaoLabel: { type: "string", example: "Saiba mais" },
+          },
+        },
+        WebsiteDiferenciaisUpdateInput: {
+          type: "object",
+          properties: {
+            icone1: { type: "string", example: "icon1" },
+            titulo1: { type: "string", example: "Título 1" },
+            descricao1: { type: "string", example: "Descrição 1" },
+            icone2: { type: "string", example: "icon2" },
+            titulo2: { type: "string", example: "Título 2" },
+            descricao2: { type: "string", example: "Descrição 2" },
+            icone3: { type: "string", example: "icon3" },
+            titulo3: { type: "string", example: "Título 3" },
+            descricao3: { type: "string", example: "Descrição 3" },
+            icone4: { type: "string", example: "icon4" },
+            titulo4: { type: "string", example: "Título 4" },
+            descricao4: { type: "string", example: "Descrição 4" },
+            titulo: { type: "string", example: "Nossos Diferenciais" },
+            descricao: { type: "string", example: "Texto geral" },
+            botaoUrl: {
+              type: "string",
+              format: "uri",
+              example: "https://example.com",
+            },
+            botaoLabel: { type: "string", example: "Saiba mais" },
           },
         },
         AdminModuleInfo: {

--- a/src/modules/website/controllers/consultoria.controller.ts
+++ b/src/modules/website/controllers/consultoria.controller.ts
@@ -1,0 +1,108 @@
+import { Request, Response } from "express";
+import path from "path";
+import { supabase } from "../../superbase/client";
+import { consultoriaService } from "../services/consultoria.service";
+
+function generateImageTitle(url: string): string {
+  try {
+    const pathname = new URL(url).pathname;
+    return path.basename(pathname).split(".")[0];
+  } catch {
+    return "";
+  }
+}
+
+async function uploadImage(file: Express.Multer.File): Promise<string> {
+  const fileExt = path.extname(file.originalname);
+  const fileName = `consultoria-${Date.now()}${fileExt}`;
+  const { error } = await supabase.storage
+    .from("website")
+    .upload(`consultoria/${fileName}`, file.buffer, {
+      contentType: file.mimetype,
+    });
+  if (error) throw error;
+  const { data } = supabase.storage
+    .from("website")
+    .getPublicUrl(`consultoria/${fileName}`);
+  return data.publicUrl;
+}
+
+export class ConsultoriaController {
+  static list = async (req: Request, res: Response) => {
+    const itens = await consultoriaService.list();
+    res.json(itens);
+  };
+
+  static get = async (req: Request, res: Response) => {
+    try {
+      const { id } = req.params;
+      const consultoria = await consultoriaService.get(id);
+      if (!consultoria) {
+        return res.status(404).json({ message: "Consultoria não encontrada" });
+      }
+      res.json(consultoria);
+    } catch (error: any) {
+      res
+        .status(500)
+        .json({ message: "Erro ao buscar consultoria", error: error.message });
+    }
+  };
+
+  static create = async (req: Request, res: Response) => {
+    try {
+      const { titulo, descricao } = req.body;
+      let imagemUrl = "";
+      if (req.file) {
+        imagemUrl = await uploadImage(req.file);
+      } else if (req.body.imagemUrl) {
+        imagemUrl = req.body.imagemUrl;
+      }
+      const imagemTitulo = imagemUrl ? generateImageTitle(imagemUrl) : "";
+      const consultoria = await consultoriaService.create({
+        imagemUrl,
+        imagemTitulo,
+        titulo,
+        descricao,
+      });
+      res.status(201).json(consultoria);
+    } catch (error: any) {
+      res
+        .status(500)
+        .json({ message: "Erro ao criar consultoria", error: error.message });
+    }
+  };
+
+  static update = async (req: Request, res: Response) => {
+    try {
+      const { id } = req.params;
+      const { titulo, descricao } = req.body;
+      let imagemUrl = req.body.imagemUrl as string | undefined;
+      if (req.file) {
+        imagemUrl = await uploadImage(req.file);
+      }
+      const data: any = { titulo, descricao };
+      if (imagemUrl) {
+        data.imagemUrl = imagemUrl;
+        data.imagemTitulo = generateImageTitle(imagemUrl);
+      }
+      const consultoria = await consultoriaService.update(id, data);
+      res.json(consultoria);
+    } catch (error: any) {
+      res
+        .status(500)
+        .json({ message: "Erro ao atualizar consultoria", error: error.message });
+    }
+  };
+
+  static remove = async (req: Request, res: Response) => {
+    try {
+      const { id } = req.params;
+      await consultoriaService.remove(id);
+      res.status(204).send();
+    } catch (error: any) {
+      res
+        .status(500)
+        .json({ message: "Erro ao remover consultoria", error: error.message });
+    }
+  };
+}

--- a/src/modules/website/controllers/diferenciais.controller.ts
+++ b/src/modules/website/controllers/diferenciais.controller.ts
@@ -1,0 +1,135 @@
+import { Request, Response } from "express";
+import { diferenciaisService } from "../services/diferenciais.service";
+
+export class DiferenciaisController {
+  static list = async (req: Request, res: Response) => {
+    const itens = await diferenciaisService.list();
+    res.json(itens);
+  };
+
+  static get = async (req: Request, res: Response) => {
+    try {
+      const { id } = req.params;
+      const diferencial = await diferenciaisService.get(id);
+      if (!diferencial) {
+        return res
+          .status(404)
+          .json({ message: "Diferenciais não encontrado" });
+      }
+      res.json(diferencial);
+    } catch (error: any) {
+      res.status(500).json({
+        message: "Erro ao buscar diferenciais",
+        error: error.message,
+      });
+    }
+  };
+
+  static create = async (req: Request, res: Response) => {
+    try {
+      const {
+        icone1,
+        titulo1,
+        descricao1,
+        icone2,
+        titulo2,
+        descricao2,
+        icone3,
+        titulo3,
+        descricao3,
+        icone4,
+        titulo4,
+        descricao4,
+        titulo,
+        descricao,
+        botaoUrl,
+        botaoLabel,
+      } = req.body;
+      const diferencial = await diferenciaisService.create({
+        icone1,
+        titulo1,
+        descricao1,
+        icone2,
+        titulo2,
+        descricao2,
+        icone3,
+        titulo3,
+        descricao3,
+        icone4,
+        titulo4,
+        descricao4,
+        titulo,
+        descricao,
+        botaoUrl,
+        botaoLabel,
+      });
+      res.status(201).json(diferencial);
+    } catch (error: any) {
+      res.status(500).json({
+        message: "Erro ao criar diferenciais",
+        error: error.message,
+      });
+    }
+  };
+
+  static update = async (req: Request, res: Response) => {
+    try {
+      const { id } = req.params;
+      const {
+        icone1,
+        titulo1,
+        descricao1,
+        icone2,
+        titulo2,
+        descricao2,
+        icone3,
+        titulo3,
+        descricao3,
+        icone4,
+        titulo4,
+        descricao4,
+        titulo,
+        descricao,
+        botaoUrl,
+        botaoLabel,
+      } = req.body;
+      const diferencial = await diferenciaisService.update(id, {
+        icone1,
+        titulo1,
+        descricao1,
+        icone2,
+        titulo2,
+        descricao2,
+        icone3,
+        titulo3,
+        descricao3,
+        icone4,
+        titulo4,
+        descricao4,
+        titulo,
+        descricao,
+        botaoUrl,
+        botaoLabel,
+      });
+      res.json(diferencial);
+    } catch (error: any) {
+      res.status(500).json({
+        message: "Erro ao atualizar diferenciais",
+        error: error.message,
+      });
+    }
+  };
+
+  static remove = async (req: Request, res: Response) => {
+    try {
+      const { id } = req.params;
+      await diferenciaisService.remove(id);
+      res.status(204).send();
+    } catch (error: any) {
+      res.status(500).json({
+        message: "Erro ao remover diferenciais",
+        error: error.message,
+      });
+    }
+  };
+}

--- a/src/modules/website/controllers/recrutamento.controller.ts
+++ b/src/modules/website/controllers/recrutamento.controller.ts
@@ -1,0 +1,113 @@
+import { Request, Response } from "express";
+import path from "path";
+import { supabase } from "../../superbase/client";
+import { recrutamentoService } from "../services/recrutamento.service";
+
+function generateImageTitle(url: string): string {
+  try {
+    const pathname = new URL(url).pathname;
+    return path.basename(pathname).split(".")[0];
+  } catch {
+    return "";
+  }
+}
+
+async function uploadImage(file: Express.Multer.File): Promise<string> {
+  const fileExt = path.extname(file.originalname);
+  const fileName = `recrutamento-${Date.now()}${fileExt}`;
+  const { error } = await supabase.storage
+    .from("website")
+    .upload(`recrutamento/${fileName}`, file.buffer, {
+      contentType: file.mimetype,
+    });
+  if (error) throw error;
+  const { data } = supabase.storage
+    .from("website")
+    .getPublicUrl(`recrutamento/${fileName}`);
+  return data.publicUrl;
+}
+
+export class RecrutamentoController {
+  static list = async (req: Request, res: Response) => {
+    const itens = await recrutamentoService.list();
+    res.json(itens);
+  };
+
+  static get = async (req: Request, res: Response) => {
+    try {
+      const { id } = req.params;
+      const recrutamento = await recrutamentoService.get(id);
+      if (!recrutamento) {
+        return res
+          .status(404)
+          .json({ message: "Recrutamento não encontrado" });
+      }
+      res.json(recrutamento);
+    } catch (error: any) {
+      res
+        .status(500)
+        .json({ message: "Erro ao buscar recrutamento", error: error.message });
+    }
+  };
+
+  static create = async (req: Request, res: Response) => {
+    try {
+      const { titulo, descricao } = req.body;
+      let imagemUrl = "";
+      if (req.file) {
+        imagemUrl = await uploadImage(req.file);
+      } else if (req.body.imagemUrl) {
+        imagemUrl = req.body.imagemUrl;
+      }
+      const imagemTitulo = imagemUrl ? generateImageTitle(imagemUrl) : "";
+      const recrutamento = await recrutamentoService.create({
+        imagemUrl,
+        imagemTitulo,
+        titulo,
+        descricao,
+      });
+      res.status(201).json(recrutamento);
+    } catch (error: any) {
+      res.status(500).json({
+        message: "Erro ao criar recrutamento",
+        error: error.message,
+      });
+    }
+  };
+
+  static update = async (req: Request, res: Response) => {
+    try {
+      const { id } = req.params;
+      const { titulo, descricao } = req.body;
+      let imagemUrl = req.body.imagemUrl as string | undefined;
+      if (req.file) {
+        imagemUrl = await uploadImage(req.file);
+      }
+      const data: any = { titulo, descricao };
+      if (imagemUrl) {
+        data.imagemUrl = imagemUrl;
+        data.imagemTitulo = generateImageTitle(imagemUrl);
+      }
+      const recrutamento = await recrutamentoService.update(id, data);
+      res.json(recrutamento);
+    } catch (error: any) {
+      res.status(500).json({
+        message: "Erro ao atualizar recrutamento",
+        error: error.message,
+      });
+    }
+  };
+
+  static remove = async (req: Request, res: Response) => {
+    try {
+      const { id } = req.params;
+      await recrutamentoService.remove(id);
+      res.status(204).send();
+    } catch (error: any) {
+      res.status(500).json({
+        message: "Erro ao remover recrutamento",
+        error: error.message,
+      });
+    }
+  };
+}

--- a/src/modules/website/controllers/sobreEmpresa.controller.ts
+++ b/src/modules/website/controllers/sobreEmpresa.controller.ts
@@ -1,0 +1,96 @@
+import { Request, Response } from "express";
+import { sobreEmpresaService } from "../services/sobreEmpresa.service";
+
+export class SobreEmpresaController {
+  static list = async (req: Request, res: Response) => {
+    const itens = await sobreEmpresaService.list();
+    res.json(itens);
+  };
+
+  static get = async (req: Request, res: Response) => {
+    try {
+      const { id } = req.params;
+      const sobreEmpresa = await sobreEmpresaService.get(id);
+      if (!sobreEmpresa) {
+        return res
+          .status(404)
+          .json({ message: "SobreEmpresa não encontrado" });
+      }
+      res.json(sobreEmpresa);
+    } catch (error: any) {
+      res.status(500).json({
+        message: "Erro ao buscar sobreEmpresa",
+        error: error.message,
+      });
+    }
+  };
+
+  static create = async (req: Request, res: Response) => {
+    try {
+      const {
+        titulo,
+        descricao,
+        descricaoVisao,
+        descricaoMissao,
+        descricaoValores,
+        videoUrl,
+      } = req.body;
+      const sobreEmpresa = await sobreEmpresaService.create({
+        titulo,
+        descricao,
+        descricaoVisao,
+        descricaoMissao,
+        descricaoValores,
+        videoUrl,
+      });
+      res.status(201).json(sobreEmpresa);
+    } catch (error: any) {
+      res.status(500).json({
+        message: "Erro ao criar sobreEmpresa",
+        error: error.message,
+      });
+    }
+  };
+
+  static update = async (req: Request, res: Response) => {
+    try {
+      const { id } = req.params;
+      const {
+        titulo,
+        descricao,
+        descricaoVisao,
+        descricaoMissao,
+        descricaoValores,
+        videoUrl,
+      } = req.body;
+      const sobreEmpresa = await sobreEmpresaService.update(id, {
+        titulo,
+        descricao,
+        descricaoVisao,
+        descricaoMissao,
+        descricaoValores,
+        videoUrl,
+      });
+      res.json(sobreEmpresa);
+    } catch (error: any) {
+      res.status(500).json({
+        message: "Erro ao atualizar sobreEmpresa",
+        error: error.message,
+      });
+    }
+  };
+
+  static remove = async (req: Request, res: Response) => {
+    try {
+      const { id } = req.params;
+      await sobreEmpresaService.remove(id);
+      res.status(204).send();
+    } catch (error: any) {
+      res.status(500).json({
+        message: "Erro ao remover sobreEmpresa",
+        error: error.message,
+      });
+    }
+  };
+}
+

--- a/src/modules/website/controllers/team.controller.ts
+++ b/src/modules/website/controllers/team.controller.ts
@@ -1,0 +1,100 @@
+import { Request, Response } from "express";
+import path from "path";
+import { supabase } from "../../superbase/client";
+import { teamService } from "../services/team.service";
+
+async function uploadImage(file: Express.Multer.File): Promise<string> {
+  const fileExt = path.extname(file.originalname);
+  const fileName = `team-${Date.now()}${fileExt}`;
+  const { error } = await supabase.storage
+    .from("website")
+    .upload(`team/${fileName}`, file.buffer, {
+      contentType: file.mimetype,
+    });
+  if (error) throw error;
+  const { data } = supabase.storage
+    .from("website")
+    .getPublicUrl(`team/${fileName}`);
+  return data.publicUrl;
+}
+
+export class TeamController {
+  static list = async (req: Request, res: Response) => {
+    const itens = await teamService.list();
+    res.json(itens);
+  };
+
+  static get = async (req: Request, res: Response) => {
+    try {
+      const { id } = req.params;
+      const team = await teamService.get(id);
+      if (!team) {
+        return res.status(404).json({ message: "Team member não encontrado" });
+      }
+      res.json(team);
+    } catch (error: any) {
+      res.status(500).json({
+        message: "Erro ao buscar team member",
+        error: error.message,
+      });
+    }
+  };
+
+  static create = async (req: Request, res: Response) => {
+    try {
+      const { nome, cargo } = req.body;
+      let photoUrl = "";
+      if (req.file) {
+        photoUrl = await uploadImage(req.file);
+      } else if (req.body.photoUrl) {
+        photoUrl = req.body.photoUrl;
+      }
+      const team = await teamService.create({
+        photoUrl,
+        nome,
+        cargo,
+      });
+      res.status(201).json(team);
+    } catch (error: any) {
+      res.status(500).json({
+        message: "Erro ao criar team member",
+        error: error.message,
+      });
+    }
+  };
+
+  static update = async (req: Request, res: Response) => {
+    try {
+      const { id } = req.params;
+      const { nome, cargo } = req.body;
+      let photoUrl = req.body.photoUrl as string | undefined;
+      if (req.file) {
+        photoUrl = await uploadImage(req.file);
+      }
+      const data: any = { nome, cargo };
+      if (photoUrl) {
+        data.photoUrl = photoUrl;
+      }
+      const team = await teamService.update(id, data);
+      res.json(team);
+    } catch (error: any) {
+      res.status(500).json({
+        message: "Erro ao atualizar team member",
+        error: error.message,
+      });
+    }
+  };
+
+  static remove = async (req: Request, res: Response) => {
+    try {
+      const { id } = req.params;
+      await teamService.remove(id);
+      res.status(204).send();
+    } catch (error: any) {
+      res.status(500).json({
+        message: "Erro ao remover team member",
+        error: error.message,
+      });
+    }
+  };
+}

--- a/src/modules/website/routes/consultoria.ts
+++ b/src/modules/website/routes/consultoria.ts
@@ -1,0 +1,219 @@
+import { Router } from "express";
+import multer from "multer";
+import { supabaseAuthMiddleware } from "../../usuarios/auth";
+import { ConsultoriaController } from "../controllers/consultoria.controller";
+
+const router = Router();
+const upload = multer({ storage: multer.memoryStorage() });
+
+/**
+ * @openapi
+ * /api/v1/website/consultoria:
+ *   get:
+ *     summary: Listar conteúdos "Consultoria"
+ *     tags: [Website - Consultoria]
+ *     responses:
+ *       200:
+ *         description: Lista de conteúdos
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 $ref: '#/components/schemas/WebsiteConsultoria'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X GET "http://localhost:3000/api/v1/website/consultoria"
+ */
+router.get("/", ConsultoriaController.list);
+
+/**
+ * @openapi
+ * /api/v1/website/consultoria/{id}:
+ *   get:
+ *     summary: Obter conteúdo por ID
+ *     tags: [Website - Consultoria]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Conteúdo encontrado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/WebsiteConsultoria'
+ *       404:
+ *         description: Conteúdo não encontrado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X GET "http://localhost:3000/api/v1/website/consultoria/{id}"
+ */
+router.get("/:id", ConsultoriaController.get);
+
+/**
+ * @openapi
+ * /api/v1/website/consultoria:
+ *   post:
+ *     summary: Criar conteúdo "Consultoria"
+ *     tags: [Website - Consultoria]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         multipart/form-data:
+ *           schema:
+ *             $ref: '#/components/schemas/WebsiteConsultoriaCreateInput'
+ *     responses:
+ *       201:
+ *         description: Conteúdo criado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/WebsiteConsultoria'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X POST "http://localhost:3000/api/v1/website/consultoria" \\
+ *            -H "Authorization: Bearer <TOKEN>" \\
+ *            -F "imagem=@consultoria.png" \\
+ *            -F "titulo=Novo" \\
+ *            -F "descricao=Conteudo"
+*/
+router.post(
+  "/",
+  supabaseAuthMiddleware(["ADMIN", "MODERADOR"]),
+  upload.single("imagem"),
+  ConsultoriaController.create
+);
+
+/**
+ * @openapi
+ * /api/v1/website/consultoria/{id}:
+ *   put:
+ *     summary: Atualizar conteúdo "Consultoria"
+ *     tags: [Website - Consultoria]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         multipart/form-data:
+ *           schema:
+ *             $ref: '#/components/schemas/WebsiteConsultoriaUpdateInput'
+ *     responses:
+ *       200:
+ *         description: Conteúdo atualizado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/WebsiteConsultoria'
+ *       404:
+ *         description: Conteúdo não encontrado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X PUT "http://localhost:3000/api/v1/website/consultoria/{id}" \\
+ *            -H "Authorization: Bearer <TOKEN>" \\
+ *            -F "imagem=@consultoria.png" \\
+ *            -F "titulo=Atualizado" \\
+ *            -F "descricao=Atualizada"
+*/
+router.put(
+  "/:id",
+  supabaseAuthMiddleware(["ADMIN", "MODERADOR"]),
+  upload.single("imagem"),
+  ConsultoriaController.update
+);
+
+/**
+ * @openapi
+ * /api/v1/website/consultoria/{id}:
+ *   delete:
+ *     summary: Remover conteúdo "Consultoria"
+ *     tags: [Website - Consultoria]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       204:
+ *         description: Conteúdo removido
+ *       404:
+ *         description: Conteúdo não encontrado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X DELETE "http://localhost:3000/api/v1/website/consultoria/{id}" \\
+ *            -H "Authorization: Bearer <TOKEN>"
+*/
+router.delete(
+  "/:id",
+  supabaseAuthMiddleware(["ADMIN", "MODERADOR"]),
+  ConsultoriaController.remove
+);
+
+export { router as consultoriaRoutes };

--- a/src/modules/website/routes/diferenciais.ts
+++ b/src/modules/website/routes/diferenciais.ts
@@ -1,0 +1,213 @@
+import { Router } from "express";
+import { supabaseAuthMiddleware } from "../../usuarios/auth";
+import { DiferenciaisController } from "../controllers/diferenciais.controller";
+
+const router = Router();
+
+/**
+ * @openapi
+ * /api/v1/website/diferenciais:
+ *   get:
+ *     summary: Listar conteúdos "Diferenciais"
+ *     tags: [Website - Diferenciais]
+ *     responses:
+ *       200:
+ *         description: Lista de conteúdos
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 $ref: '#/components/schemas/WebsiteDiferenciais'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X GET "http://localhost:3000/api/v1/website/diferenciais"
+ */
+router.get("/", DiferenciaisController.list);
+
+/**
+ * @openapi
+ * /api/v1/website/diferenciais/{id}:
+ *   get:
+ *     summary: Obter conteúdo por ID
+ *     tags: [Website - Diferenciais]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Conteúdo encontrado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/WebsiteDiferenciais'
+ *       404:
+ *         description: Conteúdo não encontrado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X GET "http://localhost:3000/api/v1/website/diferenciais/{id}"
+ */
+router.get("/:id", DiferenciaisController.get);
+
+/**
+ * @openapi
+ * /api/v1/website/diferenciais:
+ *   post:
+ *     summary: Criar conteúdo "Diferenciais"
+ *     tags: [Website - Diferenciais]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/WebsiteDiferenciaisCreateInput'
+ *     responses:
+ *       201:
+ *         description: Conteúdo criado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/WebsiteDiferenciais'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X POST "http://localhost:3000/api/v1/website/diferenciais" \\
+ *            -H "Authorization: Bearer <TOKEN>" \\
+ *            -H "Content-Type: application/json" \\
+ *            -d '{"icone1":"i1","titulo1":"Titulo 1","descricao1":"Desc 1","icone2":"i2","titulo2":"Titulo 2","descricao2":"Desc 2","icone3":"i3","titulo3":"Titulo 3","descricao3":"Desc 3","icone4":"i4","titulo4":"Titulo 4","descricao4":"Desc 4","titulo":"Geral","descricao":"Resumo","botaoUrl":"https://example.com","botaoLabel":"Saiba mais"}'
+ */
+router.post(
+  "/",
+  supabaseAuthMiddleware(["ADMIN", "MODERADOR"]),
+  DiferenciaisController.create
+);
+
+/**
+ * @openapi
+ * /api/v1/website/diferenciais/{id}:
+ *   put:
+ *     summary: Atualizar conteúdo "Diferenciais"
+ *     tags: [Website - Diferenciais]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/WebsiteDiferenciaisUpdateInput'
+ *     responses:
+ *       200:
+ *         description: Conteúdo atualizado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/WebsiteDiferenciais'
+ *       404:
+ *         description: Conteúdo não encontrado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X PUT "http://localhost:3000/api/v1/website/diferenciais/{id}" \\
+ *            -H "Authorization: Bearer <TOKEN>" \\
+ *            -H "Content-Type: application/json" \\
+ *            -d '{"titulo":"Atualizado"}'
+ */
+router.put(
+  "/:id",
+  supabaseAuthMiddleware(["ADMIN", "MODERADOR"]),
+  DiferenciaisController.update
+);
+
+/**
+ * @openapi
+ * /api/v1/website/diferenciais/{id}:
+ *   delete:
+ *     summary: Remover conteúdo "Diferenciais"
+ *     tags: [Website - Diferenciais]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       204:
+ *         description: Conteúdo removido
+ *       404:
+ *         description: Conteúdo não encontrado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X DELETE "http://localhost:3000/api/v1/website/diferenciais/{id}" \\
+ *            -H "Authorization: Bearer <TOKEN>"
+ */
+router.delete(
+  "/:id",
+  supabaseAuthMiddleware(["ADMIN", "MODERADOR"]),
+  DiferenciaisController.remove
+);
+
+export { router as diferenciaisRoutes };

--- a/src/modules/website/routes/index.ts
+++ b/src/modules/website/routes/index.ts
@@ -3,6 +3,11 @@ import { sobreRoutes } from "./sobre";
 import { sliderRoutes } from "./slider";
 import { bannerRoutes } from "./banner";
 import { logoEnterpriseRoutes } from "./logo-enterprises";
+import { consultoriaRoutes } from "./consultoria";
+import { recrutamentoRoutes } from "./recrutamento";
+import { sobreEmpresaRoutes } from "./sobre-empresa";
+import { teamRoutes } from "./team";
+import { diferenciaisRoutes } from "./diferenciais";
 
 const router = Router();
 
@@ -41,6 +46,11 @@ router.get("/", (req, res) => {
       slider: "/slider",
       banner: "/banner",
       logoEnterprises: "/logo-enterprises",
+      consultoria: "/consultoria",
+      recrutamento: "/recrutamento",
+      sobreEmpresa: "/sobre-empresa",
+      team: "/team",
+      diferenciais: "/diferenciais",
     },
     status: "operational",
   });
@@ -50,5 +60,10 @@ router.use("/sobre", sobreRoutes);
 router.use("/slider", sliderRoutes);
 router.use("/banner", bannerRoutes);
 router.use("/logo-enterprises", logoEnterpriseRoutes);
+router.use("/consultoria", consultoriaRoutes);
+router.use("/recrutamento", recrutamentoRoutes);
+router.use("/sobre-empresa", sobreEmpresaRoutes);
+router.use("/team", teamRoutes);
+router.use("/diferenciais", diferenciaisRoutes);
 
 export { router as websiteRoutes };

--- a/src/modules/website/routes/recrutamento.ts
+++ b/src/modules/website/routes/recrutamento.ts
@@ -1,0 +1,219 @@
+import { Router } from "express";
+import multer from "multer";
+import { supabaseAuthMiddleware } from "../../usuarios/auth";
+import { RecrutamentoController } from "../controllers/recrutamento.controller";
+
+const router = Router();
+const upload = multer({ storage: multer.memoryStorage() });
+
+/**
+ * @openapi
+ * /api/v1/website/recrutamento:
+ *   get:
+ *     summary: Listar conteúdos "Recrutamento"
+ *     tags: [Website - Recrutamento]
+ *     responses:
+ *       200:
+ *         description: Lista de conteúdos
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 $ref: '#/components/schemas/WebsiteRecrutamento'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X GET "http://localhost:3000/api/v1/website/recrutamento"
+ */
+router.get("/", RecrutamentoController.list);
+
+/**
+ * @openapi
+ * /api/v1/website/recrutamento/{id}:
+ *   get:
+ *     summary: Obter conteúdo por ID
+ *     tags: [Website - Recrutamento]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Conteúdo encontrado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/WebsiteRecrutamento'
+ *       404:
+ *         description: Conteúdo não encontrado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X GET "http://localhost:3000/api/v1/website/recrutamento/{id}"
+ */
+router.get("/:id", RecrutamentoController.get);
+
+/**
+ * @openapi
+ * /api/v1/website/recrutamento:
+ *   post:
+ *     summary: Criar conteúdo "Recrutamento"
+ *     tags: [Website - Recrutamento]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         multipart/form-data:
+ *           schema:
+ *             $ref: '#/components/schemas/WebsiteRecrutamentoCreateInput'
+ *     responses:
+ *       201:
+ *         description: Conteúdo criado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/WebsiteRecrutamento'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X POST "http://localhost:3000/api/v1/website/recrutamento" \\
+ *            -H "Authorization: Bearer <TOKEN>" \\
+ *            -F "imagem=@recrutamento.png" \\
+ *            -F "titulo=Novo" \\
+ *            -F "descricao=Conteudo"
+*/
+router.post(
+  "/",
+  supabaseAuthMiddleware(["ADMIN", "MODERADOR"]),
+  upload.single("imagem"),
+  RecrutamentoController.create
+);
+
+/**
+ * @openapi
+ * /api/v1/website/recrutamento/{id}:
+ *   put:
+ *     summary: Atualizar conteúdo "Recrutamento"
+ *     tags: [Website - Recrutamento]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         multipart/form-data:
+ *           schema:
+ *             $ref: '#/components/schemas/WebsiteRecrutamentoUpdateInput'
+ *     responses:
+ *       200:
+ *         description: Conteúdo atualizado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/WebsiteRecrutamento'
+ *       404:
+ *         description: Conteúdo não encontrado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X PUT "http://localhost:3000/api/v1/website/recrutamento/{id}" \\
+ *            -H "Authorization: Bearer <TOKEN>" \\
+ *            -F "imagem=@recrutamento.png" \\
+ *            -F "titulo=Atualizado" \\
+ *            -F "descricao=Atualizada"
+*/
+router.put(
+  "/:id",
+  supabaseAuthMiddleware(["ADMIN", "MODERADOR"]),
+  upload.single("imagem"),
+  RecrutamentoController.update
+);
+
+/**
+ * @openapi
+ * /api/v1/website/recrutamento/{id}:
+ *   delete:
+ *     summary: Remover conteúdo "Recrutamento"
+ *     tags: [Website - Recrutamento]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       204:
+ *         description: Conteúdo removido
+ *       404:
+ *         description: Conteúdo não encontrado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X DELETE "http://localhost:3000/api/v1/website/recrutamento/{id}" \\
+ *            -H "Authorization: Bearer <TOKEN>"
+*/
+router.delete(
+  "/:id",
+  supabaseAuthMiddleware(["ADMIN", "MODERADOR"]),
+  RecrutamentoController.remove
+);
+
+export { router as recrutamentoRoutes };

--- a/src/modules/website/routes/sobre-empresa.ts
+++ b/src/modules/website/routes/sobre-empresa.ts
@@ -1,0 +1,214 @@
+import { Router } from "express";
+import { supabaseAuthMiddleware } from "../../usuarios/auth";
+import { SobreEmpresaController } from "../controllers/sobreEmpresa.controller";
+
+const router = Router();
+
+/**
+ * @openapi
+ * /api/v1/website/sobre-empresa:
+ *   get:
+ *     summary: Listar conteúdos "SobreEmpresa"
+ *     tags: [Website - SobreEmpresa]
+ *     responses:
+ *       200:
+ *         description: Lista de conteúdos
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 $ref: '#/components/schemas/WebsiteSobreEmpresa'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X GET "http://localhost:3000/api/v1/website/sobre-empresa"
+ */
+router.get("/", SobreEmpresaController.list);
+
+/**
+ * @openapi
+ * /api/v1/website/sobre-empresa/{id}:
+ *   get:
+ *     summary: Obter conteúdo por ID
+ *     tags: [Website - SobreEmpresa]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Conteúdo encontrado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/WebsiteSobreEmpresa'
+ *       404:
+ *         description: Conteúdo não encontrado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X GET "http://localhost:3000/api/v1/website/sobre-empresa/{id}"
+ */
+router.get("/:id", SobreEmpresaController.get);
+
+/**
+ * @openapi
+ * /api/v1/website/sobre-empresa:
+ *   post:
+ *     summary: Criar conteúdo "SobreEmpresa"
+ *     tags: [Website - SobreEmpresa]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/WebsiteSobreEmpresaCreateInput'
+ *     responses:
+ *       201:
+ *         description: Conteúdo criado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/WebsiteSobreEmpresa'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X POST "http://localhost:3000/api/v1/website/sobre-empresa" \\
+ *            -H "Authorization: Bearer <TOKEN>" \\
+ *            -H "Content-Type: application/json" \\
+ *            -d '{"titulo":"Novo","descricao":"Conteudo","descricaoVisao":"Visao","descricaoMissao":"Missao","descricaoValores":"Valores","videoUrl":"https://example.com/video"}'
+ */
+router.post(
+  "/",
+  supabaseAuthMiddleware(["ADMIN", "MODERADOR"]),
+  SobreEmpresaController.create
+);
+
+/**
+ * @openapi
+ * /api/v1/website/sobre-empresa/{id}:
+ *   put:
+ *     summary: Atualizar conteúdo "SobreEmpresa"
+ *     tags: [Website - SobreEmpresa]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/WebsiteSobreEmpresaUpdateInput'
+ *     responses:
+ *       200:
+ *         description: Conteúdo atualizado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/WebsiteSobreEmpresa'
+ *       404:
+ *         description: Conteúdo não encontrado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X PUT "http://localhost:3000/api/v1/website/sobre-empresa/{id}" \\
+ *            -H "Authorization: Bearer <TOKEN>" \\
+ *            -H "Content-Type: application/json" \\
+ *            -d '{"titulo":"Atualizado"}'
+ */
+router.put(
+  "/:id",
+  supabaseAuthMiddleware(["ADMIN", "MODERADOR"]),
+  SobreEmpresaController.update
+);
+
+/**
+ * @openapi
+ * /api/v1/website/sobre-empresa/{id}:
+ *   delete:
+ *     summary: Remover conteúdo "SobreEmpresa"
+ *     tags: [Website - SobreEmpresa]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       204:
+ *         description: Conteúdo removido
+ *       404:
+ *         description: Conteúdo não encontrado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X DELETE "http://localhost:3000/api/v1/website/sobre-empresa/{id}" \\
+ *            -H "Authorization: Bearer <TOKEN>"
+ */
+router.delete(
+  "/:id",
+  supabaseAuthMiddleware(["ADMIN", "MODERADOR"]),
+  SobreEmpresaController.remove
+);
+
+export { router as sobreEmpresaRoutes };
+

--- a/src/modules/website/routes/team.ts
+++ b/src/modules/website/routes/team.ts
@@ -1,0 +1,219 @@
+import { Router } from "express";
+import multer from "multer";
+import { supabaseAuthMiddleware } from "../../usuarios/auth";
+import { TeamController } from "../controllers/team.controller";
+
+const router = Router();
+const upload = multer({ storage: multer.memoryStorage() });
+
+/**
+ * @openapi
+ * /api/v1/website/team:
+ *   get:
+ *     summary: Listar membros da equipe
+ *     tags: [Website - Team]
+ *     responses:
+ *       200:
+ *         description: Lista de membros
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 $ref: '#/components/schemas/WebsiteTeam'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X GET "http://localhost:3000/api/v1/website/team"
+ */
+router.get("/", TeamController.list);
+
+/**
+ * @openapi
+ * /api/v1/website/team/{id}:
+ *   get:
+ *     summary: Obter membro da equipe por ID
+ *     tags: [Website - Team]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Membro encontrado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/WebsiteTeam'
+ *       404:
+ *         description: Membro não encontrado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X GET "http://localhost:3000/api/v1/website/team/{id}"
+ */
+router.get("/:id", TeamController.get);
+
+/**
+ * @openapi
+ * /api/v1/website/team:
+ *   post:
+ *     summary: Criar membro da equipe
+ *     tags: [Website - Team]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         multipart/form-data:
+ *           schema:
+ *             $ref: '#/components/schemas/WebsiteTeamCreateInput'
+ *     responses:
+ *       201:
+ *         description: Membro criado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/WebsiteTeam'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X POST "http://localhost:3000/api/v1/website/team" \
+ *            -H "Authorization: Bearer <TOKEN>" \
+ *            -F "photo=@team.png" \
+ *            -F "nome=Fulano" \
+ *            -F "cargo=Dev"
+ */
+router.post(
+  "/",
+  supabaseAuthMiddleware(["ADMIN", "MODERADOR"]),
+  upload.single("photo"),
+  TeamController.create
+);
+
+/**
+ * @openapi
+ * /api/v1/website/team/{id}:
+ *   put:
+ *     summary: Atualizar membro da equipe
+ *     tags: [Website - Team]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         multipart/form-data:
+ *           schema:
+ *             $ref: '#/components/schemas/WebsiteTeamUpdateInput'
+ *     responses:
+ *       200:
+ *         description: Membro atualizado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/WebsiteTeam'
+ *       404:
+ *         description: Membro não encontrado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X PUT "http://localhost:3000/api/v1/website/team/{id}" \
+ *            -H "Authorization: Bearer <TOKEN>" \
+ *            -F "photo=@team.png" \
+ *            -F "nome=Fulano" \
+ *            -F "cargo=Dev"
+ */
+router.put(
+  "/:id",
+  supabaseAuthMiddleware(["ADMIN", "MODERADOR"]),
+  upload.single("photo"),
+  TeamController.update
+);
+
+/**
+ * @openapi
+ * /api/v1/website/team/{id}:
+ *   delete:
+ *     summary: Remover membro da equipe
+ *     tags: [Website - Team]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       204:
+ *         description: Membro removido
+ *       404:
+ *         description: Membro não encontrado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X DELETE "http://localhost:3000/api/v1/website/team/{id}" \
+ *            -H "Authorization: Bearer <TOKEN>"
+ */
+router.delete(
+  "/:id",
+  supabaseAuthMiddleware(["ADMIN", "MODERADOR"]),
+  TeamController.remove
+);
+
+export { router as teamRoutes };

--- a/src/modules/website/services/consultoria.service.ts
+++ b/src/modules/website/services/consultoria.service.ts
@@ -1,0 +1,14 @@
+import { prisma } from "../../../config/prisma";
+import { WebsiteConsultoria } from "@prisma/client";
+
+export const consultoriaService = {
+  list: () => prisma.websiteConsultoria.findMany(),
+  get: (id: string) =>
+    prisma.websiteConsultoria.findUnique({ where: { id } }),
+  create: (
+    data: Omit<WebsiteConsultoria, "id" | "criadoEm" | "atualizadoEm">
+  ) => prisma.websiteConsultoria.create({ data }),
+  update: (id: string, data: Partial<WebsiteConsultoria>) =>
+    prisma.websiteConsultoria.update({ where: { id }, data }),
+  remove: (id: string) => prisma.websiteConsultoria.delete({ where: { id } }),
+};

--- a/src/modules/website/services/diferenciais.service.ts
+++ b/src/modules/website/services/diferenciais.service.ts
@@ -1,0 +1,14 @@
+import { prisma } from "../../../config/prisma";
+import { WebsiteDiferenciais } from "@prisma/client";
+
+export const diferenciaisService = {
+  list: () => prisma.websiteDiferenciais.findMany(),
+  get: (id: string) =>
+    prisma.websiteDiferenciais.findUnique({ where: { id } }),
+  create: (
+    data: Omit<WebsiteDiferenciais, "id" | "criadoEm" | "atualizadoEm">
+  ) => prisma.websiteDiferenciais.create({ data }),
+  update: (id: string, data: Partial<WebsiteDiferenciais>) =>
+    prisma.websiteDiferenciais.update({ where: { id }, data }),
+  remove: (id: string) => prisma.websiteDiferenciais.delete({ where: { id } }),
+};

--- a/src/modules/website/services/recrutamento.service.ts
+++ b/src/modules/website/services/recrutamento.service.ts
@@ -1,0 +1,14 @@
+import { prisma } from "../../../config/prisma";
+import { WebsiteRecrutamento } from "@prisma/client";
+
+export const recrutamentoService = {
+  list: () => prisma.websiteRecrutamento.findMany(),
+  get: (id: string) =>
+    prisma.websiteRecrutamento.findUnique({ where: { id } }),
+  create: (
+    data: Omit<WebsiteRecrutamento, "id" | "criadoEm" | "atualizadoEm">
+  ) => prisma.websiteRecrutamento.create({ data }),
+  update: (id: string, data: Partial<WebsiteRecrutamento>) =>
+    prisma.websiteRecrutamento.update({ where: { id }, data }),
+  remove: (id: string) => prisma.websiteRecrutamento.delete({ where: { id } }),
+};

--- a/src/modules/website/services/sobreEmpresa.service.ts
+++ b/src/modules/website/services/sobreEmpresa.service.ts
@@ -1,0 +1,14 @@
+import { prisma } from "../../../config/prisma";
+import { WebsiteSobreEmpresa } from "@prisma/client";
+
+export const sobreEmpresaService = {
+  list: () => prisma.websiteSobreEmpresa.findMany(),
+  get: (id: string) => prisma.websiteSobreEmpresa.findUnique({ where: { id } }),
+  create: (
+    data: Omit<WebsiteSobreEmpresa, "id" | "criadoEm" | "atualizadoEm">
+  ) => prisma.websiteSobreEmpresa.create({ data }),
+  update: (id: string, data: Partial<WebsiteSobreEmpresa>) =>
+    prisma.websiteSobreEmpresa.update({ where: { id }, data }),
+  remove: (id: string) => prisma.websiteSobreEmpresa.delete({ where: { id } }),
+};
+

--- a/src/modules/website/services/team.service.ts
+++ b/src/modules/website/services/team.service.ts
@@ -1,0 +1,13 @@
+import { prisma } from "../../../config/prisma";
+import { WebsiteTeam } from "@prisma/client";
+
+export const teamService = {
+  list: () => prisma.websiteTeam.findMany(),
+  get: (id: string) => prisma.websiteTeam.findUnique({ where: { id } }),
+  create: (
+    data: Omit<WebsiteTeam, "id" | "criadoEm" | "atualizadoEm">
+  ) => prisma.websiteTeam.create({ data }),
+  update: (id: string, data: Partial<WebsiteTeam>) =>
+    prisma.websiteTeam.update({ where: { id }, data }),
+  remove: (id: string) => prisma.websiteTeam.delete({ where: { id } }),
+};


### PR DESCRIPTION
## Summary
- add Consultoria, Recrutamento, SobreEmpresa, Team, and Diferenciais models and CRUD APIs for website
- document new endpoints in swagger and redoc

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm run prisma:generate`


------
https://chatgpt.com/codex/tasks/task_e_68ae1b329d4c83258d30a4134c6df356