### PR TITLE
feat: introduce redis caching for website services

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,14 @@ NODE_ENV=development
 PORT=3000
 
 # =============================================
+# CACHE (OPCIONAL)
+# =============================================
+# URL de conexão do Redis
+REDIS_URL=redis://localhost:6379
+# Tempo de vida padrão do cache em segundos
+CACHE_TTL=60
+
+# =============================================
 # KEEP ALIVE (OPCIONAL)
 # =============================================
 # URL que será pingada periodicamente para manter a instância ativa

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "dotenv": "^17.2.1",
     "express": "^4.19.2",
     "helmet": "^8.1.0",
+    "ioredis": "^5.7.0",
     "jsonwebtoken": "^9.0.2",
     "jwks-rsa": "^3.2.0",
     "multer": "^2.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       helmet:
         specifier: ^8.1.0
         version: 8.1.0
+      ioredis:
+        specifier: ^5.7.0
+        version: 5.7.0
       jsonwebtoken:
         specifier: ^9.0.2
         version: 9.0.2
@@ -332,6 +335,9 @@ packages:
   '@humanwhocodes/object-schema@2.0.3':
     resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
     deprecated: Use @eslint/object-schema instead
+
+  '@ioredis/commands@1.3.1':
+    resolution: {integrity: sha512-bYtU8avhGIcje3IhvF9aSjsa5URMZBHnwKtOvXsT4sfYy9gppW11gLPT/9oNqlJZD47yPKveQFTAFWpHjKvUoQ==}
 
   '@istanbuljs/load-nyc-config@1.1.0':
     resolution: {integrity: sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==}
@@ -870,6 +876,10 @@ packages:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
 
+  cluster-key-slot@1.1.2:
+    resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
+    engines: {node: '>=0.10.0'}
+
   co@4.6.0:
     resolution: {integrity: sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==}
     engines: {iojs: '>= 1.0.0', node: '>= 0.12.0'}
@@ -1012,6 +1022,10 @@ packages:
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
+
+  denque@2.1.0:
+    resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
+    engines: {node: '>=0.10'}
 
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
@@ -1415,6 +1429,10 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
+  ioredis@5.7.0:
+    resolution: {integrity: sha512-NUcA93i1lukyXU+riqEyPtSEkyFq8tX90uL659J+qpCZ3rEdViB/APC58oAhIh3+bJln2hzdlZbBZsGNrlsR8g==}
+    engines: {node: '>=12.22.0'}
+
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
@@ -1724,12 +1742,18 @@ packages:
   lodash.clonedeep@4.5.0:
     resolution: {integrity: sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==}
 
+  lodash.defaults@4.2.0:
+    resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
+
   lodash.get@4.4.2:
     resolution: {integrity: sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==}
     deprecated: This package is deprecated. Use the optional chaining (?.) operator instead.
 
   lodash.includes@4.3.0:
     resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
+
+  lodash.isarguments@3.1.0:
+    resolution: {integrity: sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==}
 
   lodash.isboolean@3.0.3:
     resolution: {integrity: sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==}
@@ -2077,6 +2101,14 @@ packages:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
 
+  redis-errors@1.2.0:
+    resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
+    engines: {node: '>=4'}
+
+  redis-parser@3.0.0:
+    resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
+    engines: {node: '>=4'}
+
   request@2.88.2:
     resolution: {integrity: sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==}
     engines: {node: '>= 6'}
@@ -2208,6 +2240,9 @@ packages:
   stack-utils@2.0.6:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
     engines: {node: '>=10'}
+
+  standard-as-callback@2.1.0:
+    resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
 
   statuses@2.0.1:
     resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
@@ -2818,6 +2853,8 @@ snapshots:
   '@humanwhocodes/module-importer@1.0.1': {}
 
   '@humanwhocodes/object-schema@2.0.3': {}
+
+  '@ioredis/commands@1.3.1': {}
 
   '@istanbuljs/load-nyc-config@1.1.0':
     dependencies:
@@ -3543,6 +3580,8 @@ snapshots:
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
 
+  cluster-key-slot@1.1.2: {}
+
   co@4.6.0: {}
 
   collect-v8-coverage@1.0.2: {}
@@ -3655,6 +3694,8 @@ snapshots:
   defu@6.1.4: {}
 
   delayed-stream@1.0.0: {}
