### PR TITLE
feat: add depoimentos module for website

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -480,6 +480,30 @@ model WebsiteTeamOrdem {
   @@unique([ordem])
 }
 
+model WebsiteDepoimento {
+  id          String   @id @default(uuid())
+  depoimento  String
+  nome        String
+  cargo       String
+  fotoUrl     String
+  criadoEm    DateTime @default(now())
+  atualizadoEm DateTime @updatedAt
+
+  ordem       WebsiteDepoimentoOrdem?
+}
+
+model WebsiteDepoimentoOrdem {
+  id                   String       @id @default(uuid())
+  websiteDepoimentoId  String       @unique
+  ordem                Int
+  status               WebsiteStatus @default(RASCUNHO)
+  criadoEm             DateTime     @default(now())
+
+  depoimento           WebsiteDepoimento @relation(fields: [websiteDepoimentoId], references: [id], onDelete: Cascade)
+
+  @@unique([ordem])
+}
+
 model WebsiteDiferenciais {
   id           String   @id @default(uuid())
   icone1       String

--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -62,6 +62,10 @@ const options: Options = {
         description: "Conteúdos \"Team\"",
       },
       {
+        name: "Website - Depoimentos",
+        description: "Conteúdos \"Depoimentos\"",
+      },
+      {
         name: "Website - Diferenciais",
         description: "Conteúdos \"Diferenciais\"",
       },
@@ -981,6 +985,7 @@ const options: Options = {
                 sobreEmpresa: { type: "string", example: "/sobre-empresa" },
                 team: { type: "string", example: "/team" },
                 diferenciais: { type: "string", example: "/diferenciais" },
+                depoimentos: { type: "string", example: "/depoimentos" },
               },
             },
             status: { type: "string", example: "operational" },
@@ -1855,6 +1860,121 @@ const options: Options = {
               example: 2,
               description:
                 "Nova posição desejada do membro. Se já houver outro na posição, os demais serão reordenados automaticamente",
+            },
+          },
+        },
+        WebsiteDepoimento: {
+          type: "object",
+          properties: {
+            id: {
+              type: "string",
+              description: "ID da ordem do depoimento",
+              example: "ordem-uuid",
+            },
+            depoimentoId: {
+              type: "string",
+              description: "ID do depoimento",
+              example: "depoimento-uuid",
+            },
+            depoimento: { type: "string", example: "Ótimo serviço" },
+            nome: { type: "string", example: "Fulano" },
+            cargo: { type: "string", example: "Gerente" },
+            fotoUrl: {
+              type: "string",
+              format: "uri",
+              example: "https://cdn.example.com/foto.jpg",
+            },
+            status: {
+              $ref: '#/components/schemas/WebsiteStatus',
+              description: "Estado de publicação do depoimento",
+            },
+            ordem: {
+              type: "integer",
+              description: "Posição do depoimento",
+              example: 1,
+            },
+            ordemCriadoEm: {
+              type: "string",
+              format: "date-time",
+              description: "Data de criação da ordem",
+              example: "2024-01-01T12:00:00Z",
+            },
+            criadoEm: {
+              type: "string",
+              format: "date-time",
+              description: "Data de criação do depoimento",
+              example: "2024-01-01T12:00:00Z",
+            },
+            atualizadoEm: {
+              type: "string",
+              format: "date-time",
+              description: "Data da última atualização",
+              example: "2024-01-01T12:00:00Z",
+            },
+          },
+        },
+        WebsiteDepoimentoCreateInput: {
+          type: "object",
+          required: ["depoimento", "nome", "cargo", "fotoUrl"],
+          properties: {
+            depoimento: { type: "string", example: "Ótimo serviço" },
+            nome: { type: "string", example: "Fulano" },
+            cargo: { type: "string", example: "Gerente" },
+            fotoUrl: {
+              type: "string",
+              format: "uri",
+              description: "URL da foto do autor",
+              example: "https://cdn.example.com/foto.jpg",
+            },
+            status: {
+              description:
+                "Estado de publicação. Aceita boolean (true = PUBLICADO, false = RASCUNHO) ou string.",
+              oneOf: [
+                { $ref: '#/components/schemas/WebsiteStatus' },
+                { type: "boolean" },
+              ],
+              example: true,
+            },
+          },
+        },
+        WebsiteDepoimentoUpdateInput: {
+          type: "object",
+          description: "Envie apenas os campos que deseja atualizar.",
+          properties: {
+            depoimento: { type: "string", example: "Ótimo serviço" },
+            nome: { type: "string", example: "Fulano" },
+            cargo: { type: "string", example: "Gerente" },
+            fotoUrl: {
+              type: "string",
+              format: "uri",
+              example: "https://cdn.example.com/foto.jpg",
+            },
+            status: {
+              description:
+                "Estado de publicação. Aceita boolean (true = PUBLICADO, false = RASCUNHO) ou string.",
+              oneOf: [
+                { $ref: '#/components/schemas/WebsiteStatus' },
+                { type: "boolean" },
+              ],
+              example: false,
+            },
+            ordem: {
+              type: "integer",
+              example: 2,
+              description:
+                "Nova posição do depoimento; ao mudar este valor os demais serão reordenados automaticamente",
+            },
+          },
+        },
+        WebsiteDepoimentoReorderInput: {
+          type: "object",
+          required: ["ordem"],
+          properties: {
+            ordem: {
+              type: "integer",
+              example: 2,
+              description:
+                "Nova posição desejada do depoimento. Se já houver outro na posição, os demais serão reordenados automaticamente",
             },
           },
         },

