### PR TITLE
feat(website): add login image management

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -313,6 +313,15 @@ model WebsiteLogoEnterpriseOrdem {
   @@unique([ordem])
 }
 
+model WebsiteImagemLogin {
+  id           String   @id @default(uuid())
+  imagemUrl    String
+  imagemTitulo String
+  link         String?
+  criadoEm     DateTime @default(now())
+  atualizadoEm DateTime @updatedAt
+}
+
 model WebsitePlaninhas {
   id        String @id @default(uuid())
   titulo    String

--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -94,6 +94,10 @@ const options: Options = {
         name: "Website - InformacoesGerais",
         description: "Informações gerais do site",
       },
+      {
+        name: "Website - ImagemLogin",
+        description: "Imagem exibida na página de login",
+      },
     ],
     components: {
       schemas: {
@@ -845,6 +849,7 @@ const options: Options = {
                   type: "string",
                   example: "/informacoes-gerais",
                 },
+                imagemLogin: { type: "string", example: "/imagem-login" },
               },
             },
             status: { type: "string", example: "operational" },
@@ -1101,6 +1106,62 @@ const options: Options = {
               description:
                 "Nova posição desejada do logo. Se já houver outro na posição, os demais serão reordenados automaticamente",
             },
+          },
+        },
+        WebsiteImagemLogin: {
+          type: "object",
+          properties: {
+            id: { type: "string", example: "login-uuid" },
+            imagemUrl: {
+              type: "string",
+              format: "uri",
+              example: "https://cdn.example.com/login.png",
+            },
+            imagemTitulo: { type: "string", example: "login" },
+            link: { type: "string", nullable: true, example: "https://example.com" },
+            criadoEm: {
+              type: "string",
+              format: "date-time",
+              example: "2024-01-01T12:00:00Z",
+            },
+            atualizadoEm: {
+              type: "string",
+              format: "date-time",
+              example: "2024-01-01T12:00:00Z",
+            },
+          },
+        },
+        WebsiteImagemLoginCreateInput: {
+          type: "object",
+          properties: {
+            imagem: {
+              type: "string",
+              format: "binary",
+              description: "Arquivo de imagem",
+            },
+            imagemUrl: {
+              type: "string",
+              format: "uri",
+              description: "URL alternativa da imagem",
+              example: "https://cdn.example.com/login.png",
+            },
+            link: {
+              type: "string",
+              nullable: true,
+              example: "https://example.com",
+            },
+          },
+        },
+        WebsiteImagemLoginUpdateInput: {
+          type: "object",
+          properties: {
+            imagem: { type: "string", format: "binary" },
+            imagemUrl: {
+              type: "string",
+              format: "uri",
+              example: "https://cdn.example.com/login.png",
+            },
+            link: { type: "string", nullable: true, example: "https://example.com" },
           },
         },
         WebsiteSlider: {

--- a/src/modules/website/controllers/imagemLogin.controller.ts
+++ b/src/modules/website/controllers/imagemLogin.controller.ts
@@ -1,0 +1,114 @@
+import { Request, Response } from "express";
+import path from "path";
+import { supabase } from "../../superbase/client";
+import { imagemLoginService } from "../services/imagem-login.service";
+
+function generateImageTitle(url: string): string {
+  try {
+    const pathname = new URL(url).pathname;
+    return path.basename(pathname).split(".")[0];
+  } catch {
+    return "";
+  }
+}
+
+async function uploadImage(file: Express.Multer.File): Promise<string> {
+  const fileExt = path.extname(file.originalname);
+  const fileName = `login-${Date.now()}${fileExt}`;
+  const { error } = await supabase.storage
+    .from("website")
+    .upload(`login/${fileName}`, file.buffer, {
+      contentType: file.mimetype,
+    });
+  if (error) throw error;
+  const { data } = supabase.storage
+    .from("website")
+    .getPublicUrl(`login/${fileName}`);
+  return data.publicUrl;
+}
+
+export class ImagemLoginController {
+  static list = async (req: Request, res: Response) => {
+    const itens = await imagemLoginService.list();
+    res.json(itens);
+  };
+
+  static get = async (req: Request, res: Response) => {
+    try {
+      const { id } = req.params;
+      const item = await imagemLoginService.get(id);
+      if (!item) {
+        return res
+          .status(404)
+          .json({ message: "Imagem de login não encontrada" });
+      }
+      res.json(item);
+    } catch (error: any) {
+      res.status(500).json({
+        message: "Erro ao buscar imagem de login",
+        error: error.message,
+      });
+    }
+  };
+
+  static create = async (req: Request, res: Response) => {
+    try {
+      const { link } = req.body;
+      let imagemUrl = "";
+      if (req.file) {
+        imagemUrl = await uploadImage(req.file);
+      } else if (req.body.imagemUrl) {
+        imagemUrl = req.body.imagemUrl;
+      }
+      const imagemTitulo = imagemUrl ? generateImageTitle(imagemUrl) : "";
+      const item = await imagemLoginService.create({
+        imagemUrl,
+        imagemTitulo,
+        link,
+      });
+      res.status(201).json(item);
+    } catch (error: any) {
+      res.status(500).json({
+        message: "Erro ao criar imagem de login",
+        error: error.message,
+      });
+    }
+  };
+
+  static update = async (req: Request, res: Response) => {
+    try {
+      const { id } = req.params;
+      const { link } = req.body;
+      let imagemUrl: string | undefined = req.body.imagemUrl;
+      if (req.file) {
+        imagemUrl = await uploadImage(req.file);
+      }
+      const data: any = { link };
+      if (imagemUrl !== undefined) {
+        data.imagemUrl = imagemUrl;
+        data.imagemTitulo = generateImageTitle(imagemUrl);
+      }
+      const item = await imagemLoginService.update(id, data);
+      res.json(item);
+    } catch (error: any) {
+      res.status(500).json({
+        message: "Erro ao atualizar imagem de login",
+        error: error.message,
+      });
+    }
+  };
+
+  static remove = async (req: Request, res: Response) => {
+    try {
+      const { id } = req.params;
+      await imagemLoginService.remove(id);
+      res.status(204).send();
+    } catch (error: any) {
+      res.status(500).json({
+        message: "Erro ao remover imagem de login",
+        error: error.message,
+      });
+    }
+  };
+}
+

--- a/src/modules/website/routes/imagem-login.ts
+++ b/src/modules/website/routes/imagem-login.ts
@@ -1,0 +1,217 @@
+import { Router } from "express";
+import multer from "multer";
+import { supabaseAuthMiddleware } from "../../usuarios/auth";
+import { ImagemLoginController } from "../controllers/imagemLogin.controller";
+
+const router = Router();
+const upload = multer({ storage: multer.memoryStorage() });
+
+/**
+ * @openapi
+ * /api/v1/website/imagem-login:
+ *   get:
+ *     summary: Listar imagens de login
+ *     tags: [Website - ImagemLogin]
+ *     responses:
+ *       200:
+ *         description: Lista de imagens
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 $ref: '#/components/schemas/WebsiteImagemLogin'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X GET "http://localhost:3000/api/v1/website/imagem-login"
+ */
+router.get("/", ImagemLoginController.list);
+
+/**
+ * @openapi
+ * /api/v1/website/imagem-login/{id}:
+ *   get:
+ *     summary: Obter imagem de login por ID
+ *     tags: [Website - ImagemLogin]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Imagem encontrada
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/WebsiteImagemLogin'
+ *       404:
+ *         description: Imagem não encontrada
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X GET "http://localhost:3000/api/v1/website/imagem-login/{id}"
+ */
+router.get("/:id", ImagemLoginController.get);
+
+/**
+ * @openapi
+ * /api/v1/website/imagem-login:
+ *   post:
+ *     summary: Criar imagem de login
+ *     tags: [Website - ImagemLogin]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         multipart/form-data:
+ *           schema:
+ *             $ref: '#/components/schemas/WebsiteImagemLoginCreateInput'
+ *     responses:
+ *       201:
+ *         description: Imagem criada
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/WebsiteImagemLogin'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X POST "http://localhost:3000/api/v1/website/imagem-login" \\
+ *            -H "Authorization: Bearer <TOKEN>" \\
+ *            -F "imagem=@login.png" \\
+ *            -F "link=https://example.com"
+ */
+router.post(
+  "/",
+  supabaseAuthMiddleware(["ADMIN", "MODERADOR"]),
+  upload.single("imagem"),
+  ImagemLoginController.create
+);
+
+/**
+ * @openapi
+ * /api/v1/website/imagem-login/{id}:
+ *   put:
+ *     summary: Atualizar imagem de login
+ *     tags: [Website - ImagemLogin]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     requestBody:
+ *       content:
+ *         multipart/form-data:
+ *           schema:
+ *             $ref: '#/components/schemas/WebsiteImagemLoginUpdateInput'
+ *     responses:
+ *       200:
+ *         description: Imagem atualizada
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/WebsiteImagemLogin'
+ *       404:
+ *         description: Imagem não encontrada
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X PUT "http://localhost:3000/api/v1/website/imagem-login/{id}" \\
+ *            -H "Authorization: Bearer <TOKEN>" \\
+ *            -F "link=https://example.com" \\
+ *            -F "imagem=@login.png"
+ */
+router.put(
+  "/:id",
+  supabaseAuthMiddleware(["ADMIN", "MODERADOR"]),
+  upload.single("imagem"),
+  ImagemLoginController.update
+);
+
+/**
+ * @openapi
+ * /api/v1/website/imagem-login/{id}:
+ *   delete:
+ *     summary: Remover imagem de login
+ *     tags: [Website - ImagemLogin]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       204:
+ *         description: Imagem removida
+ *       404:
+ *         description: Imagem não encontrada
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X DELETE "http://localhost:3000/api/v1/website/imagem-login/{id}" \\
+ *            -H "Authorization: Bearer <TOKEN>"
+ */
+router.delete(
+  "/:id",
+  supabaseAuthMiddleware(["ADMIN", "MODERADOR"]),
+  ImagemLoginController.remove
+);
+
+export { router as imagemLoginRoutes };
+

--- a/src/modules/website/routes/index.ts
+++ b/src/modules/website/routes/index.ts
@@ -18,6 +18,7 @@ import { treinamentosInCompanyRoutes } from "./treinamentos-in-company";
 import { headerPagesRoutes } from "./header-pages";
 import { depoimentosRoutes } from "./depoimentos";
 import { informacoesGeraisRoutes } from "./informacoes-gerais";
+import { imagemLoginRoutes } from "./imagem-login";
 
 const router = Router();
 
@@ -71,6 +72,7 @@ router.get("/", (req, res) => {
       headerPages: "/header-pages",
       depoimentos: "/depoimentos",
       informacoesGerais: "/informacoes-gerais",
+      imagemLogin: "/imagem-login",
     },
     status: "operational",
   });
