### PR TITLE
fix: avoid slider reorder conflicts

### DIFF
--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -1239,7 +1239,8 @@ const options: Options = {
             ordem: {
               type: "integer",
               example: 2,
-              description: "Nova posição do slider",
+              description:
+                "Nova posição desejada do slider. Se já houver outro na posição, os demais serão reordenados automaticamente",
             },
           },
         },

--- a/src/modules/website/__tests__/slider.service.test.ts
+++ b/src/modules/website/__tests__/slider.service.test.ts
@@ -1,0 +1,49 @@
+jest.mock("../../../config/prisma", () => ({
+  prisma: { $transaction: jest.fn() },
+}));
+
+import { sliderService } from "../services/slider.service";
+import { prisma } from "../../../config/prisma";
+
+describe("sliderService.reorder", () => {
+  it("reorders when moving to an occupied position", async () => {
+    const items = [
+      { id: "1", websiteSliderId: "s1", ordem: 1, orientacao: "DESKTOP", slider: { id: "s1" } },
+      { id: "2", websiteSliderId: "s2", ordem: 2, orientacao: "DESKTOP", slider: { id: "s2" } },
+      { id: "3", websiteSliderId: "s3", ordem: 3, orientacao: "DESKTOP", slider: { id: "s3" } },
+    ];
+
+    (prisma.$transaction as jest.Mock).mockImplementation(async (fn) => {
+      const tx = {
+        websiteSliderOrdem: {
+          findUnique: ({ where: { id } }: any) => items.find((i) => i.id === id),
+          update: ({ where: { id }, data }: any) => {
+            const item = items.find((i) => i.id === id)!;
+            Object.assign(item, data);
+            return { ...item, slider: item.slider };
+          },
+          updateMany: ({ where, data }: any) => {
+            items.forEach((item) => {
+              if (item.orientacao !== where.orientacao) return;
+              const cond = where.ordem || {};
+              const gt = cond.gt ?? -Infinity;
+              const gte = cond.gte ?? -Infinity;
+              const lt = cond.lt ?? Infinity;
+              const lte = cond.lte ?? Infinity;
+              if (item.ordem > gt && item.ordem >= gte && item.ordem < lt && item.ordem <= lte) {
+                if (data.ordem?.decrement) item.ordem -= data.ordem.decrement;
+                if (data.ordem?.increment) item.ordem += data.ordem.increment;
+              }
+            });
+          },
+        },
+      } as any;
+      return fn(tx);
+    });
+
+    const result = await sliderService.reorder("1", 2);
+    expect(result.ordem).toBe(2);
+    expect(items.find((i) => i.id === "2")?.ordem).toBe(1);
+    expect(items.find((i) => i.id === "3")?.ordem).toBe(3);
+  });
+});

--- a/src/modules/website/routes/slider.ts
+++ b/src/modules/website/routes/slider.ts
@@ -188,7 +188,7 @@ router.put(
  * /api/v1/website/slider/{id}/reorder:
  *   put:
  *     summary: Reordenar slider
- *     description: Altera a posição do slider utilizando o ID da ordem.
+ *     description: Altera a posição do slider utilizando o ID da ordem. Caso a nova posição esteja ocupada, os demais sliders serão ajustados automaticamente.
  *     tags: [Website - Slider]
  *     security:
  *       - bearerAuth: []

--- a/src/modules/website/services/slider.service.ts
+++ b/src/modules/website/services/slider.service.ts
@@ -138,6 +138,11 @@ export const sliderService = {
       if (!current) throw new Error("Slider não encontrado");
 
       if (novaOrdem !== current.ordem) {
+        await tx.websiteSliderOrdem.update({
+          where: { id: ordemId },
+          data: { ordem: 0 },
+        });
+
         if (novaOrdem > current.ordem) {
           await tx.websiteSliderOrdem.updateMany({
             where: {


### PR DESCRIPTION
## Summary
- prevent unique constraint conflicts by reserving temporary order during slider reorder
- document reorder behavior in swagger
- cover slider reorder collision with unit test

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68b612fb7bbc8325b1654a90d41715ef