### PR TITLE
feat(prisma): add pooling and graceful shutdown

### DIFF
--- a/src/config/prisma.ts
+++ b/src/config/prisma.ts
@@ -2,9 +2,41 @@ import { PrismaClient } from "@prisma/client";
 
 // Prefer an IPv4-compatible connection string if provided
 // This allows deployments in environments without IPv6 support
-const datasourceUrl =
-  process.env.DATABASE_POOL_URL || process.env.DATABASE_URL;
+let datasourceUrl =
+  process.env.DATABASE_POOL_URL || process.env.DATABASE_URL || "";
 
-export const prisma = new PrismaClient({
-  datasourceUrl,
-});
+// Ensure pooling params if not present in connection string
+if (datasourceUrl && !datasourceUrl.includes("connection_limit")) {
+  const separator = datasourceUrl.includes("?") ? "&" : "?";
+  datasourceUrl += `${separator}pgbouncer=true&connection_limit=5`;
+}
+
+// Create a singleton Prisma client so that the connection pool is shared
+// across the entire application runtime. When pooling parameters aren't
+// provided via the connection string, fallback to a max of 5 connections.
+const globalForPrisma = globalThis as unknown as {
+  prisma: PrismaClient | undefined;
+};
+
+function createPrismaClient() {
+  const client = new PrismaClient({
+    datasourceUrl,
+  });
+  if (process.env.NODE_ENV !== "test") {
+    client
+      .$connect()
+      .then(() => console.log("✅ Prisma conectado"))
+      .catch((err) => console.error("❌ Erro ao conectar ao Prisma", err));
+  }
+
+  client.$on("error", (e) => {
+    console.error("🔥 Prisma error", e);
+  });
+
+  return client;
+}
+
+export const prisma = globalForPrisma.prisma ?? createPrismaClient();
+if (process.env.NODE_ENV !== "production") {
+  globalForPrisma.prisma = prisma;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import { appRoutes } from "./routes";
 import { startExpiredUserCleanupJob } from "./modules/usuarios/services/user-cleanup-service";
 import { setupSwagger } from "./config/swagger";
 import { startKeepAlive } from "./utils/keep-alive";
+import { prisma } from "./config/prisma";
 
 /**
  * Aplicação principal - Advance+ API
@@ -244,8 +245,14 @@ const server = app.listen(serverConfig.port, () => {
 /**
  * Graceful shutdown em caso de SIGTERM (Docker, PM2, etc.)
  */
-process.on("SIGTERM", () => {
+process.on("SIGTERM", async () => {
   console.log("🔄 SIGTERM recebido, encerrando servidor graciosamente...");
+  try {
+    await prisma.$disconnect();
+    console.log("🔌 Prisma desconectado");
+  } catch (err) {
+    console.error("Erro ao desconectar Prisma", err);
+  }
   server.close(() => {
     console.log("✅ Servidor encerrado com sucesso");
     process.exit(0);
@@ -255,8 +262,14 @@ process.on("SIGTERM", () => {
 /**
  * Graceful shutdown em caso de SIGINT (Ctrl+C)
  */
-process.on("SIGINT", () => {
+process.on("SIGINT", async () => {
   console.log("\n🔄 SIGINT recebido, encerrando servidor graciosamente...");
+  try {
+    await prisma.$disconnect();
+    console.log("🔌 Prisma desconectado");
+  } catch (err) {
+    console.error("Erro ao desconectar Prisma", err);
+  }
   server.close(() => {
     console.log("✅ Servidor encerrado com sucesso");
     process.exit(0);


### PR DESCRIPTION
## Summary
- ensure Prisma uses a single pooled client and logs connection events
- handle SIGTERM/SIGINT by disconnecting Prisma before exiting

## Testing
- `pnpm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68c3676ac30883259a094ef184adbe20