+
+  denque@2.1.0: {}
 
   depd@2.0.0: {}
 
@@ -4121,6 +4162,20 @@ snapshots:
       wrappy: 1.0.2
 
   inherits@2.0.4: {}
+
+  ioredis@5.7.0:
+    dependencies:
+      '@ioredis/commands': 1.3.1
+      cluster-key-slot: 1.1.2
+      debug: 4.4.1
+      denque: 2.1.0
+      lodash.defaults: 4.2.0
+      lodash.isarguments: 3.1.0
+      redis-errors: 1.2.0
+      redis-parser: 3.0.0
+      standard-as-callback: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
 
   ipaddr.js@1.9.1: {}
 
@@ -4612,9 +4667,13 @@ snapshots:
 
   lodash.clonedeep@4.5.0: {}
 
+  lodash.defaults@4.2.0: {}
+
   lodash.get@4.4.2: {}
 
   lodash.includes@4.3.0: {}
+
+  lodash.isarguments@3.1.0: {}
 
   lodash.isboolean@3.0.3: {}
 
@@ -4911,6 +4970,12 @@ snapshots:
 
   readdirp@4.1.2: {}
 
+  redis-errors@1.2.0: {}
+
+  redis-parser@3.0.0:
+    dependencies:
+      redis-errors: 1.2.0
+
   request@2.88.2:
     dependencies:
       aws-sign2: 0.7.0
@@ -5078,6 +5143,8 @@ snapshots:
   stack-utils@2.0.6:
     dependencies:
       escape-string-regexp: 2.0.0
+
+  standard-as-callback@2.1.0: {}
 
   statuses@2.0.1: {}
 

--- a/src/config/redis.ts
+++ b/src/config/redis.ts
@@ -1,0 +1,5 @@
+import Redis from 'ioredis';
+
+const redis = new Redis(process.env.REDIS_URL || '', { lazyConnect: true });
+
+export default redis;

--- a/src/modules/website/services/advanceAjuda.service.ts
+++ b/src/modules/website/services/advanceAjuda.service.ts
@@ -1,16 +1,35 @@
 import { prisma } from "../../../config/prisma";
 import { WebsiteAdvanceAjuda } from "@prisma/client";
+import cache from "../../../utils/cache";
+
+const CACHE_KEY = "website:advanceAjuda:list";
 
 export const advanceAjudaService = {
-  list: () => prisma.websiteAdvanceAjuda.findMany(),
+  list: async () => {
+    const cached = await cache.get(CACHE_KEY);
+    if (cached) return cached;
+    const result = await prisma.websiteAdvanceAjuda.findMany();
+    await cache.set(CACHE_KEY, result);
+    return result;
+  },
   get: (id: string) =>
     prisma.websiteAdvanceAjuda.findUnique({ where: { id } }),
-  create: (
+  create: async (
     data: Omit<WebsiteAdvanceAjuda, "id" | "criadoEm" | "atualizadoEm">
-  ) => prisma.websiteAdvanceAjuda.create({ data }),
-  update: (id: string, data: Partial<WebsiteAdvanceAjuda>) =>
-    prisma.websiteAdvanceAjuda.update({ where: { id }, data }),
-  remove: (id: string) =>
-    prisma.websiteAdvanceAjuda.delete({ where: { id } }),
+  ) => {
+    const result = await prisma.websiteAdvanceAjuda.create({ data });
+    await cache.invalidate(CACHE_KEY);
+    return result;
+  },
+  update: async (id: string, data: Partial<WebsiteAdvanceAjuda>) => {
+    const result = await prisma.websiteAdvanceAjuda.update({ where: { id }, data });
+    await cache.invalidate(CACHE_KEY);
+    return result;
+  },
+  remove: async (id: string) => {
+    const result = await prisma.websiteAdvanceAjuda.delete({ where: { id } });
+    await cache.invalidate(CACHE_KEY);
+    return result;
+  },
 };
 

--- a/src/modules/website/services/conexaoForte.service.ts
+++ b/src/modules/website/services/conexaoForte.service.ts
@@ -1,16 +1,35 @@
 import { prisma } from "../../../config/prisma";
 import { WebsiteConexaoForte } from "@prisma/client";
