### PR TITLE
feat: allow slider reorder

### DIFF
--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -1195,11 +1195,11 @@ const options: Options = {
               },
             },
           },
-          WebsiteSliderUpdateInput: {
-            type: "object",
-            description: "Envie apenas os campos que deseja atualizar.",
-            properties: {
-              imagem: { type: "string", format: "binary" },
+        WebsiteSliderUpdateInput: {
+          type: "object",
+          description: "Envie apenas os campos que deseja atualizar.",
+          properties: {
+            imagem: { type: "string", format: "binary" },
               imagemUrl: {
                 type: "string",
                 format: "uri",
@@ -1230,6 +1230,17 @@ const options: Options = {
                 description:
                   "Nova posição do slider; ao mudar este valor os demais serão reordenados automaticamente",
               },
+          },
+        },
+        WebsiteSliderReorderInput: {
+          type: "object",
+          required: ["ordem"],
+          properties: {
+            ordem: {
+              type: "integer",
+              example: 2,
+              description: "Nova posição do slider",
+            },
           },
         },
         WebsiteSobre: {

--- a/src/modules/website/controllers/slider.controller.ts
+++ b/src/modules/website/controllers/slider.controller.ts
@@ -128,6 +128,23 @@ export class SliderController {
     }
   };
 
+  static reorder = async (req: Request, res: Response) => {
+    try {
+      const { id: ordemId } = req.params;
+      const { ordem } = req.body;
+      const ordemResult = await sliderService.reorder(
+        ordemId,
+        parseInt(ordem, 10)
+      );
+      res.json(mapSlider(ordemResult));
+    } catch (error: any) {
+      res.status(500).json({
+        message: "Erro ao reordenar slider",
+        error: error.message,
+      });
+    }
+  };
+
   static remove = async (req: Request, res: Response) => {
     try {
       const { id: sliderId } = req.params;

--- a/src/modules/website/routes/slider.ts
+++ b/src/modules/website/routes/slider.ts
@@ -185,6 +185,62 @@ router.put(
 
 /**
  * @openapi
+ * /api/v1/website/slider/{id}/reorder:
+ *   put:
+ *     summary: Reordenar slider
+ *     description: Altera a posição do slider utilizando o ID da ordem.
+ *     tags: [Website - Slider]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         description: ID da ordem do slider
+ *         required: true
+ *         schema:
+ *           type: string
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/WebsiteSliderReorderInput'
+ *     responses:
+ *       200:
+ *         description: Slider reordenado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/WebsiteSlider'
+ *       404:
+ *         description: Slider não encontrado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X PUT "http://localhost:3000/api/v1/website/slider/{ordemId}/reorder" \\
+ *            -H "Authorization: Bearer <TOKEN>" \\
+ *            -H "Content-Type: application/json" \\
+ *            -d '{"ordem":2}'
+ */
+router.put(
+  "/:id/reorder",
+  supabaseAuthMiddleware(["ADMIN", "MODERADOR"]),
+  SliderController.reorder
+);
+
+/**
+ * @openapi
  * /api/v1/website/slider/{id}:
  *   delete:
  *     summary: Remover slider


### PR DESCRIPTION
## Summary
- add service method to reorder sliders and update affected items
- expose reorder operation via controller and route with Swagger docs
- document reorder request schema in API docs

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68b6044eaf908325b515df47f1686010