### PR TITLE
feat: add indexes for frequent Usuario filters

### DIFF
--- a/prisma/migrations/20240730120000_add-usuario-indexes/migration.sql
+++ b/prisma/migrations/20240730120000_add-usuario-indexes/migration.sql
@@ -1,0 +1,11 @@
+-- CreateIndex
+CREATE INDEX "Usuario_status_idx" ON "Usuario"("status");
+
+-- CreateIndex
+CREATE INDEX "Usuario_role_idx" ON "Usuario"("role");
+
+-- CreateIndex
+CREATE INDEX "Usuario_tipoUsuario_idx" ON "Usuario"("tipoUsuario");
+
+-- CreateIndex
+CREATE INDEX "Usuario_criadoEm_idx" ON "Usuario"("criadoEm");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -48,11 +48,15 @@ model Usuario {
   enderecos     Endereco[]
   empresa       Empresa?    @relation(fields: [codEmpresa], references: [id])
   codigoUsuario CodigoUsuario?
-  
-  
-  
+
+
+
   @@index([tokenRecuperacao])
   @@index([emailVerificationToken])
+  @@index([status])
+  @@index([role])
+  @@index([tipoUsuario])
+  @@index([criadoEm])
 }
 
 model Empresa {


### PR DESCRIPTION
## Summary
- index Usuario by status, role, tipoUsuario and criadoEm for faster queries
- create migration for new indexes

## Testing
- `pnpm prisma:migrate` *(fails: command not found: pnpm)*
- `pnpm test` *(fails: command not found: pnpm)*

------
https://chatgpt.com/codex/tasks/task_e_68c348f5bee08325b22cc778dea4376d