### PR TITLE
feat: cache dashboard stats

### DIFF
--- a/src/modules/usuarios/register/register-controller.ts
+++ b/src/modules/usuarios/register/register-controller.ts
@@ -1,6 +1,7 @@
 import { Request, Response, NextFunction } from "express";
 import bcrypt from "bcrypt";
 import { prisma } from "../../../config/prisma";
+import redis from "../../../config/redis";
 import { Prisma, CodigoTipo } from "@prisma/client";
 import { TipoUsuario, Role } from "../enums";
 import {
@@ -191,6 +192,14 @@ export const criarUsuario = async (
     // Cria usuário dentro de transação
     console.log(`💾 [${correlationId}] Iniciando transação de banco`);
     const usuario = await createUserWithTransaction(userData, correlationId);
+    try {
+      await redis.del("dashboard:stats");
+    } catch (cacheError) {
+      console.warn(
+        `⚠️ [${correlationId}] Falha ao invalidar cache do dashboard`,
+        cacheError
+      );
+    }
 
     const duration = Date.now() - startTime;
     console.log(


### PR DESCRIPTION
## Summary
- cache dashboard stats for 60s in Redis
- clear cached stats after user creation

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68c36de7fd9083258831a5a4936081ed