### PR TITLE
fix: remove invalid PaymentController export

### DIFF
--- a/src/modules/usuarios/controllers/index.ts
+++ b/src/modules/usuarios/controllers/index.ts
@@ -13,4 +13,3 @@ export {
 
 export { AdminController } from "./admin-controller";
 export { StatsController } from "./stats-controller";
-export { PaymentController } from "./payment-controller";


### PR DESCRIPTION
## Summary
- remove unused PaymentController export from users controllers index to avoid missing module build error

## Testing
- `pnpm build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68c09380b6e483259973fc2bbfd2ab8c