### PR TITLE
feat: optimize ordem queries

### DIFF
--- a/prisma/migrations/20240621120000_add-ordem-index/migration.sql
+++ b/prisma/migrations/20240621120000_add-ordem-index/migration.sql
@@ -1,0 +1,14 @@
+-- CreateIndex
+CREATE INDEX "WebsiteTeamOrdem_ordem_idx" ON "WebsiteTeamOrdem"("ordem");
+
+-- CreateIndex
+CREATE INDEX "WebsiteDepoimentoOrdem_ordem_idx" ON "WebsiteDepoimentoOrdem"("ordem");
+
+-- CreateIndex
+CREATE INDEX "WebsiteSliderOrdem_ordem_idx" ON "WebsiteSliderOrdem"("ordem");
+
+-- CreateIndex
+CREATE INDEX "WebsiteBannerOrdem_ordem_idx" ON "WebsiteBannerOrdem"("ordem");
+
+-- CreateIndex
+CREATE INDEX "WebsiteLogoEnterpriseOrdem_ordem_idx" ON "WebsiteLogoEnterpriseOrdem"("ordem");

--- a/prisma/migrations/migration_lock.toml
+++ b/prisma/migrations/migration_lock.toml
@@ -1,0 +1,2 @@
+# Prisma Migrate lockfile
+provider = "postgresql"

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -194,6 +194,7 @@ model WebsiteTeamOrdem {
   team          WebsiteTeam  @relation(fields: [websiteTeamId], references: [id], onDelete: Cascade)
 
   @@unique([ordem])
+  @@index([ordem])
 }
 
 model WebsiteDepoimento {
@@ -218,6 +219,7 @@ model WebsiteDepoimentoOrdem {
   depoimento           WebsiteDepoimento @relation(fields: [websiteDepoimentoId], references: [id], onDelete: Cascade)
 
   @@unique([ordem])
+  @@index([ordem])
 }
 
 model WebsiteDiferenciais {
@@ -264,6 +266,7 @@ model WebsiteSliderOrdem {
   slider          WebsiteSlider      @relation(fields: [websiteSliderId], references: [id], onDelete: Cascade)
 
   @@unique([ordem, orientacao])
+  @@index([ordem])
 }
 
 model WebsiteBanner {
@@ -287,6 +290,7 @@ model WebsiteBannerOrdem {
   banner          WebsiteBanner @relation(fields: [websiteBannerId], references: [id], onDelete: Cascade)
 
   @@unique([ordem])
+  @@index([ordem])
 }
 
 model WebsiteLogoEnterprise {
@@ -311,6 +315,7 @@ model WebsiteLogoEnterpriseOrdem {
   logo WebsiteLogoEnterprise @relation(fields: [websiteLogoEnterpriseId], references: [id], onDelete: Cascade)
 
   @@unique([ordem])
+  @@index([ordem])
 }
 
 model WebsiteImagemLogin {

--- a/src/modules/website/services/banner.service.ts
+++ b/src/modules/website/services/banner.service.ts
@@ -4,14 +4,39 @@ import { WebsiteStatus } from "@prisma/client";
 export const bannerService = {
   list: () =>
     prisma.websiteBannerOrdem.findMany({
-      include: { banner: true },
       orderBy: { ordem: "asc" },
+      take: 100,
+      select: {
+        id: true,
+        ordem: true,
+        status: true,
+        banner: {
+          select: {
+            id: true,
+            imagemUrl: true,
+            imagemTitulo: true,
+            link: true,
+          },
+        },
+      },
     }),
 
   get: (id: string) =>
     prisma.websiteBannerOrdem.findUnique({
       where: { id },
-      include: { banner: true },
+      select: {
+        id: true,
+        ordem: true,
+        status: true,
+        banner: {
+          select: {
+            id: true,
+            imagemUrl: true,
+            imagemTitulo: true,
+            link: true,
+          },
+        },
+      },
     }),
 
   create: (data: {
@@ -36,7 +61,19 @@ export const bannerService = {
             },
           },
         },
-        include: { banner: true },
+        select: {
+          id: true,
+          ordem: true,
+          status: true,
+          banner: {
+            select: {
+              id: true,
+              imagemUrl: true,
+              imagemTitulo: true,
+              link: true,
+            },
+          },
+        },
       });
     }),
 
@@ -90,7 +127,19 @@ export const bannerService = {
                 }
               : undefined,
         },
-        include: { banner: true },
+        select: {
+          id: true,
+          ordem: true,
+          status: true,
+          banner: {
+            select: {
+              id: true,
+              imagemUrl: true,
+              imagemTitulo: true,
+              link: true,
+            },
+          },
+        },
       });
     }),
 
