### PR TITLE
Allow slider update and removal by slider ID

### DIFF
--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -1123,7 +1123,8 @@ const options: Options = {
         WebsiteSlider: {
           type: "object",
           properties: {
-            id: { type: "string", example: "slider-uuid" },
+            id: { type: "string", example: "ordem-uuid" },
+            sliderId: { type: "string", example: "slider-uuid" },
             sliderName: { type: "string", example: "Banner Principal" },
             imagemUrl: {
               type: "string",
@@ -1142,7 +1143,6 @@ const options: Options = {
               example: "PUBLICADO",
             },
             ordem: { type: "integer", example: 1 },
-            ordemId: { type: "string", example: "ordem-uuid" },
             ordemCriadoEm: {
               type: "string",
               format: "date-time",

--- a/src/modules/website/controllers/slider.controller.ts
+++ b/src/modules/website/controllers/slider.controller.ts
@@ -3,15 +3,21 @@ import path from "path";
 import { supabase } from "../../superbase/client";
 import { sliderService } from "../services/slider.service";
 
+/**
+ * Mapeia uma ordem de slider para o formato exposto na API.
+ *
+ * `id`        → identificador da ordem do slider
+ * `sliderId`  → identificador do slider propriamente dito
+ */
 function mapSlider(ordem: any) {
   return {
-    id: ordem.slider.id,
+    id: ordem.id,
+    sliderId: ordem.slider.id,
     sliderName: ordem.slider.sliderName,
     imagemUrl: ordem.slider.imagemUrl,
     link: ordem.slider.link,
     criadoEm: ordem.slider.criadoEm,
     atualizadoEm: ordem.slider.atualizadoEm,
-    ordemId: ordem.id,
     ordem: ordem.ordem,
     orientacao: ordem.orientacao,
     status: ordem.status,
@@ -42,8 +48,8 @@ export class SliderController {
 
   static get = async (req: Request, res: Response) => {
     try {
-      const { id } = req.params;
-      const ordem = await sliderService.get(id);
+      const { id: ordemId } = req.params;
+      const ordem = await sliderService.get(ordemId);
       if (!ordem) {
         return res.status(404).json({ message: "Slider não encontrado" });
       }
@@ -89,7 +95,7 @@ export class SliderController {
 
   static update = async (req: Request, res: Response) => {
     try {
-      const { id } = req.params;
+      const { id: sliderId } = req.params;
       const { sliderName, link, orientacao, ordem } = req.body;
       let { status } = req.body as any;
       if (typeof status === "boolean") {
@@ -112,7 +118,7 @@ export class SliderController {
       if (imagemUrl) {
         data.imagemUrl = imagemUrl;
       }
-      const ordemResult = await sliderService.update(id, data);
+      const ordemResult = await sliderService.update(sliderId, data);
       res.json(mapSlider(ordemResult));
     } catch (error: any) {
       res.status(500).json({
@@ -124,8 +130,8 @@ export class SliderController {
 
   static remove = async (req: Request, res: Response) => {
     try {
-      const { id } = req.params;
-      await sliderService.remove(id);
+      const { id: sliderId } = req.params;
+      await sliderService.remove(sliderId);
       res.status(204).send();
     } catch (error: any) {
       res.status(500).json({

--- a/src/modules/website/routes/slider.ts
+++ b/src/modules/website/routes/slider.ts
@@ -39,11 +39,12 @@ router.get("/", SliderController.list);
  * @openapi
  * /api/v1/website/slider/{id}:
  *   get:
- *     summary: Obter slider por ID
+ *     summary: Obter slider por ID da ordem
  *     tags: [Website - Slider]
  *     parameters:
  *       - in: path
  *         name: id
+ *         description: ID da ordem do slider
  *         required: true
  *         schema:
  *           type: string
@@ -70,7 +71,7 @@ router.get("/", SliderController.list);
  *       - lang: cURL
  *         label: Exemplo
  *         source: |
- *           curl -X GET "http://localhost:3000/api/v1/website/slider/{id}"
+ *           curl -X GET "http://localhost:3000/api/v1/website/slider/{ordemId}"
 */
 router.get("/:id", SliderController.get);
 
@@ -126,13 +127,14 @@ router.post(
  * /api/v1/website/slider/{id}:
  *   put:
  *     summary: Atualizar slider
- *     description: Atualiza dados do slider e permite alterar a ordem dos banners, reordenando automaticamente os demais. Apenas campos enviados serão modificados. O campo `status` aceita booleano (true = PUBLICADO, false = RASCUNHO) ou string.
+ *     description: Atualiza dados do slider utilizando o ID do slider. Permite alterar a ordem dos banners, reordenando automaticamente os demais. Apenas campos enviados serão modificados. O campo `status` aceita booleano (true = PUBLICADO, false = RASCUNHO) ou string.
  *     tags: [Website - Slider]
  *     security:
  *       - bearerAuth: []
  *     parameters:
  *       - in: path
  *         name: id
+ *         description: ID do slider
  *         required: true
  *         schema:
  *           type: string
@@ -165,7 +167,7 @@ router.post(
  *       - lang: cURL
  *         label: Exemplo
  *         source: |
- *           curl -X PUT "http://localhost:3000/api/v1/website/slider/{id}" \\
+ *           curl -X PUT "http://localhost:3000/api/v1/website/slider/{sliderId}" \\
  *            -H "Authorization: Bearer <TOKEN>" \\
  *            -F "imagem=@slide.png" \\
  *            -F "sliderName=Novo Slider" \\
@@ -192,6 +194,7 @@ router.put(
  *     parameters:
  *       - in: path
  *         name: id
+ *         description: ID do slider
  *         required: true
  *         schema:
  *           type: string
@@ -214,7 +217,7 @@ router.put(
  *       - lang: cURL
  *         label: Exemplo
  *         source: |
- *           curl -X DELETE "http://localhost:3000/api/v1/website/slider/{id}" \\
+ *           curl -X DELETE "http://localhost:3000/api/v1/website/slider/{sliderId}" \\
  *            -H "Authorization: Bearer <TOKEN>"
 */
 router.delete(


### PR DESCRIPTION
## Summary
- allow updating and removing sliders using the slider's ID
- expose both order and slider IDs in slider API responses
- clarify Swagger docs and routes about ID usage

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5d5da78e08325b37b2f108b8269b8