+import cache from "../../../utils/cache";
+
+const CACHE_KEY = "website:conexaoForte:list";
 
 export const conexaoForteService = {
-  list: () => prisma.websiteConexaoForte.findMany(),
+  list: async () => {
+    const cached = await cache.get(CACHE_KEY);
+    if (cached) return cached;
+    const result = await prisma.websiteConexaoForte.findMany();
+    await cache.set(CACHE_KEY, result);
+    return result;
+  },
   get: (id: string) =>
     prisma.websiteConexaoForte.findUnique({ where: { id } }),
-  create: (
+  create: async (
     data: Omit<WebsiteConexaoForte, "id" | "criadoEm" | "atualizadoEm">
-  ) => prisma.websiteConexaoForte.create({ data }),
-  update: (id: string, data: Partial<WebsiteConexaoForte>) =>
-    prisma.websiteConexaoForte.update({ where: { id }, data }),
-  remove: (id: string) =>
-    prisma.websiteConexaoForte.delete({ where: { id } }),
+  ) => {
+    const result = await prisma.websiteConexaoForte.create({ data });
+    await cache.invalidate(CACHE_KEY);
+    return result;
+  },
+  update: async (id: string, data: Partial<WebsiteConexaoForte>) => {
+    const result = await prisma.websiteConexaoForte.update({ where: { id }, data });
+    await cache.invalidate(CACHE_KEY);
+    return result;
+  },
+  remove: async (id: string) => {
+    const result = await prisma.websiteConexaoForte.delete({ where: { id } });
+    await cache.invalidate(CACHE_KEY);
+    return result;
+  },
 };
 

--- a/src/modules/website/services/consultoria.service.ts
+++ b/src/modules/website/services/consultoria.service.ts
@@ -1,14 +1,34 @@
 import { prisma } from "../../../config/prisma";
 import { WebsiteConsultoria } from "@prisma/client";
+import cache from "../../../utils/cache";
+
+const CACHE_KEY = "website:consultoria:list";
 
 export const consultoriaService = {
-  list: () => prisma.websiteConsultoria.findMany(),
+  list: async () => {
+    const cached = await cache.get(CACHE_KEY);
+    if (cached) return cached;
+    const result = await prisma.websiteConsultoria.findMany();
+    await cache.set(CACHE_KEY, result);
+    return result;
+  },
   get: (id: string) =>
     prisma.websiteConsultoria.findUnique({ where: { id } }),
-  create: (
+  create: async (
     data: Omit<WebsiteConsultoria, "id" | "criadoEm" | "atualizadoEm">
-  ) => prisma.websiteConsultoria.create({ data }),
-  update: (id: string, data: Partial<WebsiteConsultoria>) =>
-    prisma.websiteConsultoria.update({ where: { id }, data }),
-  remove: (id: string) => prisma.websiteConsultoria.delete({ where: { id } }),
+  ) => {
+    const result = await prisma.websiteConsultoria.create({ data });
+    await cache.invalidate(CACHE_KEY);
+    return result;
+  },
+  update: async (id: string, data: Partial<WebsiteConsultoria>) => {
+    const result = await prisma.websiteConsultoria.update({ where: { id }, data });
+    await cache.invalidate(CACHE_KEY);
+    return result;
+  },
+  remove: async (id: string) => {
+    const result = await prisma.websiteConsultoria.delete({ where: { id } });
+    await cache.invalidate(CACHE_KEY);
+    return result;
+  },
 };

--- a/src/modules/website/services/diferenciais.service.ts
+++ b/src/modules/website/services/diferenciais.service.ts
@@ -1,14 +1,34 @@
 import { prisma } from "../../../config/prisma";
 import { WebsiteDiferenciais } from "@prisma/client";
+import cache from "../../../utils/cache";
+
+const CACHE_KEY = "website:diferenciais:list";
 
 export const diferenciaisService = {
-  list: () => prisma.websiteDiferenciais.findMany(),
+  list: async () => {
+    const cached = await cache.get(CACHE_KEY);
+    if (cached) return cached;
+    const result = await prisma.websiteDiferenciais.findMany();
+    await cache.set(CACHE_KEY, result);
+    return result;
+  },
   get: (id: string) =>
     prisma.websiteDiferenciais.findUnique({ where: { id } }),
-  create: (
+  create: async (
     data: Omit<WebsiteDiferenciais, "id" | "criadoEm" | "atualizadoEm">
-  ) => prisma.websiteDiferenciais.create({ data }),
-  update: (id: string, data: Partial<WebsiteDiferenciais>) =>
-    prisma.websiteDiferenciais.update({ where: { id }, data }),
-  remove: (id: string) => prisma.websiteDiferenciais.delete({ where: { id } }),
+  ) => {
+    const result = await prisma.websiteDiferenciais.create({ data });
+    await cache.invalidate(CACHE_KEY);
+    return result;
+  },
+  update: async (id: string, data: Partial<WebsiteDiferenciais>) => {
+    const result = await prisma.websiteDiferenciais.update({ where: { id }, data });
+    await cache.invalidate(CACHE_KEY);
+    return result;
+  },
+  remove: async (id: string) => {
+    const result = await prisma.websiteDiferenciais.delete({ where: { id } });
+    await cache.invalidate(CACHE_KEY);
+    return result;
+  },
 };

