### PR TITLE
feat: add banner order table with status

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -504,7 +504,7 @@ model WebsiteSliderOrdem {
   websiteSliderId String             @unique
   ordem           Int
   orientacao      SliderOrientation
-  status          SliderStatus       @default(RASCUNHO)
+  status          WebsiteStatus      @default(RASCUNHO)
   criadoEm        DateTime           @default(now())
 
   slider          WebsiteSlider      @relation(fields: [websiteSliderId], references: [id], onDelete: Cascade)
@@ -517,9 +517,22 @@ model WebsiteBanner {
   imagemUrl    String
   imagemTitulo String
   link         String?
-  ordem        Int
   criadoEm     DateTime @default(now())
   atualizadoEm DateTime @updatedAt
+
+  ordem        WebsiteBannerOrdem?
+}
+
+model WebsiteBannerOrdem {
+  id              String       @id @default(uuid())
+  websiteBannerId String       @unique
+  ordem           Int
+  status          WebsiteStatus @default(RASCUNHO)
+  criadoEm        DateTime     @default(now())
+
+  banner          WebsiteBanner @relation(fields: [websiteBannerId], references: [id], onDelete: Cascade)
+
+  @@unique([ordem])
 }
 
 model WebsiteLogoEnterprise {
@@ -746,7 +759,7 @@ enum SliderOrientation {
   TABLET_MOBILE
 }
 
-enum SliderStatus {
+enum WebsiteStatus {
   PUBLICADO
   RASCUNHO
 }

--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -986,30 +986,66 @@ const options: Options = {
             status: { type: "string", example: "operational" },
           },
         },
+        WebsiteStatus: {
+          type: "string",
+          enum: ["PUBLICADO", "RASCUNHO"],
+          example: "PUBLICADO",
+        },
         WebsiteBanner: {
           type: "object",
           properties: {
-            id: { type: "string", example: "banner-uuid" },
+            id: {
+              type: "string",
+              description: "ID da ordem do banner",
+              example: "ordem-uuid",
+            },
+            bannerId: {
+              type: "string",
+              description: "ID do banner associado",
+              example: "banner-uuid",
+            },
             imagemUrl: {
               type: "string",
               format: "uri",
+              description: "URL pública da imagem",
               example: "https://cdn.example.com/banner.jpg",
             },
-            imagemTitulo: { type: "string", example: "banner" },
+            imagemTitulo: {
+              type: "string",
+              description: "Título da imagem gerado a partir do arquivo",
+              example: "banner",
+            },
             link: {
               type: "string",
+              description: "URL opcional de redirecionamento",
               nullable: true,
               example: "https://example.com",
             },
-            ordem: { type: "integer", example: 1 },
+            status: {
+              $ref: '#/components/schemas/WebsiteStatus',
+              description: "Estado de publicação",
+            },
+            ordem: {
+              type: "integer",
+              description: "Posição do banner",
+              example: 1,
+            },
+            ordemCriadoEm: {
+              type: "string",
+              format: "date-time",
+              description: "Data de criação da ordem",
+              example: "2024-01-01T12:00:00Z",
+            },
             criadoEm: {
               type: "string",
               format: "date-time",
+              description: "Data de criação do banner",
               example: "2024-01-01T12:00:00Z",
             },
             atualizadoEm: {
               type: "string",
               format: "date-time",
+              description: "Data da última atualização",
               example: "2024-01-01T12:00:00Z",
             },
           },
@@ -1033,10 +1069,14 @@ const options: Options = {
               description: "Link de redirecionamento",
               example: "https://example.com",
             },
-            ordem: {
-              type: "integer",
-              description: "Ordem de exibição",
-              example: 1,
+            status: {
+              description:
+                "Estado de publicação. Aceita boolean (true = PUBLICADO, false = RASCUNHO) ou string.",
+              oneOf: [
+                { $ref: '#/components/schemas/WebsiteStatus' },
+                { type: "boolean" },
+              ],
+              example: true,
             },
           },
         },
@@ -1050,7 +1090,33 @@ const options: Options = {
               example: "https://cdn.example.com/banner.jpg",
             },
             link: { type: "string", example: "https://example.com" },
-            ordem: { type: "integer", example: 2 },
+            status: {
+              description:
+                "Estado de publicação. Aceita boolean (true = PUBLICADO, false = RASCUNHO) ou string.",
+              oneOf: [
+                { $ref: '#/components/schemas/WebsiteStatus' },
+                { type: "boolean" },
+              ],
+              example: false,
+            },
+            ordem: {
+              type: "integer",
+              example: 2,
+              description:
+                "Nova posição do banner; ao mudar este valor os demais serão reordenados automaticamente",
+            },
+          },
+        },
+        WebsiteBannerReorderInput: {
+          type: "object",
+          required: ["ordem"],
+          properties: {
+            ordem: {
+              type: "integer",
+              example: 2,
+              description:
+                "Nova posição desejada do banner. Se já houver outro na posição, os demais serão reordenados automaticamente",
+            },
           },
         },
         WebsiteLogoEnterprise: {
@@ -1123,48 +1189,74 @@ const options: Options = {
         WebsiteSlider: {
           type: "object",
           properties: {
-            id: { type: "string", example: "ordem-uuid" },
-            sliderId: { type: "string", example: "slider-uuid" },
-            sliderName: { type: "string", example: "Banner Principal" },
+            id: {
+              type: "string",
+              description: "ID da ordem do slider",
+              example: "ordem-uuid",
+            },
+            sliderId: {
+              type: "string",
+              description: "ID do slider associado",
+              example: "slider-uuid",
+            },
+            sliderName: {
+              type: "string",
+              description: "Nome identificador do slider",
+              example: "Banner Principal",
+            },
             imagemUrl: {
               type: "string",
               format: "uri",
+              description: "URL pública da imagem",
               example: "https://cdn.example.com/slide.jpg",
             },
-            link: { type: "string", nullable: true, example: "https://example.com" },
+            link: {
+              type: "string",
+              description: "URL opcional de redirecionamento",
+              nullable: true,
+              example: "https://example.com",
+            },
             orientacao: {
               type: "string",
               enum: ["DESKTOP", "TABLET_MOBILE"],
+              description: "Orientação em que o slider será exibido",
               example: "DESKTOP",
             },
             status: {
-              type: "string",
-              enum: ["PUBLICADO", "RASCUNHO"],
-              example: "PUBLICADO",
+              $ref: '#/components/schemas/WebsiteStatus',
+              description: "Estado de publicação",
             },
-            ordem: { type: "integer", example: 1 },
+            ordem: {
+              type: "integer",
+              description: "Posição do slider",
+              example: 1,
+            },
             ordemCriadoEm: {
               type: "string",
               format: "date-time",
+              description: "Data de criação da ordem",
               example: "2024-01-01T12:00:00Z",
             },
             criadoEm: {
               type: "string",
               format: "date-time",
+              description: "Data de criação do slider",
               example: "2024-01-01T12:00:00Z",
             },
             atualizadoEm: {
               type: "string",
               format: "date-time",
+              description: "Data da última atualização",
               example: "2024-01-01T12:00:00Z",
             },
           },
         },
-          WebsiteSliderCreateInput: {
-            type: "object",
-            properties: {
-              imagem: {
-                type: "string",
+        WebsiteSliderCreateInput: {
+          type: "object",
+          required: ["sliderName", "orientacao"],
+          properties: {
+            imagem: {
+              type: "string",
               format: "binary",
               description: "Arquivo de imagem do slider",
             },
@@ -1174,62 +1266,79 @@ const options: Options = {
               description: "URL alternativa da imagem",
               example: "https://cdn.example.com/slide.jpg",
             },
-            sliderName: { type: "string", example: "Banner Principal" },
-            link: { type: "string", example: "https://example.com" },
-              orientacao: {
-                type: "string",
-                enum: ["DESKTOP", "TABLET_MOBILE"],
-                example: "DESKTOP",
-              },
-              status: {
-                description:
-                  "Estado de publicação. Aceita boolean (true = PUBLICADO, false = RASCUNHO) ou string.",
-                oneOf: [
-                  {
-                    type: "string",
-                    enum: ["PUBLICADO", "RASCUNHO"],
-                  },
-                  { type: "boolean" },
-                ],
-                example: true,
-              },
+            sliderName: {
+              type: "string",
+              description: "Nome identificador do slider",
+              example: "Banner Principal",
+            },
+            link: {
+              type: "string",
+              description: "URL opcional de redirecionamento",
+              example: "https://example.com",
+            },
+            orientacao: {
+              type: "string",
+              enum: ["DESKTOP", "TABLET_MOBILE"],
+              description: "Orientação em que o slider será exibido",
+              example: "DESKTOP",
+            },
+            status: {
+              description:
+                "Estado de publicação. Aceita boolean (true = PUBLICADO, false = RASCUNHO) ou string.",
+              oneOf: [
+                { $ref: '#/components/schemas/WebsiteStatus' },
+                { type: "boolean" },
+              ],
+              example: true,
             },
           },
+        },
         WebsiteSliderUpdateInput: {
           type: "object",
           description: "Envie apenas os campos que deseja atualizar.",
           properties: {
-            imagem: { type: "string", format: "binary" },
-              imagemUrl: {
-                type: "string",
-                format: "uri",
-                example: "https://cdn.example.com/slide.jpg",
-              },
-              sliderName: { type: "string", example: "Banner Atualizado" },
-              link: { type: "string", example: "https://example.com" },
-              orientacao: {
-                type: "string",
-                enum: ["DESKTOP", "TABLET_MOBILE"],
-                example: "TABLET_MOBILE",
-              },
-              status: {
-                description:
-                  "Estado de publicação. Aceita boolean (true = PUBLICADO, false = RASCUNHO) ou string.",
-                oneOf: [
-                  {
-                    type: "string",
-                    enum: ["PUBLICADO", "RASCUNHO"],
-                  },
-                  { type: "boolean" },
-                ],
-                example: false,
-              },
-              ordem: {
-                type: "integer",
-                example: 2,
-                description:
-                  "Nova posição do slider; ao mudar este valor os demais serão reordenados automaticamente",
-              },
+            imagem: {
+              type: "string",
+              format: "binary",
+              description: "Arquivo de imagem do slider",
+            },
+            imagemUrl: {
+              type: "string",
+              format: "uri",
+              description: "URL alternativa da imagem",
+              example: "https://cdn.example.com/slide.jpg",
+            },
+            sliderName: {
+              type: "string",
+              description: "Nome identificador do slider",
+              example: "Banner Atualizado",
+            },
+            link: {
+              type: "string",
+              description: "URL opcional de redirecionamento",
+              example: "https://example.com",
+            },
+            orientacao: {
+              type: "string",
+              enum: ["DESKTOP", "TABLET_MOBILE"],
+              description: "Orientação em que o slider será exibido",
+              example: "TABLET_MOBILE",
+            },
+            status: {
+              description:
+                "Estado de publicação. Aceita boolean (true = PUBLICADO, false = RASCUNHO) ou string.",
+              oneOf: [
+                { $ref: '#/components/schemas/WebsiteStatus' },
+                { type: "boolean" },
+              ],
+              example: false,
+            },
+            ordem: {
+              type: "integer",
+              description:
+                "Nova posição do slider; ao mudar este valor os demais serão reordenados automaticamente",
+              example: 2,
+            },
           },
         },
         WebsiteSliderReorderInput: {

--- a/src/modules/website/__tests__/banner.service.test.ts
+++ b/src/modules/website/__tests__/banner.service.test.ts
@@ -1,0 +1,49 @@
+jest.mock("../../../config/prisma", () => ({
+  prisma: { $transaction: jest.fn() },
+}));
+
+import { bannerService } from "../services/banner.service";
+import { prisma } from "../../../config/prisma";
+
+describe("bannerService.reorder", () => {
+  it("reorders when moving to an occupied position", async () => {
+    const items = [
+      { id: "ord1", ordem: 1, banner: {} },
+      { id: "ord2", ordem: 2, banner: {} },
+      { id: "ord3", ordem: 3, banner: {} },
+    ];
+
+    (prisma.$transaction as jest.Mock).mockImplementation(async (fn) => {
+      const tx = {
+        websiteBannerOrdem: {
+          findUnique: ({ where: { id } }: any) => items.find((i) => i.id === id),
+          update: ({ where: { id }, data }: any) => {
+            const item = items.find((i) => i.id === id)!;
+            Object.assign(item, data);
+            return { ...item };
+          },
+          updateMany: ({ where, data }: any) => {
+            items.forEach((item) => {
+              const cond = where.ordem || {};
+              const gt = cond.gt ?? -Infinity;
+              const gte = cond.gte ?? -Infinity;
+              const lt = cond.lt ?? Infinity;
+              const lte = cond.lte ?? Infinity;
+              if (item.ordem > gt && item.ordem >= gte && item.ordem < lt && item.ordem <= lte) {
+                if (data.ordem?.decrement) item.ordem -= data.ordem.decrement;
+                if (data.ordem?.increment) item.ordem += data.ordem.increment;
+              }
+            });
+          },
+        },
+      } as any;
+      return fn(tx);
+    });
+
+    const result = await bannerService.reorder("ord1", 2);
+    expect(result.ordem).toBe(2);
+    expect(items.find((i) => i.id === "ord2")?.ordem).toBe(1);
+    expect(items.find((i) => i.id === "ord3")?.ordem).toBe(3);
+  });
+});
+

--- a/src/modules/website/routes/banner.ts
+++ b/src/modules/website/routes/banner.ts
@@ -39,11 +39,12 @@ router.get("/", BannerController.list);
  * @openapi
  * /api/v1/website/banner/{id}:
  *   get:
- *     summary: Obter banner por ID
+ *     summary: Obter banner por ID da ordem
  *     tags: [Website - Banner]
  *     parameters:
  *       - in: path
  *         name: id
+ *         description: ID da ordem do banner
  *         required: true
  *         schema:
  *           type: string
@@ -70,7 +71,7 @@ router.get("/", BannerController.list);
  *       - lang: cURL
  *         label: Exemplo
  *         source: |
- *           curl -X GET "http://localhost:3000/api/v1/website/banner/{id}"
+ *           curl -X GET "http://localhost:3000/api/v1/website/banner/{ordemId}"
  */
 router.get("/:id", BannerController.get);
 
@@ -109,7 +110,7 @@ router.get("/:id", BannerController.get);
  *            -H "Authorization: Bearer <TOKEN>" \\
  *            -F "imagem=@banner.png" \\
  *            -F "link=https://example.com" \\
- *            -F "ordem=1"
+ *            -F "status=true"
  */
 router.post(
   "/",
@@ -129,6 +130,7 @@ router.post(
  *     parameters:
  *       - in: path
  *         name: id
+ *         description: ID do banner
  *         required: true
  *         schema:
  *           type: string
@@ -161,9 +163,10 @@ router.post(
  *       - lang: cURL
  *         label: Exemplo
  *         source: |
- *           curl -X PUT "http://localhost:3000/api/v1/website/banner/{id}" \\
+ *           curl -X PUT "http://localhost:3000/api/v1/website/banner/{bannerId}" \\
  *            -H "Authorization: Bearer <TOKEN>" \\
  *            -F "link=https://example.com" \\
+ *            -F "status=false" \\
  *            -F "ordem=2"
  */
 router.put(
@@ -171,6 +174,62 @@ router.put(
   supabaseAuthMiddleware(["ADMIN", "MODERADOR"]),
   upload.single("imagem"),
   BannerController.update
+);
+
+/**
+ * @openapi
+ * /api/v1/website/banner/{id}/reorder:
+ *   put:
+ *     summary: Reordenar banner
+ *     description: Altera a posição do banner utilizando o ID da ordem. Caso a nova posição esteja ocupada, os demais banners serão ajustados automaticamente.
+ *     tags: [Website - Banner]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         description: ID da ordem do banner
+ *         required: true
+ *         schema:
+ *           type: string
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/WebsiteBannerReorderInput'
+ *     responses:
+ *       200:
+ *         description: Banner reordenado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/WebsiteBanner'
+ *       404:
+ *         description: Banner não encontrado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X PUT "http://localhost:3000/api/v1/website/banner/{ordemId}/reorder" \\
+ *            -H "Authorization: Bearer <TOKEN>" \\
+ *            -H "Content-Type: application/json" \\
+ *            -d '{"ordem":2}'
+ */
+router.put(
+  "/:id/reorder",
+  supabaseAuthMiddleware(["ADMIN", "MODERADOR"]),
+  BannerController.reorder
 );
 
 /**
@@ -206,7 +265,7 @@ router.put(
  *       - lang: cURL
  *         label: Exemplo
  *         source: |
- *           curl -X DELETE "http://localhost:3000/api/v1/website/banner/{id}" \\
+ *           curl -X DELETE "http://localhost:3000/api/v1/website/banner/{bannerId}" \\
  *            -H "Authorization: Bearer <TOKEN>"
  */
 router.delete(

--- a/src/modules/website/services/banner.service.ts
+++ b/src/modules/website/services/banner.service.ts
@@ -1,16 +1,147 @@
 import { prisma } from "../../../config/prisma";
-import { WebsiteBanner } from "@prisma/client";
+import { WebsiteStatus } from "@prisma/client";
 
 export const bannerService = {
   list: () =>
-    prisma.websiteBanner.findMany({
+    prisma.websiteBannerOrdem.findMany({
+      include: { banner: true },
       orderBy: { ordem: "asc" },
     }),
-  get: (id: string) => prisma.websiteBanner.findUnique({ where: { id } }),
-  create: (
-    data: Omit<WebsiteBanner, "id" | "criadoEm" | "atualizadoEm">
-  ) => prisma.websiteBanner.create({ data }),
-  update: (id: string, data: Partial<WebsiteBanner>) =>
-    prisma.websiteBanner.update({ where: { id }, data }),
-  remove: (id: string) => prisma.websiteBanner.delete({ where: { id } }),
+
+  get: (id: string) =>
+    prisma.websiteBannerOrdem.findUnique({
+      where: { id },
+      include: { banner: true },
+    }),
+
+  create: (data: {
+    imagemUrl: string;
+    imagemTitulo: string;
+    link?: string;
+    status?: WebsiteStatus;
+  }) =>
+    prisma.$transaction(async (tx) => {
+      const max = await tx.websiteBannerOrdem.aggregate({ _max: { ordem: true } });
+      const ordem = (max._max.ordem ?? 0) + 1;
+
+      return tx.websiteBannerOrdem.create({
+        data: {
+          ordem,
+          status: data.status ?? "RASCUNHO",
+          banner: {
+            create: {
+              imagemUrl: data.imagemUrl,
+              imagemTitulo: data.imagemTitulo,
+              link: data.link,
+            },
+          },
+        },
+        include: { banner: true },
+      });
+    }),
+
+  update: (
+    bannerId: string,
+    data: {
+      imagemUrl?: string;
+      imagemTitulo?: string;
+      link?: string;
+      status?: WebsiteStatus;
+      ordem?: number;
+    }
+  ) =>
+    prisma.$transaction(async (tx) => {
+      const current = await tx.websiteBannerOrdem.findUnique({
+        where: { websiteBannerId: bannerId },
+      });
+      if (!current) throw new Error("Banner não encontrado");
+
+      let ordem = data.ordem ?? current.ordem;
+      if (data.ordem !== undefined && data.ordem !== current.ordem) {
+        if (data.ordem > current.ordem) {
+          await tx.websiteBannerOrdem.updateMany({
+            where: { ordem: { gt: current.ordem, lte: data.ordem } },
+            data: { ordem: { decrement: 1 } },
+          });
+        } else {
+          await tx.websiteBannerOrdem.updateMany({
+            where: { ordem: { gte: data.ordem, lt: current.ordem } },
+            data: { ordem: { increment: 1 } },
+          });
+        }
+        ordem = data.ordem;
+      }
+
+      return tx.websiteBannerOrdem.update({
+        where: { id: current.id },
+        data: {
+          ordem,
+          status: data.status,
+          banner:
+            data.imagemUrl !== undefined ||
+            data.imagemTitulo !== undefined ||
+            data.link !== undefined
+              ? {
+                  update: {
+                    imagemUrl: data.imagemUrl,
+                    imagemTitulo: data.imagemTitulo,
+                    link: data.link,
+                  },
+                }
+              : undefined,
+        },
+        include: { banner: true },
+      });
+    }),
+
+  reorder: (ordemId: string, novaOrdem: number) =>
+    prisma.$transaction(async (tx) => {
+      const current = await tx.websiteBannerOrdem.findUnique({
+        where: { id: ordemId },
+        include: { banner: true },
+      });
+      if (!current) throw new Error("Banner não encontrado");
+
+      if (novaOrdem !== current.ordem) {
+        await tx.websiteBannerOrdem.update({
+          where: { id: ordemId },
+          data: { ordem: 0 },
+        });
+
+        if (novaOrdem > current.ordem) {
+          await tx.websiteBannerOrdem.updateMany({
+            where: { ordem: { gt: current.ordem, lte: novaOrdem } },
+            data: { ordem: { decrement: 1 } },
+          });
+        } else {
+          await tx.websiteBannerOrdem.updateMany({
+            where: { ordem: { gte: novaOrdem, lt: current.ordem } },
+            data: { ordem: { increment: 1 } },
+          });
+        }
+
+        return tx.websiteBannerOrdem.update({
+          where: { id: ordemId },
+          data: { ordem: novaOrdem },
+          include: { banner: true },
+        });
+      }
+
+      return current;
+    }),
+
+  remove: (bannerId: string) =>
+    prisma.$transaction(async (tx) => {
+      const ordem = await tx.websiteBannerOrdem.findUnique({
+        where: { websiteBannerId: bannerId },
+      });
+      if (!ordem) return;
+      await tx.websiteBannerOrdem.delete({ where: { id: ordem.id } });
+      await tx.websiteBanner.delete({ where: { id: bannerId } });
+      await tx.websiteBannerOrdem.updateMany({
+        where: { ordem: { gt: ordem.ordem } },
+        data: { ordem: { decrement: 1 } },
+      });
+    }),
 };
+

--- a/src/modules/website/services/slider.service.ts
+++ b/src/modules/website/services/slider.service.ts
@@ -1,5 +1,5 @@
 import { prisma } from "../../../config/prisma";
-import { SliderOrientation, SliderStatus } from "@prisma/client";
+import { SliderOrientation, WebsiteStatus } from "@prisma/client";
 
 export const sliderService = {
   list: () =>
@@ -19,7 +19,7 @@ export const sliderService = {
     imagemUrl: string;
     link?: string;
     orientacao: SliderOrientation;
-    status?: SliderStatus;
+    status?: WebsiteStatus;
   }) => {
     const max = await prisma.websiteSliderOrdem.aggregate({
       _max: { ordem: true },
@@ -51,7 +51,7 @@ export const sliderService = {
       imagemUrl?: string;
       link?: string;
       orientacao?: SliderOrientation;
-      status?: SliderStatus;
+      status?: WebsiteStatus;
       ordem?: number;
     }
   ) =>


### PR DESCRIPTION
## Summary
- use new `WebsiteBannerOrdem` table with `BannerStatus` to track banner positions
- update banner service, controller and routes for separate order management
- document banner and slider order APIs in Swagger and ReDoc with detailed field descriptions

## Testing
- `npx --yes pnpm prisma:generate`
- `npx --yes pnpm test`
- `npx --yes pnpm test src/modules/website/__tests__/banner.service.test.ts >/tmp/banner.log && tail -n 20 /tmp/banner.log`


------
https://chatgpt.com/codex/tasks/task_e_68b62c64035c8325b20e653fde20c7cf