### PR TITLE
Handle Prisma client error events correctly

### DIFF
--- a/src/config/prisma.ts
+++ b/src/config/prisma.ts
@@ -21,6 +21,7 @@ const globalForPrisma = globalThis as unknown as {
 function createPrismaClient() {
   const client = new PrismaClient({
     datasourceUrl,
+    log: [{ emit: "event", level: "error" }],
   });
   if (process.env.NODE_ENV !== "test") {
     client


### PR DESCRIPTION
## Summary
- configure PrismaClient to emit error events

## Testing
- `pnpm build`
- `pnpm test`
- `pnpm lint`
- `pnpm format`


------
https://chatgpt.com/codex/tasks/task_e_68c370902e94832584c1f8d905b02d80