--- a/src/modules/website/services/header-pages.service.ts
+++ b/src/modules/website/services/header-pages.service.ts
@@ -1,15 +1,34 @@
 import { prisma } from "../../../config/prisma";
 import { WebsiteHeaderPage } from "@prisma/client";
+import cache from "../../../utils/cache";
+
+const CACHE_KEY = "website:headerPages:list";
 
 export const headerPagesService = {
-  list: () => prisma.websiteHeaderPage.findMany(),
+  list: async () => {
+    const cached = await cache.get(CACHE_KEY);
+    if (cached) return cached;
+    const result = await prisma.websiteHeaderPage.findMany();
+    await cache.set(CACHE_KEY, result);
+    return result;
+  },
   get: (id: string) =>
     prisma.websiteHeaderPage.findUnique({ where: { id } }),
-  create: (
+  create: async (
     data: Omit<WebsiteHeaderPage, "id" | "criadoEm" | "atualizadoEm">
-  ) => prisma.websiteHeaderPage.create({ data }),
-  update: (id: string, data: Partial<WebsiteHeaderPage>) =>
-    prisma.websiteHeaderPage.update({ where: { id }, data }),
-  remove: (id: string) =>
-    prisma.websiteHeaderPage.delete({ where: { id } }),
+  ) => {
+    const result = await prisma.websiteHeaderPage.create({ data });
+    await cache.invalidate(CACHE_KEY);
+    return result;
+  },
+  update: async (id: string, data: Partial<WebsiteHeaderPage>) => {
+    const result = await prisma.websiteHeaderPage.update({ where: { id }, data });
+    await cache.invalidate(CACHE_KEY);
+    return result;
+  },
+  remove: async (id: string) => {
+    const result = await prisma.websiteHeaderPage.delete({ where: { id } });
+    await cache.invalidate(CACHE_KEY);
+    return result;
+  },
 };

--- a/src/modules/website/services/imagem-login.service.ts
+++ b/src/modules/website/services/imagem-login.service.ts
@@ -1,14 +1,34 @@
 import { prisma } from "../../../config/prisma";
 import { WebsiteImagemLogin } from "@prisma/client";
+import cache from "../../../utils/cache";
+
+const CACHE_KEY = "website:imagemLogin:list";
 
 export const imagemLoginService = {
-  list: () => prisma.websiteImagemLogin.findMany(),
+  list: async () => {
+    const cached = await cache.get(CACHE_KEY);
+    if (cached) return cached;
+    const result = await prisma.websiteImagemLogin.findMany();
+    await cache.set(CACHE_KEY, result);
+    return result;
+  },
   get: (id: string) => prisma.websiteImagemLogin.findUnique({ where: { id } }),
-  create: (
+  create: async (
     data: Omit<WebsiteImagemLogin, "id" | "criadoEm" | "atualizadoEm">
-  ) => prisma.websiteImagemLogin.create({ data }),
-  update: (id: string, data: Partial<WebsiteImagemLogin>) =>
-    prisma.websiteImagemLogin.update({ where: { id }, data }),
-  remove: (id: string) => prisma.websiteImagemLogin.delete({ where: { id } }),
+  ) => {
+    const result = await prisma.websiteImagemLogin.create({ data });
+    await cache.invalidate(CACHE_KEY);
+    return result;
+  },
+  update: async (id: string, data: Partial<WebsiteImagemLogin>) => {
+    const result = await prisma.websiteImagemLogin.update({ where: { id }, data });
+    await cache.invalidate(CACHE_KEY);
+    return result;
+  },
+  remove: async (id: string) => {
+    const result = await prisma.websiteImagemLogin.delete({ where: { id } });
+    await cache.invalidate(CACHE_KEY);
+    return result;
+  },
 };
 