@@ -95,5 +97,6 @@ router.use("/treinamentos-in-company", treinamentosInCompanyRoutes);
 router.use("/header-pages", headerPagesRoutes);
 router.use("/depoimentos", depoimentosRoutes);
 router.use("/informacoes-gerais", informacoesGeraisRoutes);
+router.use("/imagem-login", imagemLoginRoutes);
 
 export { router as websiteRoutes };

--- a/src/modules/website/services/imagem-login.service.ts
+++ b/src/modules/website/services/imagem-login.service.ts
@@ -1,0 +1,14 @@
+import { prisma } from "../../../config/prisma";
+import { WebsiteImagemLogin } from "@prisma/client";
+
+export const imagemLoginService = {
+  list: () => prisma.websiteImagemLogin.findMany(),
+  get: (id: string) => prisma.websiteImagemLogin.findUnique({ where: { id } }),
+  create: (
+    data: Omit<WebsiteImagemLogin, "id" | "criadoEm" | "atualizadoEm">
+  ) => prisma.websiteImagemLogin.create({ data }),
+  update: (id: string, data: Partial<WebsiteImagemLogin>) =>
+    prisma.websiteImagemLogin.update({ where: { id }, data }),
+  remove: (id: string) => prisma.websiteImagemLogin.delete({ where: { id } }),
+};
+


### PR DESCRIPTION
## Summary
- add WebsiteImagemLogin model and Prisma client update
- implement CRUD controller/service/routes with Supabase upload
- document ImagemLogin endpoints in Swagger/Redoc

## Testing
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68c3000db09c83258aca184cc141bc1f