### PR TITLE
feat: add daily operating hours to website info

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -715,7 +715,6 @@ model WebsiteInformacoes {
   telefone1              String
   telefone2              String?
   whatsapp               String
-  horarioDeFuncionamento String
   linkedin               String?
   facebook               String?
   instagram              String?
@@ -723,6 +722,19 @@ model WebsiteInformacoes {
   email                  String
   criadoEm               DateTime @default(now())
   atualizadoEm           DateTime @updatedAt
+
+  horarios WebsiteHorarioFuncionamento[]
+}
+
+model WebsiteHorarioFuncionamento {
+  id            String   @id @default(uuid())
+  diaDaSemana   String
+  horarioInicio String
+  horarioFim    String
+  informacoes   WebsiteInformacoes @relation(fields: [informacoesId], references: [id], onDelete: Cascade)
+  informacoesId String
+  criadoEm      DateTime @default(now())
+  atualizadoEm  DateTime @updatedAt
 }
 
 model WebsiteHeaderPage {

--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -2542,6 +2542,14 @@ const options: Options = {
             descricao5: { type: "string", example: "Descrição 5" },
           },
         },
+        WebsiteHorarioFuncionamento: {
+          type: "object",
+          properties: {
+            diaDaSemana: { type: "string", example: "segunda" },
+            horarioInicio: { type: "string", example: "08:00" },
+            horarioFim: { type: "string", example: "18:00" },
+          },
+        },
         WebsiteInformacoes: {
           type: "object",
           properties: {
@@ -2557,9 +2565,11 @@ const options: Options = {
               example: "(11) 9876-5432",
             },
             whatsapp: { type: "string", example: "(11) 91234-5678" },
-            horarioDeFuncionamento: {
-              type: "string",
-              example: "08 as 18",
+            horarios: {
+              type: "array",
+              items: {
+                $ref: '#/components/schemas/WebsiteHorarioFuncionamento',
+              },
             },
             linkedin: {
               type: "string",
@@ -2603,8 +2613,8 @@ const options: Options = {
             "estado",
             "telefone1",
             "whatsapp",
-            "horarioDeFuncionamento",
             "email",
+            "horarios",
           ],
           properties: {
             endereco: { type: "string", example: "Rua A, 123" },
@@ -2614,9 +2624,11 @@ const options: Options = {
             telefone1: { type: "string", example: "(11) 1234-5678" },
             telefone2: { type: "string", example: "(11) 9876-5432" },
             whatsapp: { type: "string", example: "(11) 91234-5678" },
-            horarioDeFuncionamento: {
-              type: "string",
-              example: "08 as 18",
+            horarios: {
+              type: "array",
+              items: {
+                $ref: '#/components/schemas/WebsiteHorarioFuncionamento',
+              },
             },
             linkedin: { type: "string", example: "https://linkedin.com/company/example" },
             facebook: { type: "string", example: "https://facebook.com/example" },
@@ -2635,9 +2647,11 @@ const options: Options = {
             telefone1: { type: "string", example: "(11) 1234-5678" },
             telefone2: { type: "string", example: "(11) 9876-5432" },
             whatsapp: { type: "string", example: "(11) 91234-5678" },
-            horarioDeFuncionamento: {
-              type: "string",
-              example: "08 as 18",
+            horarios: {
+              type: "array",
+              items: {
+                $ref: '#/components/schemas/WebsiteHorarioFuncionamento',
+              },
             },
             linkedin: { type: "string", example: "https://linkedin.com/company/example" },
             facebook: { type: "string", example: "https://facebook.com/example" },

--- a/src/modules/website/controllers/informacoes-gerais.controller.ts
+++ b/src/modules/website/controllers/informacoes-gerais.controller.ts
@@ -25,7 +25,11 @@ export class InformacoesGeraisController {
 
   static create = async (req: Request, res: Response) => {
     try {
-      const info = await informacoesGeraisService.create(req.body);
+      const { horarios = [], ...data } = req.body;
+      const info = await informacoesGeraisService.create({
+        ...data,
+        horarios: { create: horarios },
+      });
       res.status(201).json(info);
     } catch (error: any) {
       res.status(500).json({
@@ -38,7 +42,13 @@ export class InformacoesGeraisController {
   static update = async (req: Request, res: Response) => {
     try {
       const { id } = req.params;
-      const info = await informacoesGeraisService.update(id, req.body);
+      const { horarios, ...data } = req.body;
+      const info = await informacoesGeraisService.update(id, {
+        ...data,
+        ...(horarios && {
+          horarios: { deleteMany: {}, create: horarios },
+        }),
+      });
       res.json(info);
     } catch (error: any) {
       res.status(500).json({

--- a/src/modules/website/routes/informacoes-gerais.ts
+++ b/src/modules/website/routes/informacoes-gerais.ts
@@ -106,7 +106,7 @@ router.get("/:id", InformacoesGeraisController.get);
  *           curl -X POST "http://localhost:3000/api/v1/website/informacoes-gerais" \\
  *            -H "Authorization: Bearer <TOKEN>" \\
  *            -H "Content-Type: application/json" \\
- *            -d '{"endereco":"Rua A, 123","cep":"12345-678","cidade":"Cidade","estado":"ST","telefone1":"(11) 1234-5678","whatsapp":"(11) 91234-5678","horarioDeFuncionamento":"08 as 18","email":"contato@example.com"}'
+ *            -d '{"endereco":"Rua A, 123","cep":"12345-678","cidade":"Cidade","estado":"ST","telefone1":"(11) 1234-5678","whatsapp":"(11) 91234-5678","email":"contato@example.com","horarios":[{"diaDaSemana":"segunda","horarioInicio":"08:00","horarioFim":"18:00"}]}'
  */
 router.post(
   "/",

--- a/src/modules/website/services/informacoes-gerais.service.ts
+++ b/src/modules/website/services/informacoes-gerais.service.ts
@@ -1,13 +1,21 @@
 import { prisma } from "../../../config/prisma";
-import { WebsiteInformacoes } from "@prisma/client";
+import { Prisma } from "@prisma/client";
 
 export const informacoesGeraisService = {
-  list: () => prisma.websiteInformacoes.findMany(),
-  get: (id: string) => prisma.websiteInformacoes.findUnique({ where: { id } }),
-  create: (
-    data: Omit<WebsiteInformacoes, "id" | "criadoEm" | "atualizadoEm">
-  ) => prisma.websiteInformacoes.create({ data }),
-  update: (id: string, data: Partial<WebsiteInformacoes>) =>
-    prisma.websiteInformacoes.update({ where: { id }, data }),
+  list: () =>
+    prisma.websiteInformacoes.findMany({ include: { horarios: true } }),
+  get: (id: string) =>
+    prisma.websiteInformacoes.findUnique({
+      where: { id },
+      include: { horarios: true },
+    }),
+  create: (data: Prisma.WebsiteInformacoesCreateInput) =>
+    prisma.websiteInformacoes.create({ data, include: { horarios: true } }),
+  update: (id: string, data: Prisma.WebsiteInformacoesUpdateInput) =>
+    prisma.websiteInformacoes.update({
+      where: { id },
+      data,
+      include: { horarios: true },
+    }),
   remove: (id: string) => prisma.websiteInformacoes.delete({ where: { id } }),
 };


### PR DESCRIPTION
## Summary
- replace single horarioDeFuncionamento with per-day schedule entries
- expose horarios in website info API and swagger docs

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc2d84654483259b66d6940b6a1a13