@@ -98,7 +147,18 @@ export const bannerService = {
     prisma.$transaction(async (tx) => {
       const current = await tx.websiteBannerOrdem.findUnique({
         where: { id: ordemId },
-        include: { banner: true },
+        select: {
+          id: true,
+          ordem: true,
+          banner: {
+            select: {
+              id: true,
+              imagemUrl: true,
+              imagemTitulo: true,
+              link: true,
+            },
+          },
+        },
       });
       if (!current) throw new Error("Banner não encontrado");
 
@@ -123,7 +183,18 @@ export const bannerService = {
         return tx.websiteBannerOrdem.update({
           where: { id: ordemId },
           data: { ordem: novaOrdem },
-          include: { banner: true },
+          select: {
+            id: true,
+            ordem: true,
+            banner: {
+              select: {
+                id: true,
+                imagemUrl: true,
+                imagemTitulo: true,
+                link: true,
+              },
+            },
+          },
         });
       }
 
@@ -134,6 +205,7 @@ export const bannerService = {
     prisma.$transaction(async (tx) => {
       const ordem = await tx.websiteBannerOrdem.findUnique({
         where: { websiteBannerId: bannerId },
+        select: { id: true, ordem: true },
       });
       if (!ordem) return;
       await tx.websiteBannerOrdem.delete({ where: { id: ordem.id } });

--- a/src/modules/website/services/depoimentos.service.ts
+++ b/src/modules/website/services/depoimentos.service.ts
@@ -4,14 +4,41 @@ import { WebsiteStatus } from "@prisma/client";
 export const depoimentosService = {
   list: (status?: WebsiteStatus) =>
     prisma.websiteDepoimentoOrdem.findMany({
-      include: { depoimento: true },
       where: status ? { status } : undefined,
       orderBy: { ordem: "asc" },
+      take: 100,
+      select: {
+        id: true,
+        ordem: true,
+        status: true,
+        depoimento: {
+          select: {
+            id: true,
+            depoimento: true,
+            nome: true,
+            cargo: true,
+            fotoUrl: true,
+          },
+        },
+      },
     }),
   get: (id: string) =>
     prisma.websiteDepoimentoOrdem.findUnique({
       where: { id },
-      include: { depoimento: true },
+      select: {
+        id: true,
+        ordem: true,
+        status: true,
+        depoimento: {
+          select: {
+            id: true,
+            depoimento: true,
+            nome: true,
+            cargo: true,
+            fotoUrl: true,
+          },
+        },
+      },
     }),
   create: async (data: {
     depoimento: string;
@@ -37,7 +64,20 @@ export const depoimentosService = {
           },
         },
       },
-      include: { depoimento: true },
+      select: {
+        id: true,
+        ordem: true,
+        status: true,
+        depoimento: {
+          select: {
+            id: true,
+            depoimento: true,
+            nome: true,
+            cargo: true,
+            fotoUrl: true,
+          },
+        },
+      },
     });
   },
   update: (
@@ -85,7 +125,9 @@ export const depoimentosService = {
             ? {
                 depoimento: {
                   update: {
-                    ...(data.depoimento !== undefined && { depoimento: data.depoimento }),
+                    ...(data.depoimento !== undefined && {
+                      depoimento: data.depoimento,
+                    }),
                     ...(data.nome !== undefined && { nome: data.nome }),
                     ...(data.cargo !== undefined && { cargo: data.cargo }),
                     ...(data.fotoUrl !== undefined && { fotoUrl: data.fotoUrl }),
@@ -94,14 +136,39 @@ export const depoimentosService = {
               }
             : {}),
         },
-        include: { depoimento: true },
+        select: {
+          id: true,
+          ordem: true,
+          status: true,
+          depoimento: {
+            select: {
+              id: true,
+              depoimento: true,
+              nome: true,
+              cargo: true,
+              fotoUrl: true,
+            },
+          },
+        },
       });
     }),
   reorder: (ordemId: string, novaOrdem: number) =>
     prisma.$transaction(async (tx) => {
       const current = await tx.websiteDepoimentoOrdem.findUnique({
         where: { id: ordemId },
-        include: { depoimento: true },
+        select: {
+          id: true,
+          ordem: true,
+          depoimento: {
+            select: {
+              id: true,
+              depoimento: true,
+              nome: true,
+              cargo: true,
+              fotoUrl: true,
+            },
+          },
+        },
       });
       if (!current) throw new Error("Depoimento não encontrado");
 
@@ -126,7 +193,19 @@ export const depoimentosService = {
         return tx.websiteDepoimentoOrdem.update({
           where: { id: ordemId },
           data: { ordem: novaOrdem },
-          include: { depoimento: true },
+          select: {
+            id: true,
+            ordem: true,
+            depoimento: {
+              select: {
+                id: true,
+                depoimento: true,
+                nome: true,
+                cargo: true,
+                fotoUrl: true,
+              },
+            },
+          },
         });
       }
 
@@ -136,6 +215,7 @@ export const depoimentosService = {
     prisma.$transaction(async (tx) => {
       const ordem = await tx.websiteDepoimentoOrdem.findUnique({
         where: { websiteDepoimentoId: depoimentoId },
+        select: { id: true, ordem: true },
       });
       if (!ordem) return;
       await tx.websiteDepoimentoOrdem.delete({ where: { id: ordem.id } });

--- a/src/modules/website/services/informacoes-gerais.service.ts
+++ b/src/modules/website/services/informacoes-gerais.service.ts
@@ -3,19 +3,113 @@ import { Prisma } from "@prisma/client";
 
 export const informacoesGeraisService = {
   list: () =>
-    prisma.websiteInformacoes.findMany({ include: { horarios: true } }),
+    prisma.websiteInformacoes.findMany({
+      select: {
+        id: true,
+        endereco: true,
+        cep: true,
+        cidade: true,
+        estado: true,
+        telefone1: true,
+        telefone2: true,
+        whatsapp: true,
+        linkedin: true,
+        facebook: true,
+        instagram: true,
+        youtube: true,
+        email: true,
+        horarios: {
+          select: {
+            id: true,
+            diaDaSemana: true,
+            horarioInicio: true,
+            horarioFim: true,
+          },
+        },
+      },
+    }),
   get: (id: string) =>
     prisma.websiteInformacoes.findUnique({
       where: { id },
-      include: { horarios: true },
+      select: {
+        id: true,
+        endereco: true,
+        cep: true,
+        cidade: true,
+        estado: true,
+        telefone1: true,
+        telefone2: true,
+        whatsapp: true,
+        linkedin: true,
+        facebook: true,
+        instagram: true,
+        youtube: true,
+        email: true,
+        horarios: {
+          select: {
+            id: true,
+            diaDaSemana: true,
+            horarioInicio: true,
+            horarioFim: true,
+          },
+        },
+      },
     }),
   create: (data: Prisma.WebsiteInformacoesCreateInput) =>
-    prisma.websiteInformacoes.create({ data, include: { horarios: true } }),
+    prisma.websiteInformacoes.create({
+      data,
+      select: {
+        id: true,
+        endereco: true,
+        cep: true,
+        cidade: true,
+        estado: true,
+        telefone1: true,
+        telefone2: true,
+        whatsapp: true,
+        linkedin: true,
+        facebook: true,
+        instagram: true,
+        youtube: true,
+        email: true,
+        horarios: {
+          select: {
+            id: true,
+            diaDaSemana: true,
+            horarioInicio: true,
+            horarioFim: true,
+          },
+        },
+      },
+    }),
   update: (id: string, data: Prisma.WebsiteInformacoesUpdateInput) =>
     prisma.websiteInformacoes.update({
       where: { id },
       data,
-      include: { horarios: true },
+      select: {
+        id: true,
+        endereco: true,
+        cep: true,
+        cidade: true,
+        estado: true,
+        telefone1: true,
+        telefone2: true,
+        whatsapp: true,
+        linkedin: true,
+        facebook: true,
+        instagram: true,
+        youtube: true,
+        email: true,
+        horarios: {
+          select: {
+            id: true,
+            diaDaSemana: true,
+            horarioInicio: true,
+            horarioFim: true,
+          },
+        },
+      },
     }),
-  remove: (id: string) => prisma.websiteInformacoes.delete({ where: { id } }),
+  remove: (id: string) =>
+    prisma.websiteInformacoes.delete({ where: { id }, select: { id: true } }),
 };

--- a/src/modules/website/services/logoEnterprise.service.ts
+++ b/src/modules/website/services/logoEnterprise.service.ts
@@ -4,14 +4,41 @@ import { WebsiteStatus } from "@prisma/client";
 export const logoEnterpriseService = {
   list: () =>
     prisma.websiteLogoEnterpriseOrdem.findMany({
-      include: { logo: true },
       orderBy: { ordem: "asc" },
+      take: 100,
+      select: {
+        id: true,
+        ordem: true,
+        status: true,
+        logo: {
+          select: {
+            id: true,
+            nome: true,
+            imagemUrl: true,
+            imagemAlt: true,
+            website: true,
+          },
+        },
+      },
     }),
 
   get: (id: string) =>
     prisma.websiteLogoEnterpriseOrdem.findUnique({
       where: { id },
-      include: { logo: true },
+      select: {
+        id: true,
+        ordem: true,
+        status: true,
+        logo: {
+          select: {
+            id: true,
+            nome: true,
+            imagemUrl: true,
+            imagemAlt: true,
+            website: true,
+          },
+        },
+      },
     }),
 
   create: (data: {
@@ -40,7 +67,20 @@ export const logoEnterpriseService = {
             },
           },
         },
-        include: { logo: true },
+        select: {
+          id: true,
+          ordem: true,
+          status: true,
+          logo: {
+            select: {
+              id: true,
+              nome: true,
+              imagemUrl: true,
+              imagemAlt: true,
+              website: true,
+            },
+          },
+        },
       });
     }),
 
@@ -99,7 +139,20 @@ export const logoEnterpriseService = {
                 }
               : undefined,
         },
-        include: { logo: true },
+        select: {
+          id: true,
+          ordem: true,
+          status: true,
+          logo: {
+            select: {
+              id: true,
+              nome: true,
+              imagemUrl: true,
+              imagemAlt: true,
+              website: true,
+            },
+          },
+        },
       });
     }),
 