--- a/src/modules/website/controllers/depoimentos.controller.ts
+++ b/src/modules/website/controllers/depoimentos.controller.ts
@@ -1,0 +1,124 @@
+import { Request, Response } from "express";
+import { WebsiteStatus } from "@prisma/client";
+import { depoimentosService } from "../services/depoimentos.service";
+
+function mapDepoimento(ordem: any) {
+  return {
+    id: ordem.id,
+    depoimentoId: ordem.depoimento.id,
+    depoimento: ordem.depoimento.depoimento,
+    nome: ordem.depoimento.nome,
+    cargo: ordem.depoimento.cargo,
+    fotoUrl: ordem.depoimento.fotoUrl,
+    status: ordem.status,
+    ordem: ordem.ordem,
+    criadoEm: ordem.depoimento.criadoEm,
+    atualizadoEm: ordem.depoimento.atualizadoEm,
+    ordemCriadoEm: ordem.criadoEm,
+  };
+}
+
+export class DepoimentosController {
+  static list = async (req: Request, res: Response) => {
+    let { status } = req.query as any;
+    if (typeof status === "string") {
+      if (status === "true") status = "PUBLICADO";
+      else if (status === "false") status = "RASCUNHO";
+      else status = status.toUpperCase();
+    }
+    const itens = await depoimentosService.list(status as WebsiteStatus | undefined);
+    res.json(itens.map(mapDepoimento));
+  };
+
+  static get = async (req: Request, res: Response) => {
+    try {
+      const { id: ordemId } = req.params;
+      const ordem = await depoimentosService.get(ordemId);
+      if (!ordem) {
+        return res.status(404).json({ message: "Depoimento não encontrado" });
+      }
+      res.json(mapDepoimento(ordem));
+    } catch (error: any) {
+      res.status(500).json({
+        message: "Erro ao buscar depoimento",
+        error: error.message,
+      });
+    }
+  };
+
+  static create = async (req: Request, res: Response) => {
+    try {
+      const { depoimento, nome, cargo, fotoUrl } = req.body;
+      let { status } = req.body as any;
+      if (typeof status === "boolean") {
+        status = status ? "PUBLICADO" : "RASCUNHO";
+      } else if (typeof status === "string") {
+        status = status.toUpperCase();
+      }
+      const ordem = await depoimentosService.create({
+        depoimento,
+        nome,
+        cargo,
+        fotoUrl,
+        status: status as WebsiteStatus,
+      });
+      res.status(201).json(mapDepoimento(ordem));
+    } catch (error: any) {
+      res.status(500).json({
+        message: "Erro ao criar depoimento",
+        error: error.message,
+      });
+    }
+  };
+
+  static update = async (req: Request, res: Response) => {
+    try {
+      const { id: depoimentoId } = req.params;
+      const { depoimento, nome, cargo, fotoUrl, ordem } = req.body;
+      let { status } = req.body as any;
+      if (typeof status === "boolean") {
+        status = status ? "PUBLICADO" : "RASCUNHO";
+      } else if (typeof status === "string") {
+        status = status.toUpperCase();
+      }
+      const data: any = { depoimento, nome, cargo, fotoUrl };
+      if (status !== undefined) data.status = status as WebsiteStatus;
+      if (ordem !== undefined) data.ordem = parseInt(ordem, 10);
+      const ordemResult = await depoimentosService.update(depoimentoId, data);
+      res.json(mapDepoimento(ordemResult));
+    } catch (error: any) {
+      res.status(500).json({
+        message: "Erro ao atualizar depoimento",
+        error: error.message,
+      });
+    }
+  };
+
+  static reorder = async (req: Request, res: Response) => {
+    try {
+      const { id: ordemId } = req.params;
+      const { ordem } = req.body;
+      const ordemResult = await depoimentosService.reorder(ordemId, parseInt(ordem, 10));
+      res.json(mapDepoimento(ordemResult));
+    } catch (error: any) {
+      res.status(500).json({
+        message: "Erro ao reordenar depoimento",
+        error: error.message,
+      });
+    }
+  };
+
+  static remove = async (req: Request, res: Response) => {
+    try {
+      const { id: depoimentoId } = req.params;
+      await depoimentosService.remove(depoimentoId);
+      res.status(204).send();
+    } catch (error: any) {
+      res.status(500).json({
+        message: "Erro ao remover depoimento",
+        error: error.message,
+      });
+    }
+  };
+}
+

