### PR TITLE
feat(website): add status to team

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -462,6 +462,7 @@ model WebsiteTeam {
   photoUrl  String
   nome      String
   cargo     String
+  status    WebsiteStatus @default(RASCUNHO)
   criadoEm  DateTime @default(now())
   atualizadoEm DateTime @updatedAt
 }

--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -1704,6 +1704,10 @@ const options: Options = {
             },
             nome: { type: "string", example: "Fulano" },
             cargo: { type: "string", example: "Desenvolvedor" },
+            status: {
+              $ref: '#/components/schemas/WebsiteStatus',
+              description: "Estado de publicação",
+            },
             criadoEm: {
               type: "string",
               format: "date-time",
@@ -1728,6 +1732,10 @@ const options: Options = {
               description: "URL da imagem do membro",
               example: "https://cdn.example.com/team.jpg",
             },
+            status: {
+              $ref: '#/components/schemas/WebsiteStatus',
+              description: "Estado de publicação",
+            },
           },
         },
         WebsiteTeamUpdateInput: {
@@ -1739,6 +1747,10 @@ const options: Options = {
               type: "string",
               format: "uri",
               example: "https://cdn.example.com/team.jpg",
+            },
+            status: {
+              $ref: '#/components/schemas/WebsiteStatus',
+              description: "Estado de publicação",
             },
           },
         },

--- a/src/modules/website/controllers/team.controller.ts
+++ b/src/modules/website/controllers/team.controller.ts
@@ -1,9 +1,16 @@
 import { Request, Response } from "express";
+import { WebsiteStatus } from "@prisma/client";
 import { teamService } from "../services/team.service";
 
 export class TeamController {
   static list = async (req: Request, res: Response) => {
-    const itens = await teamService.list();
+    let { status } = req.query as any;
+    if (typeof status === "string") {
+      if (status === "true") status = "PUBLICADO";
+      else if (status === "false") status = "RASCUNHO";
+      else status = status.toUpperCase();
+    }
+    const itens = await teamService.list(status as WebsiteStatus | undefined);
     res.json(itens);
   };
 
@@ -26,10 +33,17 @@ export class TeamController {
   static create = async (req: Request, res: Response) => {
     try {
       const { nome, cargo, photoUrl } = req.body;
+      let { status } = req.body as any;
+      if (typeof status === "boolean") {
+        status = status ? "PUBLICADO" : "RASCUNHO";
+      } else if (typeof status === "string") {
+        status = status.toUpperCase();
+      }
       const team = await teamService.create({
         photoUrl,
         nome,
         cargo,
+        status: status as WebsiteStatus,
       });
       res.status(201).json(team);
     } catch (error: any) {
@@ -44,10 +58,17 @@ export class TeamController {
     try {
       const { id } = req.params;
       const { nome, cargo, photoUrl } = req.body;
+      let { status } = req.body as any;
+      if (typeof status === "boolean") {
+        status = status ? "PUBLICADO" : "RASCUNHO";
+      } else if (typeof status === "string") {
+        status = status.toUpperCase();
+      }
       const data: any = { nome, cargo };
       if (photoUrl) {
         data.photoUrl = photoUrl;
       }
+      if (status !== undefined) data.status = status as WebsiteStatus;
       const team = await teamService.update(id, data);
       res.json(team);
     } catch (error: any) {

--- a/src/modules/website/routes/team.ts
+++ b/src/modules/website/routes/team.ts
@@ -10,6 +10,12 @@ const router = Router();
  *   get:
  *     summary: Listar membros da equipe
  *     tags: [Website - Team]
+ *     parameters:
+ *       - in: query
+ *         name: status
+ *         schema:
+ *           $ref: '#/components/schemas/WebsiteStatus'
+ *         description: Filtra membros por status (PUBLICADO ou RASCUNHO)
  *     responses:
  *       200:
  *         description: Lista de membros
@@ -77,6 +83,7 @@ router.get("/:id", TeamController.get);
  * /api/v1/website/team:
  *   post:
  *     summary: Criar membro da equipe
+ *     description: Cria um novo membro da equipe. O campo `status` aceita booleano (true = PUBLICADO, false = RASCUNHO) ou string.
  *     tags: [Website - Team]
  *     security:
  *       - bearerAuth: []
@@ -106,7 +113,7 @@ router.get("/:id", TeamController.get);
  *           curl -X POST "http://localhost:3000/api/v1/website/team" \
  *            -H "Authorization: Bearer <TOKEN>" \
  *            -H "Content-Type: application/json" \
- *            -d '{"nome":"Fulano","cargo":"Dev","photoUrl":"https://cdn.example.com/team.jpg"}'
+ *            -d '{"nome":"Fulano","cargo":"Dev","photoUrl":"https://cdn.example.com/team.jpg","status":"PUBLICADO"}'
  */
 router.post(
   "/",
@@ -119,6 +126,7 @@ router.post(
  * /api/v1/website/team/{id}:
  *   put:
  *     summary: Atualizar membro da equipe
+ *     description: Atualiza um membro da equipe. O campo `status` aceita booleano (true = PUBLICADO, false = RASCUNHO) ou string.
  *     tags: [Website - Team]
  *     security:
  *       - bearerAuth: []
@@ -160,7 +168,7 @@ router.post(
  *           curl -X PUT "http://localhost:3000/api/v1/website/team/{id}" \
  *            -H "Authorization: Bearer <TOKEN>" \
  *            -H "Content-Type: application/json" \
- *            -d '{"nome":"Fulano","cargo":"Dev","photoUrl":"https://cdn.example.com/team.jpg"}'
+ *            -d '{"nome":"Fulano","cargo":"Dev","photoUrl":"https://cdn.example.com/team.jpg","status":"RASCUNHO"}'
  */
 router.put(
   "/:id",

--- a/src/modules/website/services/team.service.ts
+++ b/src/modules/website/services/team.service.ts
@@ -1,13 +1,34 @@
 import { prisma } from "../../../config/prisma";
-import { WebsiteTeam } from "@prisma/client";
+import { WebsiteStatus } from "@prisma/client";
 
 export const teamService = {
-  list: () => prisma.websiteTeam.findMany(),
+  list: (status?: WebsiteStatus) =>
+    prisma.websiteTeam.findMany({
+      where: status ? { status } : undefined,
+    }),
   get: (id: string) => prisma.websiteTeam.findUnique({ where: { id } }),
-  create: (
-    data: Omit<WebsiteTeam, "id" | "criadoEm" | "atualizadoEm">
-  ) => prisma.websiteTeam.create({ data }),
-  update: (id: string, data: Partial<WebsiteTeam>) =>
-    prisma.websiteTeam.update({ where: { id }, data }),
+  create: (data: {
+    photoUrl: string;
+    nome: string;
+    cargo: string;
+    status?: WebsiteStatus;
+  }) =>
+    prisma.websiteTeam.create({
+      data: {
+        photoUrl: data.photoUrl,
+        nome: data.nome,
+        cargo: data.cargo,
+        status: data.status ?? "RASCUNHO",
+      },
+    }),
+  update: (
+    id: string,
+    data: {
+      photoUrl?: string;
+      nome?: string;
+      cargo?: string;
+      status?: WebsiteStatus;
+    }
+  ) => prisma.websiteTeam.update({ where: { id }, data }),
   remove: (id: string) => prisma.websiteTeam.delete({ where: { id } }),
 };


### PR DESCRIPTION
## Summary
- add publication status to Website Team schema
- expose status handling in team service, controller, and routes
- document Website Team status in OpenAPI

## Testing
- `pnpm prisma:generate`
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68b67bdbb0f883258cdfc7dd1c26ec0e