### PR TITLE
Accept image URLs for about uploads

### DIFF
--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -1253,15 +1253,10 @@ const options: Options = {
               type: "string",
               example: "Descrição sobre a empresa",
             },
-            imagem: {
-              type: "string",
-              format: "binary",
-              description: "Arquivo de imagem do conteúdo",
-            },
             imagemUrl: {
               type: "string",
               format: "uri",
-              description: "URL alternativa da imagem",
+              description: "URL da imagem",
               example: "https://cdn.example.com/sobre.jpg",
             },
           },
@@ -1274,7 +1269,6 @@ const options: Options = {
               type: "string",
               example: "Descrição atualizada",
             },
-            imagem: { type: "string", format: "binary" },
             imagemUrl: {
               type: "string",
               format: "uri",

--- a/src/modules/website/controllers/sobre.controller.ts
+++ b/src/modules/website/controllers/sobre.controller.ts
@@ -1,6 +1,5 @@
 import { Request, Response } from "express";
 import path from "path";
-import { supabase } from "../../superbase/client";
 import { sobreService } from "../services/sobre.service";
 
 function generateImageTitle(url: string): string {
@@ -12,20 +11,6 @@ function generateImageTitle(url: string): string {
   }
 }
 
-async function uploadImage(file: Express.Multer.File): Promise<string> {
-  const fileExt = path.extname(file.originalname);
-  const fileName = `sobre-${Date.now()}${fileExt}`;
-  const { error } = await supabase.storage
-    .from("website")
-    .upload(`sobre/${fileName}`, file.buffer, {
-      contentType: file.mimetype,
-    });
-  if (error) throw error;
-  const { data } = supabase.storage
-    .from("website")
-    .getPublicUrl(`sobre/${fileName}`);
-  return data.publicUrl;
-}
 
 export class SobreController {
   static list = async (req: Request, res: Response) => {
@@ -50,13 +35,7 @@ export class SobreController {
 
   static create = async (req: Request, res: Response) => {
     try {
-      const { titulo, descricao } = req.body;
-      let imagemUrl = "";
-      if (req.file) {
-        imagemUrl = await uploadImage(req.file);
-      } else if (req.body.imagemUrl) {
-        imagemUrl = req.body.imagemUrl;
-      }
+      const { titulo, descricao, imagemUrl } = req.body;
       const imagemTitulo = imagemUrl ? generateImageTitle(imagemUrl) : "";
       const sobre = await sobreService.create({
         imagemUrl,
@@ -73,11 +52,7 @@ export class SobreController {
   static update = async (req: Request, res: Response) => {
     try {
       const { id } = req.params;
-      const { titulo, descricao } = req.body;
-      let imagemUrl = req.body.imagemUrl as string | undefined;
-      if (req.file) {
-        imagemUrl = await uploadImage(req.file);
-      }
+      const { titulo, descricao, imagemUrl } = req.body;
       const data: any = { titulo, descricao };
       if (imagemUrl) {
         data.imagemUrl = imagemUrl;

--- a/src/modules/website/routes/sobre.ts
+++ b/src/modules/website/routes/sobre.ts
@@ -1,10 +1,8 @@
 import { Router } from "express";
-import multer from "multer";
 import { supabaseAuthMiddleware } from "../../usuarios/auth";
 import { SobreController } from "../controllers/sobre.controller";
 
 const router = Router();
-const upload = multer({ storage: multer.memoryStorage() });
 
 /**
  * @openapi
@@ -85,7 +83,7 @@ router.get("/:id", SobreController.get);
  *     requestBody:
  *       required: true
  *       content:
- *         multipart/form-data:
+ *         application/json:
  *           schema:
  *             $ref: '#/components/schemas/WebsiteSobreCreateInput'
  *     responses:
@@ -107,14 +105,12 @@ router.get("/:id", SobreController.get);
  *         source: |
  *           curl -X POST "http://localhost:3000/api/v1/website/sobre" \\
  *            -H "Authorization: Bearer <TOKEN>" \\
- *            -F "imagem=@sobre.png" \\
- *            -F "titulo=Novo" \\
- *            -F "descricao=Conteudo"
+ *            -H "Content-Type: application/json" \\
+ *            -d '{"titulo":"Novo","descricao":"Conteudo","imagemUrl":"https://cdn.example.com/sobre.jpg"}'
 */
 router.post(
   "/",
   supabaseAuthMiddleware(["ADMIN", "MODERADOR"]),
-  upload.single("imagem"),
   SobreController.create
 );
 
@@ -135,7 +131,7 @@ router.post(
  *     requestBody:
  *       required: true
  *       content:
- *         multipart/form-data:
+ *         application/json:
  *           schema:
  *             $ref: '#/components/schemas/WebsiteSobreUpdateInput'
  *     responses:
@@ -163,14 +159,12 @@ router.post(
  *         source: |
  *           curl -X PUT "http://localhost:3000/api/v1/website/sobre/{id}" \\
  *            -H "Authorization: Bearer <TOKEN>" \\
- *            -F "imagem=@sobre.png" \\
- *            -F "titulo=Atualizado" \\
- *            -F "descricao=Atualizada"
+ *            -H "Content-Type: application/json" \\
+ *            -d '{"titulo":"Atualizado","descricao":"Atualizada","imagemUrl":"https://cdn.example.com/sobre.jpg"}'
 */
 router.put(
   "/:id",
   supabaseAuthMiddleware(["ADMIN", "MODERADOR"]),
-  upload.single("imagem"),
   SobreController.update
 );
 


### PR DESCRIPTION
## Summary
- remove server-side Vercel Blob usage and dependency
- accept image URLs in about controller and routes
- clean up Vercel Blob token from env example and docs

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae51f6cfa08325a29cd00ab4a11f6b