### PR TITLE
fix: broaden cors request type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,10 @@ const app = express();
  * Permite requisições do frontend configurado
  * e sempre aceita requisições do mesmo domínio do servidor
  */
-const corsOptionsDelegate: CorsOptionsDelegate = (req, callback) => {
+const corsOptionsDelegate: CorsOptionsDelegate<express.Request> = (
+  req,
+  callback
+) => {
   const origin = req.header("Origin");
   const allowedOrigins = Array.isArray(serverConfig.corsOrigin)
     ? serverConfig.corsOrigin


### PR DESCRIPTION
## Summary
- handle Express-specific headers by using Express Request in CORS delegate

## Testing
- `pnpm run build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae52656620832586cd029de993f0eb