### PR TITLE
Add keep-alive ping to prevent Render sleep

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,14 @@ NODE_ENV=development
 PORT=3000
 
 # =============================================
+# KEEP ALIVE (OPCIONAL)
+# =============================================
+# URL que será pingada periodicamente para manter a instância ativa
+KEEP_ALIVE_URL=
+# Intervalo entre pings em milissegundos (padrão: 600000 = 10min)
+KEEP_ALIVE_INTERVAL=600000
+
+# =============================================
 # BANCO DE DADOS (OBRIGATÓRIO)
 # =============================================
 # URL para conexões da aplicação (com pooler do Supabase)

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import { serverConfig } from "./config/env";
 import { appRoutes } from "./routes";
 import { startExpiredUserCleanupJob } from "./modules/usuarios/services/user-cleanup-service";
 import { setupSwagger } from "./config/swagger";
+import { startKeepAlive } from "./utils/keep-alive";
 
 /**
  * Aplicação principal - Advance+ API
@@ -240,6 +241,9 @@ const server = app.listen(serverConfig.port, () => {
     `   curl http://localhost:${serverConfig.port}/api/v1/brevo/health`
   );
   console.log("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+
+  // Inicia keep-alive para evitar hibernação da instância
+  startKeepAlive();
 });
 
 // =============================================

--- a/src/utils/keep-alive.ts
+++ b/src/utils/keep-alive.ts
@@ -1,0 +1,28 @@
+import { serverConfig } from "../config/env";
+
+/**
+ * Inicia um ping periódico para manter a instância ativa.
+ * Útil em plataformas que hibernam após inatividade (ex: Render free tier).
+ */
+export function startKeepAlive(): void {
+  const url =
+    process.env.KEEP_ALIVE_URL ||
+    process.env.RENDER_EXTERNAL_URL ||
+    `http://localhost:${serverConfig.port}/health`;
+
+  const interval = parseInt(process.env.KEEP_ALIVE_INTERVAL || "600000", 10); // 10min
+
+  if (!url || interval <= 0) {
+    console.warn("⚠️ Keep-alive desativado: URL ou intervalo inválido");
+    return;
+  }
+
+  setInterval(async () => {
+    try {
+      await fetch(url);
+      console.log(`✅ Keep-alive ping para ${url}`);
+    } catch (error) {
+      console.error(`❌ Erro no keep-alive para ${url}:`, error);
+    }
+  }, interval);
+}


### PR DESCRIPTION
## Summary
- add keep-alive utility to periodically ping API
- call keep-alive on server start
- document KEEP_ALIVE environment variables

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b38e694aec8325a13738a93619d38c