### PR TITLE
fix: normalize imagemUrl

### DIFF
--- a/src/modules/website/__tests__/sobre.test.ts
+++ b/src/modules/website/__tests__/sobre.test.ts
@@ -16,15 +16,17 @@ describe("SobreController", () => {
   app.post("/sobre", SobreController.create);
   app.put("/sobre/:id", SobreController.update);
 
-  it("should return imagemUrl on create", async () => {
+  it("should return trimmed imagemUrl on create", async () => {
     const payload = {
       titulo: "Title",
       descricao: "Desc",
-      imagemUrl: "https://cdn.example.com/img.png",
+      imagemUrl: " https://cdn.example.com/img.png ",
     };
+    const trimmed = payload.imagemUrl.trim();
     (sobreService.create as jest.Mock).mockResolvedValue({
       id: "1",
       ...payload,
+      imagemUrl: trimmed,
       imagemTitulo: "img",
       criadoEm: new Date().toISOString(),
       atualizadoEm: new Date().toISOString(),
@@ -32,9 +34,9 @@ describe("SobreController", () => {
 
     const res = await request(app).post("/sobre").send(payload);
     expect(res.status).toBe(201);
-    expect(res.body.imagemUrl).toBe(payload.imagemUrl);
+    expect(res.body.imagemUrl).toBe(trimmed);
     expect(sobreService.create).toHaveBeenCalledWith({
-      imagemUrl: payload.imagemUrl,
+      imagemUrl: trimmed,
       imagemTitulo: "img",
       titulo: payload.titulo,
       descricao: payload.descricao,
@@ -45,11 +47,13 @@ describe("SobreController", () => {
     const payload = {
       titulo: "Title",
       descricao: "Desc",
-      imagemUrl: "https://cdn.example.com/new.png",
+      imagemUrl: " https://cdn.example.com/new.png ",
     };
+    const trimmed = payload.imagemUrl.trim();
     (sobreService.update as jest.Mock).mockResolvedValue({
       id: "1",
       ...payload,
+      imagemUrl: trimmed,
       imagemTitulo: "new",
       criadoEm: new Date().toISOString(),
       atualizadoEm: new Date().toISOString(),
@@ -57,11 +61,11 @@ describe("SobreController", () => {
 
     const res = await request(app).put("/sobre/1").send(payload);
     expect(res.status).toBe(200);
-    expect(res.body.imagemUrl).toBe(payload.imagemUrl);
+    expect(res.body.imagemUrl).toBe(trimmed);
     expect(sobreService.update).toHaveBeenCalledWith("1", {
       titulo: payload.titulo,
       descricao: payload.descricao,
-      imagemUrl: payload.imagemUrl,
+      imagemUrl: trimmed,
       imagemTitulo: "new",
     });
   });

--- a/src/modules/website/controllers/sobre.controller.ts
+++ b/src/modules/website/controllers/sobre.controller.ts
@@ -35,10 +35,13 @@ export class SobreController {
 
   static create = async (req: Request, res: Response) => {
     try {
-      const { titulo, descricao, imagemUrl } = req.body;
+      const { titulo, descricao } = req.body;
+      const imagemUrlRaw = req.body.imagemUrl;
+      const imagemUrl =
+        typeof imagemUrlRaw === "string" ? imagemUrlRaw.trim() : undefined;
       const imagemTitulo = imagemUrl ? generateImageTitle(imagemUrl) : "";
       const sobre = await sobreService.create({
-        imagemUrl,
+        imagemUrl: imagemUrl ?? "",
         imagemTitulo,
         titulo,
         descricao,
@@ -52,7 +55,10 @@ export class SobreController {
   static update = async (req: Request, res: Response) => {
     try {
       const { id } = req.params;
-      const { titulo, descricao, imagemUrl } = req.body;
+      const { titulo, descricao } = req.body;
+      const imagemUrlRaw = req.body.imagemUrl;
+      const imagemUrl =
+        typeof imagemUrlRaw === "string" ? imagemUrlRaw.trim() : undefined;
       const data: any = {};
       if (titulo !== undefined) data.titulo = titulo;
       if (descricao !== undefined) data.descricao = descricao;


### PR DESCRIPTION
## Summary
- trim imagemUrl before persisting `WebsiteSobre`
- test create/update paths with whitespace-padded URLs

## Testing
- `npm test -- src/modules/website/__tests__/sobre.test.ts`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af3636959c8325b1eb0a97e5f381f1