--- a/src/modules/website/services/planinhas.service.ts
+++ b/src/modules/website/services/planinhas.service.ts
@@ -1,16 +1,35 @@
 import { prisma } from "../../../config/prisma";
 import { WebsitePlaninhas } from "@prisma/client";
+import cache from "../../../utils/cache";
+
+const CACHE_KEY = "website:planinhas:list";
 
 export const planinhasService = {
-  list: () => prisma.websitePlaninhas.findMany(),
+  list: async () => {
+    const cached = await cache.get(CACHE_KEY);
+    if (cached) return cached;
+    const result = await prisma.websitePlaninhas.findMany();
+    await cache.set(CACHE_KEY, result);
+    return result;
+  },
   get: (id: string) =>
     prisma.websitePlaninhas.findUnique({ where: { id } }),
-  create: (
+  create: async (
     data: Omit<WebsitePlaninhas, "id" | "criadoEm" | "atualizadoEm">
-  ) => prisma.websitePlaninhas.create({ data }),
-  update: (id: string, data: Partial<WebsitePlaninhas>) =>
-    prisma.websitePlaninhas.update({ where: { id }, data }),
-  remove: (id: string) =>
-    prisma.websitePlaninhas.delete({ where: { id } }),
+  ) => {
+    const result = await prisma.websitePlaninhas.create({ data });
+    await cache.invalidate(CACHE_KEY);
+    return result;
+  },
+  update: async (id: string, data: Partial<WebsitePlaninhas>) => {
+    const result = await prisma.websitePlaninhas.update({ where: { id }, data });
+    await cache.invalidate(CACHE_KEY);
+    return result;
+  },
+  remove: async (id: string) => {
+    const result = await prisma.websitePlaninhas.delete({ where: { id } });
+    await cache.invalidate(CACHE_KEY);
+    return result;
+  },
 };
 

--- a/src/modules/website/services/recrutamento.service.ts
+++ b/src/modules/website/services/recrutamento.service.ts
@@ -1,14 +1,34 @@
 import { prisma } from "../../../config/prisma";
 import { WebsiteRecrutamento } from "@prisma/client";
+import cache from "../../../utils/cache";
+
+const CACHE_KEY = "website:recrutamento:list";
 
 export const recrutamentoService = {
-  list: () => prisma.websiteRecrutamento.findMany(),
+  list: async () => {
+    const cached = await cache.get(CACHE_KEY);
+    if (cached) return cached;
+    const result = await prisma.websiteRecrutamento.findMany();
+    await cache.set(CACHE_KEY, result);
+    return result;
+  },
   get: (id: string) =>
     prisma.websiteRecrutamento.findUnique({ where: { id } }),
-  create: (
+  create: async (
     data: Omit<WebsiteRecrutamento, "id" | "criadoEm" | "atualizadoEm">
-  ) => prisma.websiteRecrutamento.create({ data }),
-  update: (id: string, data: Partial<WebsiteRecrutamento>) =>
-    prisma.websiteRecrutamento.update({ where: { id }, data }),
-  remove: (id: string) => prisma.websiteRecrutamento.delete({ where: { id } }),
+  ) => {
+    const result = await prisma.websiteRecrutamento.create({ data });
+    await cache.invalidate(CACHE_KEY);
+    return result;
+  },
+  update: async (id: string, data: Partial<WebsiteRecrutamento>) => {
+    const result = await prisma.websiteRecrutamento.update({ where: { id }, data });
+    await cache.invalidate(CACHE_KEY);
+    return result;
+  },
+  remove: async (id: string) => {
+    const result = await prisma.websiteRecrutamento.delete({ where: { id } });
+    await cache.invalidate(CACHE_KEY);
+    return result;
+  },
 };

--- a/src/modules/website/services/recrutamentoSelecao.service.ts
+++ b/src/modules/website/services/recrutamentoSelecao.service.ts
@@ -1,16 +1,35 @@
 import { prisma } from "../../../config/prisma";
 import { WebsiteRecrutamentoSelecao } from "@prisma/client";
