### PR TITLE
feat: add button fields to consultoria and recrutamento

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -427,6 +427,8 @@ model WebsiteConsultoria {
   imagemTitulo String
   titulo       String
   descricao    String
+  buttonUrl    String
+  buttonLabel  String
   criadoEm     DateTime @default(now())
   atualizadoEm DateTime @updatedAt
 }
@@ -437,6 +439,8 @@ model WebsiteRecrutamento {
   imagemTitulo String
   titulo       String
   descricao    String
+  buttonUrl    String
+  buttonLabel  String
   criadoEm     DateTime @default(now())
   atualizadoEm DateTime @updatedAt
 }

--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -1291,6 +1291,15 @@ const options: Options = {
               type: "string",
               example: "Descrição sobre consultoria",
             },
+            buttonUrl: {
+              type: "string",
+              format: "uri",
+              example: "https://example.com/consultoria",
+            },
+            buttonLabel: {
+              type: "string",
+              example: "Saiba mais",
+            },
             criadoEm: {
               type: "string",
               format: "date-time",
@@ -1305,7 +1314,7 @@ const options: Options = {
         },
         WebsiteConsultoriaCreateInput: {
           type: "object",
-          required: ["titulo", "descricao"],
+          required: ["titulo", "descricao", "buttonUrl", "buttonLabel"],
           properties: {
             titulo: {
               type: "string",
@@ -1315,6 +1324,12 @@ const options: Options = {
               type: "string",
               example: "Descrição sobre consultoria",
             },
+            buttonUrl: {
+              type: "string",
+              format: "uri",
+              example: "https://example.com/consultoria",
+            },
+            buttonLabel: { type: "string", example: "Saiba mais" },
             imagem: {
               type: "string",
               format: "binary",
@@ -1339,6 +1354,12 @@ const options: Options = {
               type: "string",
               example: "Descrição atualizada",
             },
+            buttonUrl: {
+              type: "string",
+              format: "uri",
+              example: "https://example.com/consultoria",
+            },
+            buttonLabel: { type: "string", example: "Saiba mais" },
             imagem: { type: "string", format: "binary" },
             imagemUrl: {
               type: "string",
@@ -1362,6 +1383,12 @@ const options: Options = {
               type: "string",
               example: "Descrição sobre recrutamento",
             },
+            buttonUrl: {
+              type: "string",
+              format: "uri",
+              example: "https://example.com/recrutamento",
+            },
+            buttonLabel: { type: "string", example: "Saiba mais" },
             criadoEm: {
               type: "string",
               format: "date-time",
@@ -1376,7 +1403,7 @@ const options: Options = {
         },
         WebsiteRecrutamentoCreateInput: {
           type: "object",
-          required: ["titulo", "descricao"],
+          required: ["titulo", "descricao", "buttonUrl", "buttonLabel"],
           properties: {
             titulo: {
               type: "string",
@@ -1386,6 +1413,12 @@ const options: Options = {
               type: "string",
               example: "Descrição sobre recrutamento",
             },
+            buttonUrl: {
+              type: "string",
+              format: "uri",
+              example: "https://example.com/recrutamento",
+            },
+            buttonLabel: { type: "string", example: "Saiba mais" },
             imagem: {
               type: "string",
               format: "binary",
@@ -1410,6 +1443,12 @@ const options: Options = {
               type: "string",
               example: "Descrição atualizada",
             },
+            buttonUrl: {
+              type: "string",
+              format: "uri",
+              example: "https://example.com/recrutamento",
+            },
+            buttonLabel: { type: "string", example: "Saiba mais" },
             imagem: { type: "string", format: "binary" },
             imagemUrl: {
               type: "string",

--- a/src/modules/website/__tests__/consultoria.test.ts
+++ b/src/modules/website/__tests__/consultoria.test.ts
@@ -1,0 +1,92 @@
+import express from "express";
+import request from "supertest";
+import { consultoriaService } from "../services/consultoria.service";
+
+jest.mock("../../superbase/client", () => ({
+  supabase: {
+    storage: {
+      from: () => ({
+        upload: jest.fn(),
+        getPublicUrl: () => ({ data: { publicUrl: "" } }),
+      }),
+    },
+  },
+}));
+
+jest.mock("../services/consultoria.service", () => ({
+  consultoriaService: {
+    create: jest.fn(),
+    update: jest.fn(),
+  },
+}));
+
+import { ConsultoriaController } from "../controllers/consultoria.controller";
+
+describe("ConsultoriaController", () => {
+  const app = express();
+  app.use(express.json());
+  app.post("/consultoria", ConsultoriaController.create);
+  app.put("/consultoria/:id", ConsultoriaController.update);
+
+  it("should return trimmed imagemUrl on create", async () => {
+    const payload = {
+      titulo: "Title",
+      descricao: "Desc",
+      imagemUrl: " https://cdn.example.com/img.png ",
+      buttonUrl: "https://example.com",
+      buttonLabel: "Saiba mais",
+    };
+    const trimmed = payload.imagemUrl.trim();
+    (consultoriaService.create as jest.Mock).mockResolvedValue({
+      id: "1",
+      ...payload,
+      imagemUrl: trimmed,
+      imagemTitulo: "img",
+      criadoEm: new Date().toISOString(),
+      atualizadoEm: new Date().toISOString(),
+    });
+
+    const res = await request(app).post("/consultoria").send(payload);
+    expect(res.status).toBe(201);
+    expect(res.body.imagemUrl).toBe(trimmed);
+    expect(consultoriaService.create).toHaveBeenCalledWith({
+      imagemUrl: trimmed,
+      imagemTitulo: "img",
+      titulo: payload.titulo,
+      descricao: payload.descricao,
+      buttonUrl: payload.buttonUrl,
+      buttonLabel: payload.buttonLabel,
+    });
+  });
+
+  it("should update imagemUrl when provided", async () => {
+    const payload = {
+      titulo: "Title",
+      descricao: "Desc",
+      imagemUrl: " https://cdn.example.com/new.png ",
+      buttonUrl: "https://example.com",
+      buttonLabel: "Saiba mais",
+    };
+    const trimmed = payload.imagemUrl.trim();
+    (consultoriaService.update as jest.Mock).mockResolvedValue({
+      id: "1",
+      ...payload,
+      imagemUrl: trimmed,
+      imagemTitulo: "new",
+      criadoEm: new Date().toISOString(),
+      atualizadoEm: new Date().toISOString(),
+    });
+
+    const res = await request(app).put("/consultoria/1").send(payload);
+    expect(res.status).toBe(200);
+    expect(res.body.imagemUrl).toBe(trimmed);
+    expect(consultoriaService.update).toHaveBeenCalledWith("1", {
+      titulo: payload.titulo,
+      descricao: payload.descricao,
+      buttonUrl: payload.buttonUrl,
+      buttonLabel: payload.buttonLabel,
+      imagemUrl: trimmed,
+      imagemTitulo: "new",
+    });
+  });
+});

--- a/src/modules/website/controllers/consultoria.controller.ts
+++ b/src/modules/website/controllers/consultoria.controller.ts
@@ -50,12 +50,12 @@ export class ConsultoriaController {
 
   static create = async (req: Request, res: Response) => {
     try {
-      const { titulo, descricao } = req.body;
+      const { titulo, descricao, buttonUrl, buttonLabel } = req.body;
       let imagemUrl = "";
       if (req.file) {
         imagemUrl = await uploadImage(req.file);
-      } else if (req.body.imagemUrl) {
-        imagemUrl = req.body.imagemUrl;
+      } else if (typeof req.body.imagemUrl === "string") {
+        imagemUrl = req.body.imagemUrl.trim();
       }
       const imagemTitulo = imagemUrl ? generateImageTitle(imagemUrl) : "";
       const consultoria = await consultoriaService.create({
@@ -63,6 +63,8 @@ export class ConsultoriaController {
         imagemTitulo,
         titulo,
         descricao,
+        buttonUrl,
+        buttonLabel,
       });
       res.status(201).json(consultoria);
     } catch (error: any) {
@@ -75,13 +77,19 @@ export class ConsultoriaController {
   static update = async (req: Request, res: Response) => {
     try {
       const { id } = req.params;
-      const { titulo, descricao } = req.body;
-      let imagemUrl = req.body.imagemUrl as string | undefined;
+      const { titulo, descricao, buttonUrl, buttonLabel } = req.body;
+      const imagemUrlRaw = req.body.imagemUrl;
+      let imagemUrl =
+        typeof imagemUrlRaw === "string" ? imagemUrlRaw.trim() : undefined;
       if (req.file) {
         imagemUrl = await uploadImage(req.file);
       }
-      const data: any = { titulo, descricao };
-      if (imagemUrl) {
+      const data: any = {};
+      if (titulo !== undefined) data.titulo = titulo;
+      if (descricao !== undefined) data.descricao = descricao;
+      if (buttonUrl !== undefined) data.buttonUrl = buttonUrl;
+      if (buttonLabel !== undefined) data.buttonLabel = buttonLabel;
+      if (imagemUrl !== undefined) {
         data.imagemUrl = imagemUrl;
         data.imagemTitulo = generateImageTitle(imagemUrl);
       }

--- a/src/modules/website/controllers/recrutamento.controller.ts
+++ b/src/modules/website/controllers/recrutamento.controller.ts
@@ -52,12 +52,12 @@ export class RecrutamentoController {
 
   static create = async (req: Request, res: Response) => {
     try {
-      const { titulo, descricao } = req.body;
+      const { titulo, descricao, buttonUrl, buttonLabel } = req.body;
       let imagemUrl = "";
       if (req.file) {
         imagemUrl = await uploadImage(req.file);
-      } else if (req.body.imagemUrl) {
-        imagemUrl = req.body.imagemUrl;
+      } else if (typeof req.body.imagemUrl === "string") {
+        imagemUrl = req.body.imagemUrl.trim();
       }
       const imagemTitulo = imagemUrl ? generateImageTitle(imagemUrl) : "";
       const recrutamento = await recrutamentoService.create({
@@ -65,6 +65,8 @@ export class RecrutamentoController {
         imagemTitulo,
         titulo,
         descricao,
+        buttonUrl,
+        buttonLabel,
       });
       res.status(201).json(recrutamento);
     } catch (error: any) {
@@ -78,13 +80,19 @@ export class RecrutamentoController {
   static update = async (req: Request, res: Response) => {
     try {
       const { id } = req.params;
-      const { titulo, descricao } = req.body;
-      let imagemUrl = req.body.imagemUrl as string | undefined;
+      const { titulo, descricao, buttonUrl, buttonLabel } = req.body;
+      const imagemUrlRaw = req.body.imagemUrl;
+      let imagemUrl =
+        typeof imagemUrlRaw === "string" ? imagemUrlRaw.trim() : undefined;
       if (req.file) {
         imagemUrl = await uploadImage(req.file);
       }
-      const data: any = { titulo, descricao };
-      if (imagemUrl) {
+      const data: any = {};
+      if (titulo !== undefined) data.titulo = titulo;
+      if (descricao !== undefined) data.descricao = descricao;
+      if (buttonUrl !== undefined) data.buttonUrl = buttonUrl;
+      if (buttonLabel !== undefined) data.buttonLabel = buttonLabel;
+      if (imagemUrl !== undefined) {
         data.imagemUrl = imagemUrl;
         data.imagemTitulo = generateImageTitle(imagemUrl);
       }

--- a/src/modules/website/routes/consultoria.ts
+++ b/src/modules/website/routes/consultoria.ts
@@ -109,7 +109,9 @@ router.get("/:id", ConsultoriaController.get);
  *            -H "Authorization: Bearer <TOKEN>" \\
  *            -F "imagem=@consultoria.png" \\
  *            -F "titulo=Novo" \\
- *            -F "descricao=Conteudo"
+ *            -F "descricao=Conteudo" \\
+ *            -F "buttonUrl=https://example.com" \\
+ *            -F "buttonLabel=Saiba mais"
 */
 router.post(
   "/",
@@ -165,7 +167,9 @@ router.post(
  *            -H "Authorization: Bearer <TOKEN>" \\
  *            -F "imagem=@consultoria.png" \\
  *            -F "titulo=Atualizado" \\
- *            -F "descricao=Atualizada"
+ *            -F "descricao=Atualizada" \\
+ *            -F "buttonUrl=https://example.com" \\
+ *            -F "buttonLabel=Saiba mais"
 */
 router.put(
   "/:id",

--- a/src/modules/website/routes/recrutamento.ts
+++ b/src/modules/website/routes/recrutamento.ts
@@ -109,7 +109,9 @@ router.get("/:id", RecrutamentoController.get);
  *            -H "Authorization: Bearer <TOKEN>" \\
  *            -F "imagem=@recrutamento.png" \\
  *            -F "titulo=Novo" \\
- *            -F "descricao=Conteudo"
+ *            -F "descricao=Conteudo" \\
+ *            -F "buttonUrl=https://example.com" \\
+ *            -F "buttonLabel=Saiba mais"
 */
 router.post(
   "/",
@@ -165,7 +167,9 @@ router.post(
  *            -H "Authorization: Bearer <TOKEN>" \\
  *            -F "imagem=@recrutamento.png" \\
  *            -F "titulo=Atualizado" \\
- *            -F "descricao=Atualizada"
+ *            -F "descricao=Atualizada" \\
+ *            -F "buttonUrl=https://example.com" \\
+ *            -F "buttonLabel=Saiba mais"
 */
 router.put(
   "/:id",


### PR DESCRIPTION
## Summary
- add `buttonUrl` and `buttonLabel` to WebsiteConsultoria and WebsiteRecrutamento models
- handle button fields and normalized `imagemUrl` in consultoria and recrutamento controllers
- document new fields in Swagger and update examples
- add tests for ConsultoriaController to ensure trimming and button handling

## Testing
- `pnpm run prisma:generate`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68af71f728f88325b2de6018fc26fafc