@@ -107,7 +160,19 @@ export const logoEnterpriseService = {
     prisma.$transaction(async (tx) => {
       const current = await tx.websiteLogoEnterpriseOrdem.findUnique({
         where: { id: ordemId },
-        include: { logo: true },
+        select: {
+          id: true,
+          ordem: true,
+          logo: {
+            select: {
+              id: true,
+              nome: true,
+              imagemUrl: true,
+              imagemAlt: true,
+              website: true,
+            },
+          },
+        },
       });
       if (!current) throw new Error("Logo não encontrada");
 
@@ -132,7 +197,19 @@ export const logoEnterpriseService = {
         return tx.websiteLogoEnterpriseOrdem.update({
           where: { id: ordemId },
           data: { ordem: novaOrdem },
-          include: { logo: true },
+          select: {
+            id: true,
+            ordem: true,
+            logo: {
+              select: {
+                id: true,
+                nome: true,
+                imagemUrl: true,
+                imagemAlt: true,
+                website: true,
+              },
+            },
+          },
         });
       }
 
@@ -143,6 +220,7 @@ export const logoEnterpriseService = {
     prisma.$transaction(async (tx) => {
       const ordem = await tx.websiteLogoEnterpriseOrdem.findUnique({
         where: { websiteLogoEnterpriseId: logoId },
+        select: { id: true, ordem: true },
       });
       if (!ordem) return;
       await tx.websiteLogoEnterpriseOrdem.delete({ where: { id: ordem.id } });

--- a/src/modules/website/services/slider.service.ts
+++ b/src/modules/website/services/slider.service.ts
@@ -4,14 +4,41 @@ import { SliderOrientation, WebsiteStatus } from "@prisma/client";
 export const sliderService = {
   list: () =>
     prisma.websiteSliderOrdem.findMany({
-      include: { slider: true },
       orderBy: { ordem: "asc" },
+      take: 100,
+      select: {
+        id: true,
+        ordem: true,
+        orientacao: true,
+        status: true,
+        slider: {
+          select: {
+            id: true,
+            sliderName: true,
+            imagemUrl: true,
+            link: true,
+          },
+        },
+      },
     }),
 
   get: (id: string) =>
     prisma.websiteSliderOrdem.findUnique({
       where: { id },
-      include: { slider: true },
+      select: {
+        id: true,
+        ordem: true,
+        orientacao: true,
+        status: true,
+        slider: {
+          select: {
+            id: true,
+            sliderName: true,
+            imagemUrl: true,
+            link: true,
+          },
+        },
+      },
     }),
 
   create: async (data: {
@@ -40,7 +67,20 @@ export const sliderService = {
           },
         },
       },
-      include: { slider: true },
+      select: {
+        id: true,
+        ordem: true,
+        orientacao: true,
+        status: true,
+        slider: {
+          select: {
+            id: true,
+            sliderName: true,
+            imagemUrl: true,
+            link: true,
+          },
+        },
+      },
     });
   },
 
@@ -125,7 +165,20 @@ export const sliderService = {
                 }
               : undefined,
         },
-        include: { slider: true },
+        select: {
+          id: true,
+          ordem: true,
+          orientacao: true,
+          status: true,
+          slider: {
+            select: {
+              id: true,
+              sliderName: true,
+              imagemUrl: true,
+              link: true,
+            },
+          },
+        },
       });
     }),
 
