### PR TITLE
feat: add logo enterprises ordering

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -555,11 +555,22 @@ model WebsiteLogoEnterprise {
   imagemUrl  String
   imagemAlt  String
   website    String
-  categoria  String
-  ordem      Int
-  ativo      Boolean  @default(true)
   criadoEm   DateTime @default(now())
   atualizadoEm DateTime @updatedAt
+
+  ordem      WebsiteLogoEnterpriseOrdem?
+}
+
+model WebsiteLogoEnterpriseOrdem {
+  id                     String       @id @default(uuid())
+  websiteLogoEnterpriseId String       @unique
+  ordem                  Int
+  status                 WebsiteStatus @default(RASCUNHO)
+  criadoEm               DateTime     @default(now())
+
+  logo WebsiteLogoEnterprise @relation(fields: [websiteLogoEnterpriseId], references: [id], onDelete: Cascade)
+
+  @@unique([ordem])
 }
 
 model WebsitePlaninhas {

--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -1122,7 +1122,16 @@ const options: Options = {
         WebsiteLogoEnterprise: {
           type: "object",
           properties: {
-            id: { type: "string", example: "logo-uuid" },
+            id: {
+              type: "string",
+              description: "ID da ordem do logo",
+              example: "ordem-uuid",
+            },
+            logoId: {
+              type: "string",
+              description: "ID do logo associado",
+              example: "logo-uuid",
+            },
             nome: { type: "string", example: "Empresa X" },
             imagemUrl: {
               type: "string",
@@ -1131,31 +1140,35 @@ const options: Options = {
             },
             imagemAlt: { type: "string", example: "Logo da Empresa X" },
             website: { type: "string", example: "https://empresa.com" },
-            categoria: { type: "string", example: "tecnologia" },
-            ordem: { type: "integer", example: 1 },
-            ativo: { type: "boolean", example: true },
+            status: {
+              $ref: '#/components/schemas/WebsiteStatus',
+              description: "Estado de publicação",
+            },
+            ordem: { type: "integer", example: 1, description: "Posição do logo" },
+            ordemCriadoEm: {
+              type: "string",
+              format: "date-time",
+              description: "Data de criação da ordem",
+              example: "2024-01-01T12:00:00Z",
+            },
             criadoEm: {
               type: "string",
               format: "date-time",
+              description: "Data de criação do logo",
               example: "2024-01-01T12:00:00Z",
             },
             atualizadoEm: {
               type: "string",
               format: "date-time",
+              description: "Data da última atualização",
               example: "2024-01-01T12:00:00Z",
             },
           },
         },
         WebsiteLogoEnterpriseCreateInput: {
           type: "object",
-          required: ["nome", "website", "categoria"],
+          required: ["nome", "website"],
           properties: {
-            nome: { type: "string", example: "Empresa X" },
-            website: { type: "string", example: "https://empresa.com" },
-            categoria: { type: "string", example: "tecnologia" },
-            ordem: { type: "integer", example: 1 },
-            ativo: { type: "boolean", example: true },
-            imagemAlt: { type: "string", example: "Logo da Empresa X" },
             imagem: {
               type: "string",
               format: "binary",
@@ -1167,22 +1180,58 @@ const options: Options = {
               description: "URL alternativa da imagem",
               example: "https://cdn.example.com/logo.png",
             },
+            nome: { type: "string", example: "Empresa X" },
+            website: { type: "string", example: "https://empresa.com" },
+            status: {
+              description:
+                "Estado de publicação. Aceita boolean (true = PUBLICADO, false = RASCUNHO) ou string.",
+              oneOf: [
+                { $ref: '#/components/schemas/WebsiteStatus' },
+                { type: "boolean" },
+              ],
+              example: true,
+            },
+            imagemAlt: { type: "string", example: "Logo da Empresa X" },
           },
         },
         WebsiteLogoEnterpriseUpdateInput: {
           type: "object",
           properties: {
-            nome: { type: "string", example: "Empresa X" },
-            website: { type: "string", example: "https://empresa.com" },
-            categoria: { type: "string", example: "tecnologia" },
-            ordem: { type: "integer", example: 2 },
-            ativo: { type: "boolean", example: true },
-            imagemAlt: { type: "string", example: "Logo da Empresa X" },
             imagem: { type: "string", format: "binary" },
             imagemUrl: {
               type: "string",
               format: "uri",
               example: "https://cdn.example.com/logo.png",
+            },
+            nome: { type: "string", example: "Empresa X" },
+            website: { type: "string", example: "https://empresa.com" },
+            status: {
+              description:
+                "Estado de publicação. Aceita boolean (true = PUBLICADO, false = RASCUNHO) ou string.",
+              oneOf: [
+                { $ref: '#/components/schemas/WebsiteStatus' },
+                { type: "boolean" },
+              ],
+              example: false,
+            },
+            imagemAlt: { type: "string", example: "Logo da Empresa X" },
+            ordem: {
+              type: "integer",
+              example: 2,
+              description:
+                "Nova posição do logo; ao mudar este valor os demais serão reordenados automaticamente",
+            },
+          },
+        },
+        WebsiteLogoEnterpriseReorderInput: {
+          type: "object",
+          required: ["ordem"],
+          properties: {
+            ordem: {
+              type: "integer",
+              example: 2,
+              description:
+                "Nova posição desejada do logo. Se já houver outro na posição, os demais serão reordenados automaticamente",
             },
           },
         },

--- a/src/modules/website/services/logoEnterprise.service.ts
+++ b/src/modules/website/services/logoEnterprise.service.ts
@@ -1,18 +1,153 @@
 import { prisma } from "../../../config/prisma";
-import { WebsiteLogoEnterprise } from "@prisma/client";
+import { WebsiteStatus } from "@prisma/client";
 
 export const logoEnterpriseService = {
   list: () =>
-    prisma.websiteLogoEnterprise.findMany({
+    prisma.websiteLogoEnterpriseOrdem.findMany({
+      include: { logo: true },
       orderBy: { ordem: "asc" },
     }),
+
   get: (id: string) =>
-    prisma.websiteLogoEnterprise.findUnique({ where: { id } }),
-  create: (
-    data: Omit<WebsiteLogoEnterprise, "id" | "criadoEm" | "atualizadoEm">
-  ) => prisma.websiteLogoEnterprise.create({ data }),
-  update: (id: string, data: Partial<WebsiteLogoEnterprise>) =>
-    prisma.websiteLogoEnterprise.update({ where: { id }, data }),
-  remove: (id: string) =>
-    prisma.websiteLogoEnterprise.delete({ where: { id } }),
+    prisma.websiteLogoEnterpriseOrdem.findUnique({
+      where: { id },
+      include: { logo: true },
+    }),
+
+  create: (data: {
+    nome: string;
+    imagemUrl: string;
+    imagemAlt: string;
+    website: string;
+    status?: WebsiteStatus;
+  }) =>
+    prisma.$transaction(async (tx) => {
+      const max = await tx.websiteLogoEnterpriseOrdem.aggregate({
+        _max: { ordem: true },
+      });
+      const ordem = (max._max.ordem ?? 0) + 1;
+
+      return tx.websiteLogoEnterpriseOrdem.create({
+        data: {
+          ordem,
+          status: data.status ?? "RASCUNHO",
+          logo: {
+            create: {
+              nome: data.nome,
+              imagemUrl: data.imagemUrl,
+              imagemAlt: data.imagemAlt,
+              website: data.website,
+            },
+          },
+        },
+        include: { logo: true },
+      });
+    }),
+
+  update: (
+    logoId: string,
+    data: {
+      nome?: string;
+      imagemUrl?: string;
+      imagemAlt?: string;
+      website?: string;
+      status?: WebsiteStatus;
+      ordem?: number;
+    }
+  ) =>
+    prisma.$transaction(async (tx) => {
+      const current = await tx.websiteLogoEnterpriseOrdem.findUnique({
+        where: { websiteLogoEnterpriseId: logoId },
+      });
+      if (!current) throw new Error("Logo não encontrada");
+
+      let ordem = data.ordem ?? current.ordem;
+      if (data.ordem !== undefined && data.ordem !== current.ordem) {
+        if (data.ordem > current.ordem) {
+          await tx.websiteLogoEnterpriseOrdem.updateMany({
+            where: { ordem: { gt: current.ordem, lte: data.ordem } },
+            data: { ordem: { decrement: 1 } },
+          });
+        } else {
+          await tx.websiteLogoEnterpriseOrdem.updateMany({
+            where: { ordem: { gte: data.ordem, lt: current.ordem } },
+            data: { ordem: { increment: 1 } },
+          });
+        }
+        ordem = data.ordem;
+      }
+
+      return tx.websiteLogoEnterpriseOrdem.update({
+        where: { id: current.id },
+        data: {
+          ordem,
+          status: data.status,
+          logo:
+            data.nome !== undefined ||
+            data.imagemUrl !== undefined ||
+            data.imagemAlt !== undefined ||
+            data.website !== undefined
+              ? {
+                  update: {
+                    nome: data.nome,
+                    imagemUrl: data.imagemUrl,
+                    imagemAlt: data.imagemAlt,
+                    website: data.website,
+                  },
+                }
+              : undefined,
+        },
+        include: { logo: true },
+      });
+    }),
+
+  reorder: (ordemId: string, novaOrdem: number) =>
+    prisma.$transaction(async (tx) => {
+      const current = await tx.websiteLogoEnterpriseOrdem.findUnique({
+        where: { id: ordemId },
+        include: { logo: true },
+      });
+      if (!current) throw new Error("Logo não encontrada");
+
+      if (novaOrdem !== current.ordem) {
+        await tx.websiteLogoEnterpriseOrdem.update({
+          where: { id: ordemId },
+          data: { ordem: 0 },
+        });
+
+        if (novaOrdem > current.ordem) {
+          await tx.websiteLogoEnterpriseOrdem.updateMany({
+            where: { ordem: { gt: current.ordem, lte: novaOrdem } },
+            data: { ordem: { decrement: 1 } },
+          });
+        } else {
+          await tx.websiteLogoEnterpriseOrdem.updateMany({
+            where: { ordem: { gte: novaOrdem, lt: current.ordem } },
+            data: { ordem: { increment: 1 } },
+          });
+        }
+
+        return tx.websiteLogoEnterpriseOrdem.update({
+          where: { id: ordemId },
+          data: { ordem: novaOrdem },
+          include: { logo: true },
+        });
+      }
+
+      return current;
+    }),
+
+  remove: (logoId: string) =>
+    prisma.$transaction(async (tx) => {
+      const ordem = await tx.websiteLogoEnterpriseOrdem.findUnique({
+        where: { websiteLogoEnterpriseId: logoId },
+      });
+      if (!ordem) return;
+      await tx.websiteLogoEnterpriseOrdem.delete({ where: { id: ordem.id } });
+      await tx.websiteLogoEnterprise.delete({ where: { id: logoId } });
+      await tx.websiteLogoEnterpriseOrdem.updateMany({
+        where: { ordem: { gt: ordem.ordem } },
+        data: { ordem: { decrement: 1 } },
+      });
+    }),
 };


### PR DESCRIPTION
## Summary
- add WebsiteLogoEnterpriseOrdem schema with status and order support
- expose CRUD and reorder endpoints for logo enterprises
- document logo enterprise API in Swagger

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb43df45bc8325bb65bb4c656d0b42