### PR TITLE
feat: tornar website opcional em logo enterprises

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -554,7 +554,7 @@ model WebsiteLogoEnterprise {
   nome       String
   imagemUrl  String
   imagemAlt  String
-  website    String
+  website    String?
   criadoEm   DateTime @default(now())
   atualizadoEm DateTime @updatedAt
 

--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -1167,7 +1167,7 @@ const options: Options = {
         },
         WebsiteLogoEnterpriseCreateInput: {
           type: "object",
-          required: ["nome", "website"],
+          required: ["nome"],
           properties: {
             imagem: {
               type: "string",
@@ -1181,7 +1181,11 @@ const options: Options = {
               example: "https://cdn.example.com/logo.png",
             },
             nome: { type: "string", example: "Empresa X" },
-            website: { type: "string", example: "https://empresa.com" },
+            website: {
+              type: "string",
+              example: "https://empresa.com",
+              description: "URL do site da empresa (opcional)",
+            },
             status: {
               description:
                 "Estado de publicação. Aceita boolean (true = PUBLICADO, false = RASCUNHO) ou string.",

--- a/src/modules/website/services/logoEnterprise.service.ts
+++ b/src/modules/website/services/logoEnterprise.service.ts
@@ -18,7 +18,7 @@ export const logoEnterpriseService = {
     nome: string;
     imagemUrl: string;
     imagemAlt: string;
-    website: string;
+    website?: string;
     status?: WebsiteStatus;
   }) =>
     prisma.$transaction(async (tx) => {
@@ -36,7 +36,7 @@ export const logoEnterpriseService = {
               nome: data.nome,
               imagemUrl: data.imagemUrl,
               imagemAlt: data.imagemAlt,
-              website: data.website,
+              ...(data.website !== undefined && { website: data.website }),
             },
           },
         },
@@ -92,7 +92,9 @@ export const logoEnterpriseService = {
                     nome: data.nome,
                     imagemUrl: data.imagemUrl,
                     imagemAlt: data.imagemAlt,
-                    website: data.website,
+                    ...(data.website !== undefined && {
+                      website: data.website,
+                    }),
                   },
                 }
               : undefined,


### PR DESCRIPTION
## Summary
- tornar campo website opcional para logos de empresas
- atualizar service para lidar com website opcional
- documentar no Swagger que website é opcional

## Testing
- `pnpm prisma:generate`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb57f359f483258f2d4d08687108e3