### PR TITLE
fix: persist imagemUrl in website "sobre" API

### DIFF
--- a/src/modules/website/__tests__/sobre.test.ts
+++ b/src/modules/website/__tests__/sobre.test.ts
@@ -1,0 +1,68 @@
+import express from "express";
+import request from "supertest";
+import { SobreController } from "../controllers/sobre.controller";
+import { sobreService } from "../services/sobre.service";
+
+jest.mock("../services/sobre.service", () => ({
+  sobreService: {
+    create: jest.fn(),
+    update: jest.fn(),
+  },
+}));
+
+describe("SobreController", () => {
+  const app = express();
+  app.use(express.json());
+  app.post("/sobre", SobreController.create);
+  app.put("/sobre/:id", SobreController.update);
+
+  it("should return imagemUrl on create", async () => {
+    const payload = {
+      titulo: "Title",
+      descricao: "Desc",
+      imagemUrl: "https://cdn.example.com/img.png",
+    };
+    (sobreService.create as jest.Mock).mockResolvedValue({
+      id: "1",
+      ...payload,
+      imagemTitulo: "img",
+      criadoEm: new Date().toISOString(),
+      atualizadoEm: new Date().toISOString(),
+    });
+
+    const res = await request(app).post("/sobre").send(payload);
+    expect(res.status).toBe(201);
+    expect(res.body.imagemUrl).toBe(payload.imagemUrl);
+    expect(sobreService.create).toHaveBeenCalledWith({
+      imagemUrl: payload.imagemUrl,
+      imagemTitulo: "img",
+      titulo: payload.titulo,
+      descricao: payload.descricao,
+    });
+  });
+
+  it("should update imagemUrl when provided", async () => {
+    const payload = {
+      titulo: "Title",
+      descricao: "Desc",
+      imagemUrl: "https://cdn.example.com/new.png",
+    };
+    (sobreService.update as jest.Mock).mockResolvedValue({
+      id: "1",
+      ...payload,
+      imagemTitulo: "new",
+      criadoEm: new Date().toISOString(),
+      atualizadoEm: new Date().toISOString(),
+    });
+
+    const res = await request(app).put("/sobre/1").send(payload);
+    expect(res.status).toBe(200);
+    expect(res.body.imagemUrl).toBe(payload.imagemUrl);
+    expect(sobreService.update).toHaveBeenCalledWith("1", {
+      titulo: payload.titulo,
+      descricao: payload.descricao,
+      imagemUrl: payload.imagemUrl,
+      imagemTitulo: "new",
+    });
+  });
+});

--- a/src/modules/website/controllers/sobre.controller.ts
+++ b/src/modules/website/controllers/sobre.controller.ts
@@ -53,8 +53,10 @@ export class SobreController {
     try {
       const { id } = req.params;
       const { titulo, descricao, imagemUrl } = req.body;
-      const data: any = { titulo, descricao };
-      if (imagemUrl) {
+      const data: any = {};
+      if (titulo !== undefined) data.titulo = titulo;
+      if (descricao !== undefined) data.descricao = descricao;
+      if (imagemUrl !== undefined) {
         data.imagemUrl = imagemUrl;
         data.imagemTitulo = generateImageTitle(imagemUrl);
       }


### PR DESCRIPTION
## Summary
- ensure website `sobre` update only sets provided fields and persists `imagemUrl`
- add unit tests verifying create and update return the supplied `imagemUrl`

## Testing
- `pnpm test src/modules/website/__tests__/sobre.test.ts`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68af302269e08325827987f495024068