@@ -133,7 +186,19 @@ export const sliderService = {
     prisma.$transaction(async (tx) => {
       const current = await tx.websiteSliderOrdem.findUnique({
         where: { id: ordemId },
-        include: { slider: true },
+        select: {
+          id: true,
+          ordem: true,
+          orientacao: true,
+          slider: {
+            select: {
+              id: true,
+              sliderName: true,
+              imagemUrl: true,
+              link: true,
+            },
+          },
+        },
       });
       if (!current) throw new Error("Slider não encontrado");
 
@@ -164,7 +229,19 @@ export const sliderService = {
         return tx.websiteSliderOrdem.update({
           where: { id: ordemId },
           data: { ordem: novaOrdem },
-          include: { slider: true },
+          select: {
+            id: true,
+            ordem: true,
+            orientacao: true,
+            slider: {
+              select: {
+                id: true,
+                sliderName: true,
+                imagemUrl: true,
+                link: true,
+              },
+            },
+          },
         });
       }
 
@@ -175,6 +252,7 @@ export const sliderService = {
     await prisma.$transaction(async (tx) => {
       const ordem = await tx.websiteSliderOrdem.findUnique({
         where: { websiteSliderId: sliderId },
+        select: { id: true, ordem: true, orientacao: true },
       });
       if (!ordem) return;
       await tx.websiteSliderOrdem.delete({ where: { id: ordem.id } });

--- a/src/modules/website/services/team.service.ts
+++ b/src/modules/website/services/team.service.ts
@@ -4,14 +4,29 @@ import { WebsiteStatus } from "@prisma/client";
 export const teamService = {
   list: (status?: WebsiteStatus) =>
     prisma.websiteTeamOrdem.findMany({
-      include: { team: true },
       where: status ? { status } : undefined,
       orderBy: { ordem: "asc" },
+      take: 100,
+      select: {
+        id: true,
+        ordem: true,
+        status: true,
+        team: {
+          select: { id: true, photoUrl: true, nome: true, cargo: true },
+        },
+      },
     }),
   get: (id: string) =>
     prisma.websiteTeamOrdem.findUnique({
       where: { id },
-      include: { team: true },
+      select: {
+        id: true,
+        ordem: true,
+        status: true,
+        team: {
+          select: { id: true, photoUrl: true, nome: true, cargo: true },
+        },
+      },
     }),
   create: async (data: {
     photoUrl: string;
@@ -35,7 +50,14 @@ export const teamService = {
           },
         },
       },
-      include: { team: true },
+      select: {
+        id: true,
+        ordem: true,
+        status: true,
+        team: {
+          select: { id: true, photoUrl: true, nome: true, cargo: true },
+        },
+      },
     });
   },
   update: (
@@ -89,14 +111,25 @@ export const teamService = {
               }
             : {}),
         },
-        include: { team: true },
+        select: {
+          id: true,
+          ordem: true,
+          status: true,
+          team: {
+            select: { id: true, photoUrl: true, nome: true, cargo: true },
+          },
+        },
       });
     }),
   reorder: (ordemId: string, novaOrdem: number) =>
     prisma.$transaction(async (tx) => {
       const current = await tx.websiteTeamOrdem.findUnique({
         where: { id: ordemId },
-        include: { team: true },
+        select: {
+          id: true,
+          ordem: true,
+          team: { select: { id: true, photoUrl: true, nome: true, cargo: true } },
+        },
       });
       if (!current) throw new Error("Team member não encontrado");
 
@@ -121,7 +154,13 @@ export const teamService = {
         return tx.websiteTeamOrdem.update({
           where: { id: ordemId },
           data: { ordem: novaOrdem },
-          include: { team: true },
+          select: {
+            id: true,
+            ordem: true,
+            team: {
+              select: { id: true, photoUrl: true, nome: true, cargo: true },
+            },
+          },
         });
       }
 
@@ -131,6 +170,7 @@ export const teamService = {
     prisma.$transaction(async (tx) => {
       const ordem = await tx.websiteTeamOrdem.findUnique({
         where: { websiteTeamId: teamId },
+        select: { id: true, ordem: true },
       });
       if (!ordem) return;
       await tx.websiteTeamOrdem.delete({ where: { id: ordem.id } });


### PR DESCRIPTION
## Summary
- add indexes for frequently filtered `ordem` columns
- limit website service queries with select and pagination

## Testing
- `npx prisma migrate dev --name add-ordem-index` *(fails: Can't reach database server at `localhost:5432`)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c33d0d94c08325b22f2e7abfae62ac