### PR TITLE
fix: ensure cache list methods return arrays

### DIFF
--- a/src/modules/website/services/banner.service.ts
+++ b/src/modules/website/services/banner.service.ts
@@ -6,7 +6,9 @@ const CACHE_KEY = "website:banner:list";
 
 export const bannerService = {
   list: async () => {
-    const cached = await cache.get(CACHE_KEY);
+    const cached = await cache.get<Awaited<ReturnType<typeof prisma.websiteBannerOrdem.findMany>>>(
+      CACHE_KEY
+    );
     if (cached) return cached;
     const result = await prisma.websiteBannerOrdem.findMany({
       orderBy: { ordem: "asc" },

--- a/src/modules/website/services/depoimentos.service.ts
+++ b/src/modules/website/services/depoimentos.service.ts
@@ -27,7 +27,9 @@ export const depoimentosService = {
         },
       });
     }
-    const cached = await cache.get(CACHE_KEY);
+    const cached = await cache.get<
+      Awaited<ReturnType<typeof prisma.websiteDepoimentoOrdem.findMany>>
+    >(CACHE_KEY);
     if (cached) return cached;
     const result = await prisma.websiteDepoimentoOrdem.findMany({
       orderBy: { ordem: "asc" },

--- a/src/modules/website/services/logoEnterprise.service.ts
+++ b/src/modules/website/services/logoEnterprise.service.ts
@@ -6,7 +6,9 @@ const CACHE_KEY = "website:logoEnterprise:list";
 
 export const logoEnterpriseService = {
   list: async () => {
-    const cached = await cache.get(CACHE_KEY);
+    const cached = await cache.get<
+      Awaited<ReturnType<typeof prisma.websiteLogoEnterpriseOrdem.findMany>>
+    >(CACHE_KEY);
     if (cached) return cached;
     const result = await prisma.websiteLogoEnterpriseOrdem.findMany({
       orderBy: { ordem: "asc" },

--- a/src/modules/website/services/slider.service.ts
+++ b/src/modules/website/services/slider.service.ts
@@ -6,7 +6,9 @@ const CACHE_KEY = "website:slider:list";
 
 export const sliderService = {
   list: async () => {
-    const cached = await cache.get(CACHE_KEY);
+    const cached = await cache.get<
+      Awaited<ReturnType<typeof prisma.websiteSliderOrdem.findMany>>
+    >(CACHE_KEY);
     if (cached) return cached;
     const result = await prisma.websiteSliderOrdem.findMany({
       orderBy: { ordem: "asc" },

--- a/src/modules/website/services/team.service.ts
+++ b/src/modules/website/services/team.service.ts
@@ -21,7 +21,9 @@ export const teamService = {
         },
       });
     }
-    const cached = await cache.get(CACHE_KEY);
+    const cached = await cache.get<
+      Awaited<ReturnType<typeof prisma.websiteTeamOrdem.findMany>>
+    >(CACHE_KEY);
     if (cached) return cached;
     const result = await prisma.websiteTeamOrdem.findMany({
       orderBy: { ordem: "asc" },


### PR DESCRIPTION
## Summary
- type cache retrievals in banner, depoimentos, logos, slider and team services to return arrays

## Testing
- `pnpm build`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68c35beed3a483258f708bbb01d8732b