--- a/src/modules/website/routes/depoimentos.ts
+++ b/src/modules/website/routes/depoimentos.ts
@@ -1,0 +1,280 @@
+import { Router } from "express";
+import { supabaseAuthMiddleware } from "../../usuarios/auth";
+import { DepoimentosController } from "../controllers/depoimentos.controller";
+
+const router = Router();
+
+/**
+ * @openapi
+ * /api/v1/website/depoimentos:
+ *   get:
+ *     summary: Listar depoimentos
+ *     tags: [Website - Depoimentos]
+ *     parameters:
+ *       - in: query
+ *         name: status
+ *         schema:
+ *           $ref: '#/components/schemas/WebsiteStatus'
+ *         description: Filtra depoimentos por status (PUBLICADO ou RASCUNHO)
+ *     responses:
+ *       200:
+ *         description: Lista de depoimentos
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 $ref: '#/components/schemas/WebsiteDepoimento'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X GET "http://localhost:3000/api/v1/website/depoimentos"
+ */
+router.get("/", DepoimentosController.list);
+
+/**
+ * @openapi
+ * /api/v1/website/depoimentos/{id}:
+ *   get:
+ *     summary: Obter depoimento por ID da ordem
+ *     tags: [Website - Depoimentos]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         description: ID da ordem do depoimento
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Depoimento encontrado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/WebsiteDepoimento'
+ *       404:
+ *         description: Depoimento não encontrado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X GET "http://localhost:3000/api/v1/website/depoimentos/{ordemId}"
+ */
+router.get("/:id", DepoimentosController.get);
+
+/**
+ * @openapi
+ * /api/v1/website/depoimentos:
+ *   post:
+ *     summary: Criar depoimento
+ *     description: Cria um novo depoimento. O campo `status` representa o estado de publicação e aceita boolean (true = PUBLICADO, false = RASCUNHO) ou string.
+ *     tags: [Website - Depoimentos]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/WebsiteDepoimentoCreateInput'
+ *     responses:
+ *       201:
+ *         description: Depoimento criado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/WebsiteDepoimento'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X POST "http://localhost:3000/api/v1/website/depoimentos" \\
+ *            -H "Authorization: Bearer <TOKEN>" \\
+ *            -H "Content-Type: application/json" \\
+ *            -d '{"depoimento":"Excelente serviço","nome":"Fulano","cargo":"Gerente","fotoUrl":"https://cdn.example.com/foto.jpg","status":"PUBLICADO"}'
+ */
+router.post(
+  "/",
+  supabaseAuthMiddleware(["ADMIN", "MODERADOR"]),
+  DepoimentosController.create
+);
+
+/**
+ * @openapi
+ * /api/v1/website/depoimentos/{id}:
+ *   put:
+ *     summary: Atualizar depoimento
+ *     description: Atualiza um depoimento. O campo `status` representa o estado de publicação e aceita boolean (true = PUBLICADO, false = RASCUNHO) ou string.
+ *     tags: [Website - Depoimentos]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         description: ID do depoimento
+ *         required: true
+ *         schema:
+ *           type: string
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/WebsiteDepoimentoUpdateInput'
+ *     responses:
+ *       200:
+ *         description: Depoimento atualizado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/WebsiteDepoimento'
+ *       404:
+ *         description: Depoimento não encontrado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X PUT "http://localhost:3000/api/v1/website/depoimentos/{id}" \\
+ *            -H "Authorization: Bearer <TOKEN>" \\
+ *            -H "Content-Type: application/json" \\
+ *            -d '{"depoimento":"Texto","status":"RASCUNHO"}'
+ */
+router.put(
+  "/:id",
+  supabaseAuthMiddleware(["ADMIN", "MODERADOR"]),
+  DepoimentosController.update
+);
+
+/**
+ * @openapi
+ * /api/v1/website/depoimentos/{id}/reorder:
+ *   put:
+ *     summary: Reordenar depoimento
+ *     description: Altera a posição do depoimento utilizando o ID da ordem. Caso a nova posição esteja ocupada, os demais serão ajustados automaticamente.
+ *     tags: [Website - Depoimentos]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         description: ID da ordem do depoimento
+ *         required: true
+ *         schema:
+ *           type: string
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/WebsiteDepoimentoReorderInput'
+ *     responses:
+ *       200:
+ *         description: Depoimento reordenado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/WebsiteDepoimento'
+ *       404:
+ *         description: Depoimento não encontrado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X PUT "http://localhost:3000/api/v1/website/depoimentos/{ordemId}/reorder" \\
+ *            -H "Authorization: Bearer <TOKEN>" \\
+ *            -H "Content-Type: application/json" \\
+ *            -d '{"ordem":2}'
+ */
+router.put(
+  "/:id/reorder",
+  supabaseAuthMiddleware(["ADMIN", "MODERADOR"]),
+  DepoimentosController.reorder
+);
+
+/**
+ * @openapi
+ * /api/v1/website/depoimentos/{id}:
+ *   delete:
+ *     summary: Remover depoimento
+ *     tags: [Website - Depoimentos]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       204:
+ *         description: Depoimento removido
+ *       404:
+ *         description: Depoimento não encontrado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X DELETE "http://localhost:3000/api/v1/website/depoimentos/{id}" \\
+ *            -H "Authorization: Bearer <TOKEN>"
+ */
+router.delete(
+  "/:id",
+  supabaseAuthMiddleware(["ADMIN", "MODERADOR"]),
+  DepoimentosController.remove
+);
+
+export { router as depoimentosRoutes };
+

