### PR TITLE
feat(website): simplify team member fields

### DIFF
--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -1718,19 +1718,14 @@ const options: Options = {
         },
         WebsiteTeamCreateInput: {
           type: "object",
-          required: ["nome", "cargo"],
+          required: ["nome", "cargo", "photoUrl"],
           properties: {
             nome: { type: "string", example: "Fulano" },
             cargo: { type: "string", example: "Desenvolvedor" },
-            photo: {
-              type: "string",
-              format: "binary",
-              description: "Arquivo de imagem do membro",
-            },
             photoUrl: {
               type: "string",
               format: "uri",
-              description: "URL alternativa da imagem",
+              description: "URL da imagem do membro",
               example: "https://cdn.example.com/team.jpg",
             },
           },
@@ -1740,7 +1735,6 @@ const options: Options = {
           properties: {
             nome: { type: "string", example: "Fulano" },
             cargo: { type: "string", example: "Desenvolvedor" },
-            photo: { type: "string", format: "binary" },
             photoUrl: {
               type: "string",
               format: "uri",

--- a/src/modules/website/controllers/team.controller.ts
+++ b/src/modules/website/controllers/team.controller.ts
@@ -1,22 +1,5 @@
 import { Request, Response } from "express";
-import path from "path";
-import { supabase } from "../../superbase/client";
 import { teamService } from "../services/team.service";
-
-async function uploadImage(file: Express.Multer.File): Promise<string> {
-  const fileExt = path.extname(file.originalname);
-  const fileName = `team-${Date.now()}${fileExt}`;
-  const { error } = await supabase.storage
-    .from("website")
-    .upload(`team/${fileName}`, file.buffer, {
-      contentType: file.mimetype,
-    });
-  if (error) throw error;
-  const { data } = supabase.storage
-    .from("website")
-    .getPublicUrl(`team/${fileName}`);
-  return data.publicUrl;
-}
 
 export class TeamController {
   static list = async (req: Request, res: Response) => {
@@ -42,13 +25,7 @@ export class TeamController {
 
   static create = async (req: Request, res: Response) => {
     try {
-      const { nome, cargo } = req.body;
-      let photoUrl = "";
-      if (req.file) {
-        photoUrl = await uploadImage(req.file);
-      } else if (req.body.photoUrl) {
-        photoUrl = req.body.photoUrl;
-      }
+      const { nome, cargo, photoUrl } = req.body;
       const team = await teamService.create({
         photoUrl,
         nome,
@@ -66,11 +43,7 @@ export class TeamController {
   static update = async (req: Request, res: Response) => {
     try {
       const { id } = req.params;
-      const { nome, cargo } = req.body;
-      let photoUrl = req.body.photoUrl as string | undefined;
-      if (req.file) {
-        photoUrl = await uploadImage(req.file);
-      }
+      const { nome, cargo, photoUrl } = req.body;
       const data: any = { nome, cargo };
       if (photoUrl) {
         data.photoUrl = photoUrl;

--- a/src/modules/website/routes/team.ts
+++ b/src/modules/website/routes/team.ts
@@ -1,10 +1,8 @@
 import { Router } from "express";
-import multer from "multer";
 import { supabaseAuthMiddleware } from "../../usuarios/auth";
 import { TeamController } from "../controllers/team.controller";
 
 const router = Router();
-const upload = multer({ storage: multer.memoryStorage() });
 
 /**
  * @openapi
@@ -85,7 +83,7 @@ router.get("/:id", TeamController.get);
  *     requestBody:
  *       required: true
  *       content:
- *         multipart/form-data:
+ *         application/json:
  *           schema:
  *             $ref: '#/components/schemas/WebsiteTeamCreateInput'
  *     responses:
@@ -107,14 +105,12 @@ router.get("/:id", TeamController.get);
  *         source: |
  *           curl -X POST "http://localhost:3000/api/v1/website/team" \
  *            -H "Authorization: Bearer <TOKEN>" \
- *            -F "photo=@team.png" \
- *            -F "nome=Fulano" \
- *            -F "cargo=Dev"
+ *            -H "Content-Type: application/json" \
+ *            -d '{"nome":"Fulano","cargo":"Dev","photoUrl":"https://cdn.example.com/team.jpg"}'
  */
 router.post(
   "/",
   supabaseAuthMiddleware(["ADMIN", "MODERADOR"]),
-  upload.single("photo"),
   TeamController.create
 );
 
@@ -135,7 +131,7 @@ router.post(
  *     requestBody:
  *       required: true
  *       content:
- *         multipart/form-data:
+ *         application/json:
  *           schema:
  *             $ref: '#/components/schemas/WebsiteTeamUpdateInput'
  *     responses:
@@ -163,14 +159,12 @@ router.post(
  *         source: |
  *           curl -X PUT "http://localhost:3000/api/v1/website/team/{id}" \
  *            -H "Authorization: Bearer <TOKEN>" \
- *            -F "photo=@team.png" \
- *            -F "nome=Fulano" \
- *            -F "cargo=Dev"
+ *            -H "Content-Type: application/json" \
+ *            -d '{"nome":"Fulano","cargo":"Dev","photoUrl":"https://cdn.example.com/team.jpg"}'
  */
 router.put(
   "/:id",
   supabaseAuthMiddleware(["ADMIN", "MODERADOR"]),
-  upload.single("photo"),
   TeamController.update
 );
 


### PR DESCRIPTION
## Summary
- remove image upload from website team endpoints
- require photoUrl, nome and cargo in website team schema

## Testing
- `npx --yes pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68b667f3d6388325b40db42e0fd6568f