+import cache from "../../../utils/cache";
+
+const CACHE_KEY = "website:recrutamentoSelecao:list";
 
 export const recrutamentoSelecaoService = {
-  list: () => prisma.websiteRecrutamentoSelecao.findMany(),
+  list: async () => {
+    const cached = await cache.get(CACHE_KEY);
+    if (cached) return cached;
+    const result = await prisma.websiteRecrutamentoSelecao.findMany();
+    await cache.set(CACHE_KEY, result);
+    return result;
+  },
   get: (id: string) =>
     prisma.websiteRecrutamentoSelecao.findUnique({ where: { id } }),
-  create: (
+  create: async (
     data: Omit<WebsiteRecrutamentoSelecao, "id" | "criadoEm" | "atualizadoEm">
-  ) => prisma.websiteRecrutamentoSelecao.create({ data }),
-  update: (id: string, data: Partial<WebsiteRecrutamentoSelecao>) =>
-    prisma.websiteRecrutamentoSelecao.update({ where: { id }, data }),
-  remove: (id: string) =>
-    prisma.websiteRecrutamentoSelecao.delete({ where: { id } }),
+  ) => {
+    const result = await prisma.websiteRecrutamentoSelecao.create({ data });
+    await cache.invalidate(CACHE_KEY);
+    return result;
+  },
+  update: async (id: string, data: Partial<WebsiteRecrutamentoSelecao>) => {
+    const result = await prisma.websiteRecrutamentoSelecao.update({ where: { id }, data });
+    await cache.invalidate(CACHE_KEY);
+    return result;
+  },
+  remove: async (id: string) => {
+    const result = await prisma.websiteRecrutamentoSelecao.delete({ where: { id } });
+    await cache.invalidate(CACHE_KEY);
+    return result;
+  },
 };
 

--- a/src/modules/website/services/sistema.service.ts
+++ b/src/modules/website/services/sistema.service.ts
@@ -1,16 +1,35 @@
 import { prisma } from "../../../config/prisma";
 import { WebsiteSistema } from "@prisma/client";
+import cache from "../../../utils/cache";
+
+const CACHE_KEY = "website:sistema:list";
 
 export const sistemaService = {
-  list: () => prisma.websiteSistema.findMany(),
+  list: async () => {
+    const cached = await cache.get(CACHE_KEY);
+    if (cached) return cached;
+    const result = await prisma.websiteSistema.findMany();
+    await cache.set(CACHE_KEY, result);
+    return result;
+  },
   get: (id: string) =>
     prisma.websiteSistema.findUnique({ where: { id } }),
-  create: (
+  create: async (
     data: Omit<WebsiteSistema, "id" | "criadoEm" | "atualizadoEm">
-  ) => prisma.websiteSistema.create({ data }),
-  update: (id: string, data: Partial<WebsiteSistema>) =>
-    prisma.websiteSistema.update({ where: { id }, data }),
-  remove: (id: string) =>
-    prisma.websiteSistema.delete({ where: { id } }),
+  ) => {
+    const result = await prisma.websiteSistema.create({ data });
+    await cache.invalidate(CACHE_KEY);
+    return result;
+  },
+  update: async (id: string, data: Partial<WebsiteSistema>) => {
+    const result = await prisma.websiteSistema.update({ where: { id }, data });
+    await cache.invalidate(CACHE_KEY);
+    return result;
+  },
+  remove: async (id: string) => {
+    const result = await prisma.websiteSistema.delete({ where: { id } });
+    await cache.invalidate(CACHE_KEY);
+    return result;
+  },
 };
 

--- a/src/modules/website/services/sobre.service.ts
+++ b/src/modules/website/services/sobre.service.ts
@@ -1,12 +1,31 @@
 import { prisma } from "../../../config/prisma";
 import { WebsiteSobre } from "@prisma/client";
