### PR TITLE
feat: add team order management

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -462,9 +462,22 @@ model WebsiteTeam {
   photoUrl  String
   nome      String
   cargo     String
-  status    WebsiteStatus @default(RASCUNHO)
   criadoEm  DateTime @default(now())
   atualizadoEm DateTime @updatedAt
+
+  ordem     WebsiteTeamOrdem?
+}
+
+model WebsiteTeamOrdem {
+  id            String       @id @default(uuid())
+  websiteTeamId String       @unique
+  ordem         Int
+  status        WebsiteStatus @default(RASCUNHO)
+  criadoEm      DateTime     @default(now())
+
+  team          WebsiteTeam  @relation(fields: [websiteTeamId], references: [id], onDelete: Cascade)
+
+  @@unique([ordem])
 }
 
 model WebsiteDiferenciais {

--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -1696,7 +1696,16 @@ const options: Options = {
         WebsiteTeam: {
           type: "object",
           properties: {
-            id: { type: "string", example: "team-uuid" },
+            id: {
+              type: "string",
+              description: "ID da ordem do membro",
+              example: "ordem-uuid",
+            },
+            teamId: {
+              type: "string",
+              description: "ID do membro",
+              example: "team-uuid",
+            },
             photoUrl: {
               type: "string",
               format: "uri",
@@ -1706,16 +1715,29 @@ const options: Options = {
             cargo: { type: "string", example: "Desenvolvedor" },
             status: {
               $ref: '#/components/schemas/WebsiteStatus',
-              description: "Estado de publicação",
+              description: "Estado de publicação do membro",
+            },
+            ordem: {
+              type: "integer",
+              description: "Posição do membro",
+              example: 1,
+            },
+            ordemCriadoEm: {
+              type: "string",
+              format: "date-time",
+              description: "Data de criação da ordem",
+              example: "2024-01-01T12:00:00Z",
             },
             criadoEm: {
               type: "string",
               format: "date-time",
+              description: "Data de criação do membro",
               example: "2024-01-01T12:00:00Z",
             },
             atualizadoEm: {
               type: "string",
               format: "date-time",
+              description: "Data da última atualização",
               example: "2024-01-01T12:00:00Z",
             },
           },
@@ -1733,13 +1755,19 @@ const options: Options = {
               example: "https://cdn.example.com/team.jpg",
             },
             status: {
-              $ref: '#/components/schemas/WebsiteStatus',
-              description: "Estado de publicação",
+              description:
+                "Estado de publicação. Aceita boolean (true = PUBLICADO, false = RASCUNHO) ou string.",
+              oneOf: [
+                { $ref: '#/components/schemas/WebsiteStatus' },
+                { type: "boolean" },
+              ],
+              example: true,
             },
           },
         },
         WebsiteTeamUpdateInput: {
           type: "object",
+          description: "Envie apenas os campos que deseja atualizar.",
           properties: {
             nome: { type: "string", example: "Fulano" },
             cargo: { type: "string", example: "Desenvolvedor" },
@@ -1749,8 +1777,31 @@ const options: Options = {
               example: "https://cdn.example.com/team.jpg",
             },
             status: {
-              $ref: '#/components/schemas/WebsiteStatus',
-              description: "Estado de publicação",
+              description:
+                "Estado de publicação. Aceita boolean (true = PUBLICADO, false = RASCUNHO) ou string.",
+              oneOf: [
+                { $ref: '#/components/schemas/WebsiteStatus' },
+                { type: "boolean" },
+              ],
+              example: false,
+            },
+            ordem: {
+              type: "integer",
+              example: 2,
+              description:
+                "Nova posição do membro; ao mudar este valor os demais serão reordenados automaticamente",
+            },
+          },
+        },
+        WebsiteTeamReorderInput: {
+          type: "object",
+          required: ["ordem"],
+          properties: {
+            ordem: {
+              type: "integer",
+              example: 2,
+              description:
+                "Nova posição desejada do membro. Se já houver outro na posição, os demais serão reordenados automaticamente",
             },
           },
         },

--- a/src/modules/website/routes/team.ts
+++ b/src/modules/website/routes/team.ts
@@ -43,11 +43,12 @@ router.get("/", TeamController.list);
  * @openapi
  * /api/v1/website/team/{id}:
  *   get:
- *     summary: Obter membro da equipe por ID
+ *     summary: Obter membro da equipe por ID da ordem
  *     tags: [Website - Team]
  *     parameters:
  *       - in: path
  *         name: id
+ *         description: ID da ordem do membro
  *         required: true
  *         schema:
  *           type: string
@@ -74,7 +75,7 @@ router.get("/", TeamController.list);
  *       - lang: cURL
  *         label: Exemplo
  *         source: |
- *           curl -X GET "http://localhost:3000/api/v1/website/team/{id}"
+ *           curl -X GET "http://localhost:3000/api/v1/website/team/{ordemId}"
  */
 router.get("/:id", TeamController.get);
 
@@ -83,7 +84,7 @@ router.get("/:id", TeamController.get);
  * /api/v1/website/team:
  *   post:
  *     summary: Criar membro da equipe
- *     description: Cria um novo membro da equipe. O campo `status` aceita booleano (true = PUBLICADO, false = RASCUNHO) ou string.
+ *     description: Cria um novo membro da equipe. O campo `status` representa o estado de publicação do membro e aceita booleano (true = PUBLICADO, false = RASCUNHO) ou string.
  *     tags: [Website - Team]
  *     security:
  *       - bearerAuth: []
@@ -126,13 +127,14 @@ router.post(
  * /api/v1/website/team/{id}:
  *   put:
  *     summary: Atualizar membro da equipe
- *     description: Atualiza um membro da equipe. O campo `status` aceita booleano (true = PUBLICADO, false = RASCUNHO) ou string.
+ *     description: Atualiza um membro da equipe. O campo `status` representa o estado de publicação do membro e aceita booleano (true = PUBLICADO, false = RASCUNHO) ou string.
  *     tags: [Website - Team]
  *     security:
  *       - bearerAuth: []
  *     parameters:
  *       - in: path
  *         name: id
+ *         description: ID do membro da equipe
  *         required: true
  *         schema:
  *           type: string
@@ -165,7 +167,7 @@ router.post(
  *       - lang: cURL
  *         label: Exemplo
  *         source: |
- *           curl -X PUT "http://localhost:3000/api/v1/website/team/{id}" \
+ *           curl -X PUT "http://localhost:3000/api/v1/website/team/{teamId}" \
  *            -H "Authorization: Bearer <TOKEN>" \
  *            -H "Content-Type: application/json" \
  *            -d '{"nome":"Fulano","cargo":"Dev","photoUrl":"https://cdn.example.com/team.jpg","status":"RASCUNHO"}'
@@ -174,6 +176,62 @@ router.put(
   "/:id",
   supabaseAuthMiddleware(["ADMIN", "MODERADOR"]),
   TeamController.update
+);
+
+/**
+ * @openapi
+ * /api/v1/website/team/{id}/reorder:
+ *   put:
+ *     summary: Reordenar membro da equipe
+ *     description: Altera a posição do membro utilizando o ID da ordem. Caso a nova posição esteja ocupada, os demais membros serão ajustados automaticamente.
+ *     tags: [Website - Team]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         description: ID da ordem do membro
+ *         required: true
+ *         schema:
+ *           type: string
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/WebsiteTeamReorderInput'
+ *     responses:
+ *       200:
+ *         description: Membro reordenado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/WebsiteTeam'
+ *       404:
+ *         description: Membro não encontrado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X PUT "http://localhost:3000/api/v1/website/team/{ordemId}/reorder" \\
+ *            -H "Authorization: Bearer <TOKEN>" \\
+ *            -H "Content-Type: application/json" \\
+ *            -d '{"ordem":2}'
+ */
+router.put(
+  "/:id/reorder",
+  supabaseAuthMiddleware(["ADMIN", "MODERADOR"]),
+  TeamController.reorder
 );
 
 /**

--- a/src/modules/website/services/team.service.ts
+++ b/src/modules/website/services/team.service.ts
@@ -3,32 +3,142 @@ import { WebsiteStatus } from "@prisma/client";
 
 export const teamService = {
   list: (status?: WebsiteStatus) =>
-    prisma.websiteTeam.findMany({
+    prisma.websiteTeamOrdem.findMany({
+      include: { team: true },
       where: status ? { status } : undefined,
+      orderBy: { ordem: "asc" },
     }),
-  get: (id: string) => prisma.websiteTeam.findUnique({ where: { id } }),
-  create: (data: {
+  get: (id: string) =>
+    prisma.websiteTeamOrdem.findUnique({
+      where: { id },
+      include: { team: true },
+    }),
+  create: async (data: {
     photoUrl: string;
     nome: string;
     cargo: string;
     status?: WebsiteStatus;
-  }) =>
-    prisma.websiteTeam.create({
+  }) => {
+    const max = await prisma.websiteTeamOrdem.aggregate({
+      _max: { ordem: true },
+    });
+    const ordem = (max._max.ordem ?? 0) + 1;
+    return prisma.websiteTeamOrdem.create({
       data: {
-        photoUrl: data.photoUrl,
-        nome: data.nome,
-        cargo: data.cargo,
+        ordem,
         status: data.status ?? "RASCUNHO",
+        team: {
+          create: {
+            photoUrl: data.photoUrl,
+            nome: data.nome,
+            cargo: data.cargo,
+          },
+        },
       },
-    }),
+      include: { team: true },
+    });
+  },
   update: (
-    id: string,
+    teamId: string,
     data: {
       photoUrl?: string;
       nome?: string;
       cargo?: string;
       status?: WebsiteStatus;
+      ordem?: number;
     }
-  ) => prisma.websiteTeam.update({ where: { id }, data }),
-  remove: (id: string) => prisma.websiteTeam.delete({ where: { id } }),
+  ) =>
+    prisma.$transaction(async (tx) => {
+      const current = await tx.websiteTeamOrdem.findUnique({
+        where: { websiteTeamId: teamId },
+      });
+      if (!current) throw new Error("Team member não encontrado");
+
+      let ordem = data.ordem ?? current.ordem;
+      if (data.ordem !== undefined && data.ordem !== current.ordem) {
+        if (data.ordem > current.ordem) {
+          await tx.websiteTeamOrdem.updateMany({
+            where: { ordem: { gt: current.ordem, lte: data.ordem } },
+            data: { ordem: { decrement: 1 } },
+          });
+        } else {
+          await tx.websiteTeamOrdem.updateMany({
+            where: { ordem: { gte: data.ordem, lt: current.ordem } },
+            data: { ordem: { increment: 1 } },
+          });
+        }
+        ordem = data.ordem;
+      }
+
+      return tx.websiteTeamOrdem.update({
+        where: { id: current.id },
+        data: {
+          ordem,
+          ...(data.status !== undefined && { status: data.status }),
+          ...(data.photoUrl !== undefined ||
+          data.nome !== undefined ||
+          data.cargo !== undefined
+            ? {
+                team: {
+                  update: {
+                    ...(data.photoUrl !== undefined && { photoUrl: data.photoUrl }),
+                    ...(data.nome !== undefined && { nome: data.nome }),
+                    ...(data.cargo !== undefined && { cargo: data.cargo }),
+                  },
+                },
+              }
+            : {}),
+        },
+        include: { team: true },
+      });
+    }),
+  reorder: (ordemId: string, novaOrdem: number) =>
+    prisma.$transaction(async (tx) => {
+      const current = await tx.websiteTeamOrdem.findUnique({
+        where: { id: ordemId },
+        include: { team: true },
+      });
+      if (!current) throw new Error("Team member não encontrado");
+
+      if (novaOrdem !== current.ordem) {
+        await tx.websiteTeamOrdem.update({
+          where: { id: ordemId },
+          data: { ordem: 0 },
+        });
+
+        if (novaOrdem > current.ordem) {
+          await tx.websiteTeamOrdem.updateMany({
+            where: { ordem: { gt: current.ordem, lte: novaOrdem } },
+            data: { ordem: { decrement: 1 } },
+          });
+        } else {
+          await tx.websiteTeamOrdem.updateMany({
+            where: { ordem: { gte: novaOrdem, lt: current.ordem } },
+            data: { ordem: { increment: 1 } },
+          });
+        }
+
+        return tx.websiteTeamOrdem.update({
+          where: { id: ordemId },
+          data: { ordem: novaOrdem },
+          include: { team: true },
+        });
+      }
+
+      return current;
+    }),
+  remove: (teamId: string) =>
+    prisma.$transaction(async (tx) => {
+      const ordem = await tx.websiteTeamOrdem.findUnique({
+        where: { websiteTeamId: teamId },
+      });
+      if (!ordem) return;
+      await tx.websiteTeamOrdem.delete({ where: { id: ordem.id } });
+      await tx.websiteTeam.delete({ where: { id: teamId } });
+      await tx.websiteTeamOrdem.updateMany({
+        where: { ordem: { gt: ordem.ordem } },
+        data: { ordem: { decrement: 1 } },
+      });
+    }),
 };
+


### PR DESCRIPTION
## Summary
- move `status` field to `WebsiteTeamOrdem` to centralize publication state
- refactor team service/controller to handle status on order records
- add ordering API with reorder endpoint for team members
- refresh Swagger/Redoc docs for team ordering and status handling

## Testing
- `pnpm prisma:generate`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b67e366b50832598dbe23c6ac88643