--- a/src/modules/website/routes/index.ts
+++ b/src/modules/website/routes/index.ts
@@ -16,6 +16,7 @@ import { treinamentoCompanyRoutes } from "./treinamento-company";
 import { conexaoForteRoutes } from "./conexao-forte";
 import { treinamentosInCompanyRoutes } from "./treinamentos-in-company";
 import { headerPagesRoutes } from "./header-pages";
+import { depoimentosRoutes } from "./depoimentos";
 
 const router = Router();
 
@@ -67,6 +68,7 @@ router.get("/", (req, res) => {
       conexaoForte: "/conexao-forte",
       treinamentosInCompany: "/treinamentos-in-company",
       headerPages: "/header-pages",
+      depoimentos: "/depoimentos",
     },
     status: "operational",
   });
@@ -89,5 +91,6 @@ router.use("/treinamento-company", treinamentoCompanyRoutes);
 router.use("/conexao-forte", conexaoForteRoutes);
 router.use("/treinamentos-in-company", treinamentosInCompanyRoutes);
 router.use("/header-pages", headerPagesRoutes);
+router.use("/depoimentos", depoimentosRoutes);
 
 export { router as websiteRoutes };

--- a/src/modules/website/services/depoimentos.service.ts
+++ b/src/modules/website/services/depoimentos.service.ts
@@ -1,0 +1,149 @@
+import { prisma } from "../../../config/prisma";
+import { WebsiteStatus } from "@prisma/client";
+
+export const depoimentosService = {
+  list: (status?: WebsiteStatus) =>
+    prisma.websiteDepoimentoOrdem.findMany({
+      include: { depoimento: true },
+      where: status ? { status } : undefined,
+      orderBy: { ordem: "asc" },
+    }),
+  get: (id: string) =>
+    prisma.websiteDepoimentoOrdem.findUnique({
+      where: { id },
+      include: { depoimento: true },
+    }),
+  create: async (data: {
+    depoimento: string;
+    nome: string;
+    cargo: string;
+    fotoUrl: string;
+    status?: WebsiteStatus;
+  }) => {
+    const max = await prisma.websiteDepoimentoOrdem.aggregate({
+      _max: { ordem: true },
+    });
+    const ordem = (max._max.ordem ?? 0) + 1;
+    return prisma.websiteDepoimentoOrdem.create({
+      data: {
+        ordem,
+        status: data.status ?? "RASCUNHO",
+        depoimento: {
+          create: {
+            depoimento: data.depoimento,
+            nome: data.nome,
+            cargo: data.cargo,
+            fotoUrl: data.fotoUrl,
+          },
+        },
+      },
+      include: { depoimento: true },
+    });
+  },
+  update: (
+    depoimentoId: string,
+    data: {
+      depoimento?: string;
+      nome?: string;
+      cargo?: string;
+      fotoUrl?: string;
+      status?: WebsiteStatus;
+      ordem?: number;
+    }
+  ) =>
+    prisma.$transaction(async (tx) => {
+      const current = await tx.websiteDepoimentoOrdem.findUnique({
+        where: { websiteDepoimentoId: depoimentoId },
+      });
+      if (!current) throw new Error("Depoimento não encontrado");
+
+      let ordem = data.ordem ?? current.ordem;
+      if (data.ordem !== undefined && data.ordem !== current.ordem) {
+        if (data.ordem > current.ordem) {
+          await tx.websiteDepoimentoOrdem.updateMany({
+            where: { ordem: { gt: current.ordem, lte: data.ordem } },
+            data: { ordem: { decrement: 1 } },
+          });
+        } else {
+          await tx.websiteDepoimentoOrdem.updateMany({
+            where: { ordem: { gte: data.ordem, lt: current.ordem } },
+            data: { ordem: { increment: 1 } },
+          });
+        }
+        ordem = data.ordem;
+      }
+
+      return tx.websiteDepoimentoOrdem.update({
+        where: { id: current.id },
+        data: {
+          ordem,
+          ...(data.status !== undefined && { status: data.status }),
+          ...(data.depoimento !== undefined ||
+          data.nome !== undefined ||
+          data.cargo !== undefined ||
+          data.fotoUrl !== undefined
+            ? {
+                depoimento: {
+                  update: {
+                    ...(data.depoimento !== undefined && { depoimento: data.depoimento }),
+                    ...(data.nome !== undefined && { nome: data.nome }),
+                    ...(data.cargo !== undefined && { cargo: data.cargo }),
+                    ...(data.fotoUrl !== undefined && { fotoUrl: data.fotoUrl }),
+                  },
+                },
+              }
+            : {}),
+        },
+        include: { depoimento: true },
+      });
+    }),
+  reorder: (ordemId: string, novaOrdem: number) =>
+    prisma.$transaction(async (tx) => {
+      const current = await tx.websiteDepoimentoOrdem.findUnique({
+        where: { id: ordemId },
+        include: { depoimento: true },
+      });
+      if (!current) throw new Error("Depoimento não encontrado");
+
+      if (novaOrdem !== current.ordem) {
+        await tx.websiteDepoimentoOrdem.update({
+          where: { id: ordemId },
+          data: { ordem: 0 },
+        });
+
+        if (novaOrdem > current.ordem) {
+          await tx.websiteDepoimentoOrdem.updateMany({
+            where: { ordem: { gt: current.ordem, lte: novaOrdem } },
+            data: { ordem: { decrement: 1 } },
+          });
+        } else {
+          await tx.websiteDepoimentoOrdem.updateMany({
+            where: { ordem: { gte: novaOrdem, lt: current.ordem } },
+            data: { ordem: { increment: 1 } },
+          });
+        }
+
+        return tx.websiteDepoimentoOrdem.update({
+          where: { id: ordemId },
+          data: { ordem: novaOrdem },
+          include: { depoimento: true },
+        });
+      }
+
+      return current;
+    }),
+  remove: (depoimentoId: string) =>
+    prisma.$transaction(async (tx) => {
+      const ordem = await tx.websiteDepoimentoOrdem.findUnique({
+        where: { websiteDepoimentoId: depoimentoId },
+      });
+      if (!ordem) return;
+      await tx.websiteDepoimentoOrdem.delete({ where: { id: ordem.id } });
+      await tx.websiteDepoimento.delete({ where: { id: depoimentoId } });
+      await tx.websiteDepoimentoOrdem.updateMany({
+        where: { ordem: { gt: ordem.ordem } },
+        data: { ordem: { decrement: 1 } },
+      });
+    }),
+};
+


### PR DESCRIPTION
## Summary
- add Prisma models for website testimonials
- implement depoimentos service, controller and routes with ordering and status support
- document depoimentos endpoints and schemas in Swagger

## Testing
- `pnpm prisma:generate`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb91c6e63883259d7cb2ba1e9d1c4f