+import cache from "../../../utils/cache";
+
+const CACHE_KEY = "website:sobre:list";
 
 export const sobreService = {
-  list: () => prisma.websiteSobre.findMany(),
+  list: async () => {
+    const cached = await cache.get(CACHE_KEY);
+    if (cached) return cached;
+    const result = await prisma.websiteSobre.findMany();
+    await cache.set(CACHE_KEY, result);
+    return result;
+  },
   get: (id: string) => prisma.websiteSobre.findUnique({ where: { id } }),
-  create: (data: Omit<WebsiteSobre, "id" | "criadoEm" | "atualizadoEm">) =>
-    prisma.websiteSobre.create({ data }),
-  update: (id: string, data: Partial<WebsiteSobre>) =>
-    prisma.websiteSobre.update({ where: { id }, data }),
-  remove: (id: string) => prisma.websiteSobre.delete({ where: { id } }),
+  create: async (data: Omit<WebsiteSobre, "id" | "criadoEm" | "atualizadoEm">) => {
+    const result = await prisma.websiteSobre.create({ data });
+    await cache.invalidate(CACHE_KEY);
+    return result;
+  },
+  update: async (id: string, data: Partial<WebsiteSobre>) => {
+    const result = await prisma.websiteSobre.update({ where: { id }, data });
+    await cache.invalidate(CACHE_KEY);
+    return result;
+  },
+  remove: async (id: string) => {
+    const result = await prisma.websiteSobre.delete({ where: { id } });
+    await cache.invalidate(CACHE_KEY);
+    return result;
+  },
 };

--- a/src/modules/website/services/sobreEmpresa.service.ts
+++ b/src/modules/website/services/sobreEmpresa.service.ts
@@ -1,14 +1,34 @@
 import { prisma } from "../../../config/prisma";
 import { WebsiteSobreEmpresa } from "@prisma/client";
+import cache from "../../../utils/cache";
+
+const CACHE_KEY = "website:sobreEmpresa:list";
 
 export const sobreEmpresaService = {
-  list: () => prisma.websiteSobreEmpresa.findMany(),
+  list: async () => {
+    const cached = await cache.get(CACHE_KEY);
+    if (cached) return cached;
+    const result = await prisma.websiteSobreEmpresa.findMany();
+    await cache.set(CACHE_KEY, result);
+    return result;
+  },
   get: (id: string) => prisma.websiteSobreEmpresa.findUnique({ where: { id } }),
-  create: (
+  create: async (
     data: Omit<WebsiteSobreEmpresa, "id" | "criadoEm" | "atualizadoEm">
-  ) => prisma.websiteSobreEmpresa.create({ data }),
-  update: (id: string, data: Partial<WebsiteSobreEmpresa>) =>
-    prisma.websiteSobreEmpresa.update({ where: { id }, data }),
-  remove: (id: string) => prisma.websiteSobreEmpresa.delete({ where: { id } }),
+  ) => {
+    const result = await prisma.websiteSobreEmpresa.create({ data });
+    await cache.invalidate(CACHE_KEY);
+    return result;
+  },
+  update: async (id: string, data: Partial<WebsiteSobreEmpresa>) => {
+    const result = await prisma.websiteSobreEmpresa.update({ where: { id }, data });
+    await cache.invalidate(CACHE_KEY);
+    return result;
+  },
+  remove: async (id: string) => {
+    const result = await prisma.websiteSobreEmpresa.delete({ where: { id } });
+    await cache.invalidate(CACHE_KEY);
+    return result;
+  },
 };
 

--- a/src/modules/website/services/treinamentoCompany.service.ts
+++ b/src/modules/website/services/treinamentoCompany.service.ts
@@ -1,16 +1,35 @@
 import { prisma } from "../../../config/prisma";
 import { WebsiteTreinamentoCompany } from "@prisma/client";
+import cache from "../../../utils/cache";
+
+const CACHE_KEY = "website:treinamentoCompany:list";
 
 export const treinamentoCompanyService = {
-  list: () => prisma.websiteTreinamentoCompany.findMany(),
+  list: async () => {
+    const cached = await cache.get(CACHE_KEY);
+    if (cached) return cached;
+    const result = await prisma.websiteTreinamentoCompany.findMany();
+    await cache.set(CACHE_KEY, result);
+    return result;
+  },
   get: (id: string) =>
     prisma.websiteTreinamentoCompany.findUnique({ where: { id } }),
-  create: (
+  create: async (
     data: Omit<WebsiteTreinamentoCompany, "id" | "criadoEm" | "atualizadoEm">
-  ) => prisma.websiteTreinamentoCompany.create({ data }),
-  update: (id: string, data: Partial<WebsiteTreinamentoCompany>) =>
-    prisma.websiteTreinamentoCompany.update({ where: { id }, data }),
-  remove: (id: string) =>
-    prisma.websiteTreinamentoCompany.delete({ where: { id } }),
+  ) => {
+    const result = await prisma.websiteTreinamentoCompany.create({ data });
+    await cache.invalidate(CACHE_KEY);
+    return result;
+  },
+  update: async (id: string, data: Partial<WebsiteTreinamentoCompany>) => {
+    const result = await prisma.websiteTreinamentoCompany.update({ where: { id }, data });
+    await cache.invalidate(CACHE_KEY);
+    return result;
+  },
+  remove: async (id: string) => {
+    const result = await prisma.websiteTreinamentoCompany.delete({ where: { id } });
+    await cache.invalidate(CACHE_KEY);
+    return result;
+  },
 };
 

--- a/src/modules/website/services/treinamentosInCompany.service.ts
+++ b/src/modules/website/services/treinamentosInCompany.service.ts
@@ -1,16 +1,35 @@
 import { prisma } from "../../../config/prisma";
 import { WebsiteTreinamentosInCompany } from "@prisma/client";
+import cache from "../../../utils/cache";
+
+const CACHE_KEY = "website:treinamentosInCompany:list";
 
 export const treinamentosInCompanyService = {
-  list: () => prisma.websiteTreinamentosInCompany.findMany(),
+  list: async () => {
+    const cached = await cache.get(CACHE_KEY);
+    if (cached) return cached;
+    const result = await prisma.websiteTreinamentosInCompany.findMany();
+    await cache.set(CACHE_KEY, result);
+    return result;
+  },
   get: (id: string) =>
     prisma.websiteTreinamentosInCompany.findUnique({ where: { id } }),
-  create: (
+  create: async (
     data: Omit<WebsiteTreinamentosInCompany, "id" | "criadoEm" | "atualizadoEm">
-  ) => prisma.websiteTreinamentosInCompany.create({ data }),
-  update: (id: string, data: Partial<WebsiteTreinamentosInCompany>) =>
-    prisma.websiteTreinamentosInCompany.update({ where: { id }, data }),
-  remove: (id: string) =>
-    prisma.websiteTreinamentosInCompany.delete({ where: { id } }),
+  ) => {
+    const result = await prisma.websiteTreinamentosInCompany.create({ data });
+    await cache.invalidate(CACHE_KEY);
+    return result;
+  },
+  update: async (id: string, data: Partial<WebsiteTreinamentosInCompany>) => {
+    const result = await prisma.websiteTreinamentosInCompany.update({ where: { id }, data });
+    await cache.invalidate(CACHE_KEY);
+    return result;
+  },
+  remove: async (id: string) => {
+    const result = await prisma.websiteTreinamentosInCompany.delete({ where: { id } });
+    await cache.invalidate(CACHE_KEY);
+    return result;
+  },
 };
 

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -1,0 +1,48 @@
+import redis from '../config/redis';
+
+const DEFAULT_TTL = Number(process.env.CACHE_TTL || '60');
+const memoryStore = new Map<string, any>();
+
+async function get<T>(key: string): Promise<T | null> {
+  try {
+    if (!process.env.REDIS_URL) {
+      return memoryStore.has(key) ? (memoryStore.get(key) as T) : null;
+    }
+    const data = await redis.get(key);
+    return data ? (JSON.parse(data) as T) : null;
+  } catch {
+    return null;
+  }
+}
+
+async function set(key: string, value: any, ttl = DEFAULT_TTL): Promise<void> {
+  try {
+    if (!process.env.REDIS_URL) {
+      memoryStore.set(key, value);
+      setTimeout(() => memoryStore.delete(key), ttl * 1000);
+      return;
+    }
+    await redis.set(key, JSON.stringify(value), 'EX', ttl);
+  } catch {
+    // ignore errors
+  }
+}
+
+async function invalidate(key: string | string[]): Promise<void> {
+  try {
+    if (!process.env.REDIS_URL) {
+      if (Array.isArray(key)) key.forEach((k) => memoryStore.delete(k));
+      else memoryStore.delete(key);
+      return;
+    }
+    if (Array.isArray(key)) {
+      if (key.length) await redis.del(...key);
+    } else {
+      await redis.del(key);
+    }
+  } catch {
+    // ignore errors
+  }
+}
+
+export default { get, set, invalidate };


### PR DESCRIPTION
## Summary
- add Redis client configuration and cache utility
- cache website service queries and invalidate on writes
- document REDIS_URL and CACHE_TTL environment variables

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68c34b9e6a188325b8c3d0c8fba05e3e