### PR TITLE
feat: add caching layer and http caching headers

### DIFF
--- a/src/modules/website/controllers/advanceAjuda.controller.ts
+++ b/src/modules/website/controllers/advanceAjuda.controller.ts
@@ -1,4 +1,5 @@
 import { Request, Response } from "express";
+import { setCacheHeaders } from '../../../utils/cache';
 import path from "path";
 import { supabase } from "../../superbase/client";
 import { advanceAjudaService } from "../services/advanceAjuda.service";
@@ -30,7 +31,11 @@ async function uploadImage(file: Express.Multer.File): Promise<string> {
 export class AdvanceAjudaController {
   static list = async (req: Request, res: Response) => {
     const itens = await advanceAjudaService.list();
-    res.json(itens);
+    const response = itens;
+
+    setCacheHeaders(res, response);
+
+    res.json(response);
   };
 
   static get = async (req: Request, res: Response) => {
@@ -42,7 +47,11 @@ export class AdvanceAjudaController {
           .status(404)
           .json({ message: "Advance Ajuda não encontrado" });
       }
-      res.json(item);
+      const response = item;
+
+      setCacheHeaders(res, response);
+
+      res.json(response);
     } catch (error: any) {
       res.status(500).json({
         message: "Erro ao buscar Advance Ajuda",

--- a/src/modules/website/controllers/banner.controller.ts
+++ b/src/modules/website/controllers/banner.controller.ts
@@ -1,4 +1,5 @@
 import { Request, Response } from "express";
+import { setCacheHeaders } from '../../../utils/cache';
 import path from "path";
 import { supabase } from "../../superbase/client";
 import { bannerService } from "../services/banner.service";
@@ -46,7 +47,11 @@ async function uploadImage(file: Express.Multer.File): Promise<string> {
 export class BannerController {
   static list = async (req: Request, res: Response) => {
     const itens = await bannerService.list();
-    res.json(itens.map(mapBanner));
+    const response = itens.map(mapBanner);
+
+    setCacheHeaders(res, response);
+
+    res.json(response);
   };
 
   static get = async (req: Request, res: Response) => {
@@ -56,7 +61,11 @@ export class BannerController {
       if (!ordem) {
         return res.status(404).json({ message: "Banner não encontrado" });
       }
-      res.json(mapBanner(ordem));
+      const response = mapBanner(ordem);
+
+      setCacheHeaders(res, response);
+
+      res.json(response);
     } catch (error: any) {
       res.status(500).json({
         message: "Erro ao buscar banner",

--- a/src/modules/website/controllers/conexaoForte.controller.ts
+++ b/src/modules/website/controllers/conexaoForte.controller.ts
@@ -1,4 +1,5 @@
 import { Request, Response } from "express";
+import { setCacheHeaders } from '../../../utils/cache';
 import path from "path";
 import { supabase } from "../../superbase/client";
 import { conexaoForteService } from "../services/conexaoForte.service";
@@ -33,7 +34,11 @@ async function uploadImage(
 export class ConexaoForteController {
   static list = async (req: Request, res: Response) => {
     const itens = await conexaoForteService.list();
-    res.json(itens);
+    const response = itens;
+
+    setCacheHeaders(res, response);
+
+    res.json(response);
   };
 
   static get = async (req: Request, res: Response) => {
@@ -45,7 +50,11 @@ export class ConexaoForteController {
           .status(404)
           .json({ message: "ConexaoForte não encontrado" });
       }
-      res.json(item);
+      const response = item;
+
+      setCacheHeaders(res, response);
+
+      res.json(response);
     } catch (error: any) {
       res.status(500).json({
         message: "Erro ao buscar ConexaoForte",

--- a/src/modules/website/controllers/consultoria.controller.ts
+++ b/src/modules/website/controllers/consultoria.controller.ts
@@ -1,4 +1,5 @@
 import { Request, Response } from "express";
+import { setCacheHeaders } from '../../../utils/cache';
 import path from "path";
 import { supabase } from "../../superbase/client";
 import { consultoriaService } from "../services/consultoria.service";
@@ -30,7 +31,11 @@ async function uploadImage(file: Express.Multer.File): Promise<string> {
 export class ConsultoriaController {
   static list = async (req: Request, res: Response) => {
     const itens = await consultoriaService.list();
-    res.json(itens);
+    const response = itens;
+
+    setCacheHeaders(res, response);
+
+    res.json(response);
   };
 
   static get = async (req: Request, res: Response) => {
@@ -40,7 +45,11 @@ export class ConsultoriaController {
       if (!consultoria) {
         return res.status(404).json({ message: "Consultoria não encontrada" });
       }
-      res.json(consultoria);
+      const response = consultoria;
+
+      setCacheHeaders(res, response);
+
+      res.json(response);
     } catch (error: any) {
       res
         .status(500)

--- a/src/modules/website/controllers/depoimentos.controller.ts
+++ b/src/modules/website/controllers/depoimentos.controller.ts
@@ -1,4 +1,5 @@
 import { Request, Response } from "express";
+import { setCacheHeaders } from '../../../utils/cache';
 import { WebsiteStatus } from "@prisma/client";
 import { depoimentosService } from "../services/depoimentos.service";
 
@@ -27,7 +28,11 @@ export class DepoimentosController {
       else status = status.toUpperCase();
     }
     const itens = await depoimentosService.list(status as WebsiteStatus | undefined);
-    res.json(itens.map(mapDepoimento));
+    const response = itens.map(mapDepoimento);
+
+    setCacheHeaders(res, response);
+
+    res.json(response);
   };
 
   static get = async (req: Request, res: Response) => {
@@ -37,7 +42,11 @@ export class DepoimentosController {
       if (!ordem) {
         return res.status(404).json({ message: "Depoimento não encontrado" });
       }
-      res.json(mapDepoimento(ordem));
+      const response = mapDepoimento(ordem);
+
+      setCacheHeaders(res, response);
+
+      res.json(response);
     } catch (error: any) {
       res.status(500).json({
         message: "Erro ao buscar depoimento",

--- a/src/modules/website/controllers/diferenciais.controller.ts
+++ b/src/modules/website/controllers/diferenciais.controller.ts
@@ -1,10 +1,15 @@
 import { Request, Response } from "express";
+import { setCacheHeaders } from '../../../utils/cache';
 import { diferenciaisService } from "../services/diferenciais.service";
 
 export class DiferenciaisController {
   static list = async (req: Request, res: Response) => {
     const itens = await diferenciaisService.list();
-    res.json(itens);
+    const response = itens;
+
+    setCacheHeaders(res, response);
+
+    res.json(response);
   };
 
   static get = async (req: Request, res: Response) => {
@@ -16,7 +21,11 @@ export class DiferenciaisController {
           .status(404)
           .json({ message: "Diferenciais não encontrado" });
       }
-      res.json(diferencial);
+      const response = diferencial;
+
+      setCacheHeaders(res, response);
+
+      res.json(response);
     } catch (error: any) {
       res.status(500).json({
         message: "Erro ao buscar diferenciais",

--- a/src/modules/website/controllers/header-pages.controller.ts
+++ b/src/modules/website/controllers/header-pages.controller.ts
@@ -1,10 +1,15 @@
 import { Request, Response } from "express";
+import { setCacheHeaders } from '../../../utils/cache';
 import { headerPagesService } from "../services/header-pages.service";
 
 export class HeaderPageController {
   static list = async (_req: Request, res: Response) => {
     const items = await headerPagesService.list();
-    res.json(items);
+    const response = items;
+
+    setCacheHeaders(res, response);
+
+    res.json(response);
   };
 
   static get = async (req: Request, res: Response) => {
@@ -14,7 +19,11 @@ export class HeaderPageController {
       if (!item) {
         return res.status(404).json({ message: "Header page não encontrado" });
       }
-      res.json(item);
+      const response = item;
+
+      setCacheHeaders(res, response);
+
+      res.json(response);
     } catch (error: any) {
       res
         .status(500)

--- a/src/modules/website/controllers/imagemLogin.controller.ts
+++ b/src/modules/website/controllers/imagemLogin.controller.ts
@@ -1,4 +1,5 @@
 import { Request, Response } from "express";
+import { setCacheHeaders } from '../../../utils/cache';
 import path from "path";
 import { supabase } from "../../superbase/client";
 import { imagemLoginService } from "../services/imagem-login.service";
@@ -30,7 +31,11 @@ async function uploadImage(file: Express.Multer.File): Promise<string> {
 export class ImagemLoginController {
   static list = async (req: Request, res: Response) => {
     const itens = await imagemLoginService.list();
-    res.json(itens);
+    const response = itens;
+
+    setCacheHeaders(res, response);
+
+    res.json(response);
   };
 
   static get = async (req: Request, res: Response) => {
@@ -42,7 +47,11 @@ export class ImagemLoginController {
           .status(404)
           .json({ message: "Imagem de login não encontrada" });
       }
-      res.json(item);
+      const response = item;
+
+      setCacheHeaders(res, response);
+
+      res.json(response);
     } catch (error: any) {
       res.status(500).json({
         message: "Erro ao buscar imagem de login",

--- a/src/modules/website/controllers/informacoes-gerais.controller.ts
+++ b/src/modules/website/controllers/informacoes-gerais.controller.ts
@@ -1,10 +1,15 @@
 import { Request, Response } from "express";
+import { setCacheHeaders } from '../../../utils/cache';
 import { informacoesGeraisService } from "../services/informacoes-gerais.service";
 
 export class InformacoesGeraisController {
   static list = async (req: Request, res: Response) => {
     const itens = await informacoesGeraisService.list();
-    res.json(itens);
+    const response = itens;
+
+    setCacheHeaders(res, response);
+
+    res.json(response);
   };
 
   static get = async (req: Request, res: Response) => {
@@ -14,7 +19,11 @@ export class InformacoesGeraisController {
       if (!info) {
         return res.status(404).json({ message: "Informação não encontrada" });
       }
-      res.json(info);
+      const response = info;
+
+      setCacheHeaders(res, response);
+
+      res.json(response);
     } catch (error: any) {
       res.status(500).json({
         message: "Erro ao buscar informação",

--- a/src/modules/website/controllers/logoEnterprise.controller.ts
+++ b/src/modules/website/controllers/logoEnterprise.controller.ts
@@ -1,4 +1,5 @@
 import { Request, Response } from "express";
+import { setCacheHeaders } from '../../../utils/cache';
 import path from "path";
 import { supabase } from "../../superbase/client";
 import { logoEnterpriseService } from "../services/logoEnterprise.service";
@@ -47,7 +48,11 @@ async function uploadImage(file: Express.Multer.File): Promise<string> {
 export class LogoEnterpriseController {
   static list = async (req: Request, res: Response) => {
     const itens = await logoEnterpriseService.list();
-    res.json(itens.map(mapLogo));
+    const response = itens.map(mapLogo);
+
+    setCacheHeaders(res, response);
+
+    res.json(response);
   };
 
   static get = async (req: Request, res: Response) => {
@@ -57,7 +62,11 @@ export class LogoEnterpriseController {
       if (!item) {
         return res.status(404).json({ message: "Logo não encontrado" });
       }
-      res.json(mapLogo(item));
+      const response = mapLogo(item);
+
+      setCacheHeaders(res, response);
+
+      res.json(response);
     } catch (error: any) {
       res.status(500).json({
         message: "Erro ao buscar logo",

--- a/src/modules/website/controllers/planinhas.controller.ts
+++ b/src/modules/website/controllers/planinhas.controller.ts
@@ -1,10 +1,15 @@
 import { Request, Response } from "express";
+import { setCacheHeaders } from '../../../utils/cache';
 import { planinhasService } from "../services/planinhas.service";
 
 export class PlaninhasController {
   static list = async (req: Request, res: Response) => {
     const itens = await planinhasService.list();
-    res.json(itens);
+    const response = itens;
+
+    setCacheHeaders(res, response);
+
+    res.json(response);
   };
 
   static get = async (req: Request, res: Response) => {
@@ -16,7 +21,11 @@ export class PlaninhasController {
           .status(404)
           .json({ message: "Planinhas não encontrado" });
       }
-      res.json(item);
+      const response = item;
+
+      setCacheHeaders(res, response);
+
+      res.json(response);
     } catch (error: any) {
       res.status(500).json({
         message: "Erro ao buscar planinhas",

--- a/src/modules/website/controllers/recrutamento.controller.ts
+++ b/src/modules/website/controllers/recrutamento.controller.ts
@@ -1,4 +1,5 @@
 import { Request, Response } from "express";
+import { setCacheHeaders } from '../../../utils/cache';
 import path from "path";
 import { supabase } from "../../superbase/client";
 import { recrutamentoService } from "../services/recrutamento.service";
@@ -30,7 +31,11 @@ async function uploadImage(file: Express.Multer.File): Promise<string> {
 export class RecrutamentoController {
   static list = async (req: Request, res: Response) => {
     const itens = await recrutamentoService.list();
-    res.json(itens);
+    const response = itens;
+
+    setCacheHeaders(res, response);
+
+    res.json(response);
   };
 
   static get = async (req: Request, res: Response) => {
@@ -42,7 +47,11 @@ export class RecrutamentoController {
           .status(404)
           .json({ message: "Recrutamento não encontrado" });
       }
-      res.json(recrutamento);
+      const response = recrutamento;
+
+      setCacheHeaders(res, response);
+
+      res.json(response);
     } catch (error: any) {
       res
         .status(500)

--- a/src/modules/website/controllers/recrutamentoSelecao.controller.ts
+++ b/src/modules/website/controllers/recrutamentoSelecao.controller.ts
@@ -1,4 +1,5 @@
 import { Request, Response } from "express";
+import { setCacheHeaders } from '../../../utils/cache';
 import path from "path";
 import { supabase } from "../../superbase/client";
 import { recrutamentoSelecaoService } from "../services/recrutamentoSelecao.service";
@@ -30,7 +31,11 @@ async function uploadImage(file: Express.Multer.File): Promise<string> {
 export class RecrutamentoSelecaoController {
   static list = async (req: Request, res: Response) => {
     const itens = await recrutamentoSelecaoService.list();
-    res.json(itens);
+    const response = itens;
+
+    setCacheHeaders(res, response);
+
+    res.json(response);
   };
 
   static get = async (req: Request, res: Response) => {
@@ -42,7 +47,11 @@ export class RecrutamentoSelecaoController {
           .status(404)
           .json({ message: "RecrutamentoSelecao não encontrado" });
       }
-      res.json(item);
+      const response = item;
+
+      setCacheHeaders(res, response);
+
+      res.json(response);
     } catch (error: any) {
       res.status(500).json({
         message: "Erro ao buscar RecrutamentoSelecao",

--- a/src/modules/website/controllers/sistema.controller.ts
+++ b/src/modules/website/controllers/sistema.controller.ts
@@ -1,10 +1,15 @@
 import { Request, Response } from "express";
+import { setCacheHeaders } from '../../../utils/cache';
 import { sistemaService } from "../services/sistema.service";
 
 export class SistemaController {
   static list = async (req: Request, res: Response) => {
     const itens = await sistemaService.list();
-    res.json(itens);
+    const response = itens;
+
+    setCacheHeaders(res, response);
+
+    res.json(response);
   };
 
   static get = async (req: Request, res: Response) => {
@@ -14,7 +19,11 @@ export class SistemaController {
       if (!item) {
         return res.status(404).json({ message: "Sistema não encontrado" });
       }
-      res.json(item);
+      const response = item;
+
+      setCacheHeaders(res, response);
+
+      res.json(response);
     } catch (error: any) {
       res.status(500).json({
         message: "Erro ao buscar sistema",

--- a/src/modules/website/controllers/slider.controller.ts
+++ b/src/modules/website/controllers/slider.controller.ts
@@ -1,4 +1,5 @@
 import { Request, Response } from "express";
+import { setCacheHeaders } from '../../../utils/cache';
 import path from "path";
 import { supabase } from "../../superbase/client";
 import { sliderService } from "../services/slider.service";
@@ -43,7 +44,11 @@ async function uploadImage(file: Express.Multer.File): Promise<string> {
 export class SliderController {
   static list = async (req: Request, res: Response) => {
     const itens = await sliderService.list();
-    res.json(itens.map(mapSlider));
+    const response = itens.map(mapSlider);
+
+    setCacheHeaders(res, response);
+
+    res.json(response);
   };
 
   static get = async (req: Request, res: Response) => {
@@ -53,7 +58,11 @@ export class SliderController {
       if (!ordem) {
         return res.status(404).json({ message: "Slider não encontrado" });
       }
-      res.json(mapSlider(ordem));
+      const response = mapSlider(ordem);
+
+      setCacheHeaders(res, response);
+
+      res.json(response);
     } catch (error: any) {
       res.status(500).json({
         message: "Erro ao buscar slider",

--- a/src/modules/website/controllers/sobre.controller.ts
+++ b/src/modules/website/controllers/sobre.controller.ts
@@ -1,4 +1,5 @@
 import { Request, Response } from "express";
+import { setCacheHeaders } from '../../../utils/cache';
 import path from "path";
 import { sobreService } from "../services/sobre.service";
 
@@ -15,7 +16,11 @@ function generateImageTitle(url: string): string {
 export class SobreController {
   static list = async (req: Request, res: Response) => {
     const itens = await sobreService.list();
-    res.json(itens);
+    const response = itens;
+
+    setCacheHeaders(res, response);
+
+    res.json(response);
   };
 
   static get = async (req: Request, res: Response) => {
@@ -25,7 +30,11 @@ export class SobreController {
       if (!sobre) {
         return res.status(404).json({ message: "Sobre não encontrado" });
       }
-      res.json(sobre);
+      const response = sobre;
+
+      setCacheHeaders(res, response);
+
+      res.json(response);
     } catch (error: any) {
       res
         .status(500)

--- a/src/modules/website/controllers/sobreEmpresa.controller.ts
+++ b/src/modules/website/controllers/sobreEmpresa.controller.ts
@@ -1,10 +1,15 @@
 import { Request, Response } from "express";
+import { setCacheHeaders } from '../../../utils/cache';
 import { sobreEmpresaService } from "../services/sobreEmpresa.service";
 
 export class SobreEmpresaController {
   static list = async (req: Request, res: Response) => {
     const itens = await sobreEmpresaService.list();
-    res.json(itens);
+    const response = itens;
+
+    setCacheHeaders(res, response);
+
+    res.json(response);
   };
 
   static get = async (req: Request, res: Response) => {
@@ -16,7 +21,11 @@ export class SobreEmpresaController {
           .status(404)
           .json({ message: "SobreEmpresa não encontrado" });
       }
-      res.json(sobreEmpresa);
+      const response = sobreEmpresa;
+
+      setCacheHeaders(res, response);
+
+      res.json(response);
     } catch (error: any) {
       res.status(500).json({
         message: "Erro ao buscar sobreEmpresa",

--- a/src/modules/website/controllers/team.controller.ts
+++ b/src/modules/website/controllers/team.controller.ts
@@ -1,4 +1,5 @@
 import { Request, Response } from "express";
+import { setCacheHeaders } from '../../../utils/cache';
 import { WebsiteStatus } from "@prisma/client";
 import { teamService } from "../services/team.service";
 
@@ -26,7 +27,11 @@ export class TeamController {
       else status = status.toUpperCase();
     }
     const itens = await teamService.list(status as WebsiteStatus | undefined);
-    res.json(itens.map(mapTeam));
+    const response = itens.map(mapTeam);
+
+    setCacheHeaders(res, response);
+
+    res.json(response);
   };
 
   static get = async (req: Request, res: Response) => {
@@ -36,7 +41,11 @@ export class TeamController {
       if (!ordem) {
         return res.status(404).json({ message: "Team member não encontrado" });
       }
-      res.json(mapTeam(ordem));
+      const response = mapTeam(ordem);
+
+      setCacheHeaders(res, response);
+
+      res.json(response);
     } catch (error: any) {
       res.status(500).json({
         message: "Erro ao buscar team member",

--- a/src/modules/website/controllers/treinamentoCompany.controller.ts
+++ b/src/modules/website/controllers/treinamentoCompany.controller.ts
@@ -1,4 +1,5 @@
 import { Request, Response } from "express";
+import { setCacheHeaders } from '../../../utils/cache';
 import path from "path";
 import { supabase } from "../../superbase/client";
 import { treinamentoCompanyService } from "../services/treinamentoCompany.service";
@@ -30,7 +31,11 @@ async function uploadImage(file: Express.Multer.File): Promise<string> {
 export class TreinamentoCompanyController {
   static list = async (req: Request, res: Response) => {
     const itens = await treinamentoCompanyService.list();
-    res.json(itens);
+    const response = itens;
+
+    setCacheHeaders(res, response);
+
+    res.json(response);
   };
 
   static get = async (req: Request, res: Response) => {
@@ -42,7 +47,11 @@ export class TreinamentoCompanyController {
           .status(404)
           .json({ message: "TreinamentoCompany não encontrado" });
       }
-      res.json(item);
+      const response = item;
+
+      setCacheHeaders(res, response);
+
+      res.json(response);
     } catch (error: any) {
       res.status(500).json({
         message: "Erro ao buscar TreinamentoCompany",

--- a/src/modules/website/controllers/treinamentosInCompany.controller.ts
+++ b/src/modules/website/controllers/treinamentosInCompany.controller.ts
@@ -1,10 +1,15 @@
 import { Request, Response } from "express";
+import { setCacheHeaders } from '../../../utils/cache';
 import { treinamentosInCompanyService } from "../services/treinamentosInCompany.service";
 
 export class TreinamentosInCompanyController {
   static list = async (req: Request, res: Response) => {
     const itens = await treinamentosInCompanyService.list();
-    res.json(itens);
+    const response = itens;
+
+    setCacheHeaders(res, response);
+
+    res.json(response);
   };
 
   static get = async (req: Request, res: Response) => {
@@ -16,7 +21,11 @@ export class TreinamentosInCompanyController {
           .status(404)
           .json({ message: "TreinamentosInCompany não encontrado" });
       }
-      res.json(item);
+      const response = item;
+
+      setCacheHeaders(res, response);
+
+      res.json(response);
     } catch (error: any) {
       res.status(500).json({
         message: "Erro ao buscar TreinamentosInCompany",

--- a/src/modules/website/services/advanceAjuda.service.ts
+++ b/src/modules/website/services/advanceAjuda.service.ts
@@ -1,15 +1,15 @@
 import { prisma } from "../../../config/prisma";
 import { WebsiteAdvanceAjuda } from "@prisma/client";
-import cache from "../../../utils/cache";
+import { getCache, setCache, invalidateCache } from "../../../utils/cache";
 
 const CACHE_KEY = "website:advanceAjuda:list";
 
 export const advanceAjudaService = {
   list: async () => {
-    const cached = await cache.get(CACHE_KEY);
+    const cached = await getCache(CACHE_KEY);
     if (cached) return cached;
     const result = await prisma.websiteAdvanceAjuda.findMany();
-    await cache.set(CACHE_KEY, result);
+    await setCache(CACHE_KEY, result);
     return result;
   },
   get: (id: string) =>
@@ -18,17 +18,17 @@ export const advanceAjudaService = {
     data: Omit<WebsiteAdvanceAjuda, "id" | "criadoEm" | "atualizadoEm">
   ) => {
     const result = await prisma.websiteAdvanceAjuda.create({ data });
-    await cache.invalidate(CACHE_KEY);
+    await invalidateCache(CACHE_KEY);
     return result;
   },
   update: async (id: string, data: Partial<WebsiteAdvanceAjuda>) => {
     const result = await prisma.websiteAdvanceAjuda.update({ where: { id }, data });
-    await cache.invalidate(CACHE_KEY);
+    await invalidateCache(CACHE_KEY);
     return result;
   },
   remove: async (id: string) => {
     const result = await prisma.websiteAdvanceAjuda.delete({ where: { id } });
-    await cache.invalidate(CACHE_KEY);
+    await invalidateCache(CACHE_KEY);
     return result;
   },
 };

--- a/src/modules/website/services/banner.service.ts
+++ b/src/modules/website/services/banner.service.ts
@@ -1,12 +1,12 @@
 import { prisma } from "../../../config/prisma";
 import { WebsiteStatus } from "@prisma/client";
-import cache from "../../../utils/cache";
+import { getCache, setCache, invalidateCache } from "../../../utils/cache";
 
 const CACHE_KEY = "website:banner:list";
 
 export const bannerService = {
   list: async () => {
-    const cached = await cache.get<Awaited<ReturnType<typeof prisma.websiteBannerOrdem.findMany>>>(
+    const cached = await getCache<Awaited<ReturnType<typeof prisma.websiteBannerOrdem.findMany>>>(
       CACHE_KEY
     );
     if (cached) return cached;
@@ -27,7 +27,7 @@ export const bannerService = {
         },
       },
     });
-    await cache.set(CACHE_KEY, result);
+    await setCache(CACHE_KEY, result);
     return result;
   },
 
@@ -86,7 +86,7 @@ export const bannerService = {
         },
       });
     });
-    await cache.invalidate(CACHE_KEY);
+    await invalidateCache(CACHE_KEY);
     return result;
   },
 
@@ -155,7 +155,7 @@ export const bannerService = {
         },
       });
     });
-    await cache.invalidate(CACHE_KEY);
+    await invalidateCache(CACHE_KEY);
     return result;
   },
 
@@ -216,7 +216,7 @@ export const bannerService = {
 
       return current;
     });
-    await cache.invalidate(CACHE_KEY);
+    await invalidateCache(CACHE_KEY);
     return result;
   },
 
@@ -234,7 +234,7 @@ export const bannerService = {
         data: { ordem: { decrement: 1 } },
       });
     });
-    await cache.invalidate(CACHE_KEY);
+    await invalidateCache(CACHE_KEY);
   },
 };
 

--- a/src/modules/website/services/conexaoForte.service.ts
+++ b/src/modules/website/services/conexaoForte.service.ts
@@ -1,15 +1,15 @@
 import { prisma } from "../../../config/prisma";
 import { WebsiteConexaoForte } from "@prisma/client";
-import cache from "../../../utils/cache";
+import { getCache, setCache, invalidateCache } from "../../../utils/cache";
 
 const CACHE_KEY = "website:conexaoForte:list";
 
 export const conexaoForteService = {
   list: async () => {
-    const cached = await cache.get(CACHE_KEY);
+    const cached = await getCache(CACHE_KEY);
     if (cached) return cached;
     const result = await prisma.websiteConexaoForte.findMany();
-    await cache.set(CACHE_KEY, result);
+    await setCache(CACHE_KEY, result);
     return result;
   },
   get: (id: string) =>
@@ -18,17 +18,17 @@ export const conexaoForteService = {
     data: Omit<WebsiteConexaoForte, "id" | "criadoEm" | "atualizadoEm">
   ) => {
     const result = await prisma.websiteConexaoForte.create({ data });
-    await cache.invalidate(CACHE_KEY);
+    await invalidateCache(CACHE_KEY);
     return result;
   },
   update: async (id: string, data: Partial<WebsiteConexaoForte>) => {
     const result = await prisma.websiteConexaoForte.update({ where: { id }, data });
-    await cache.invalidate(CACHE_KEY);
+    await invalidateCache(CACHE_KEY);
     return result;
   },
   remove: async (id: string) => {
     const result = await prisma.websiteConexaoForte.delete({ where: { id } });
-    await cache.invalidate(CACHE_KEY);
+    await invalidateCache(CACHE_KEY);
     return result;
   },
 };

--- a/src/modules/website/services/consultoria.service.ts
+++ b/src/modules/website/services/consultoria.service.ts
@@ -1,15 +1,15 @@
 import { prisma } from "../../../config/prisma";
 import { WebsiteConsultoria } from "@prisma/client";
-import cache from "../../../utils/cache";
+import { getCache, setCache, invalidateCache } from "../../../utils/cache";
 
 const CACHE_KEY = "website:consultoria:list";
 
 export const consultoriaService = {
   list: async () => {
-    const cached = await cache.get(CACHE_KEY);
+    const cached = await getCache(CACHE_KEY);
     if (cached) return cached;
     const result = await prisma.websiteConsultoria.findMany();
-    await cache.set(CACHE_KEY, result);
+    await setCache(CACHE_KEY, result);
     return result;
   },
   get: (id: string) =>
@@ -18,17 +18,17 @@ export const consultoriaService = {
     data: Omit<WebsiteConsultoria, "id" | "criadoEm" | "atualizadoEm">
   ) => {
     const result = await prisma.websiteConsultoria.create({ data });
-    await cache.invalidate(CACHE_KEY);
+    await invalidateCache(CACHE_KEY);
     return result;
   },
   update: async (id: string, data: Partial<WebsiteConsultoria>) => {
     const result = await prisma.websiteConsultoria.update({ where: { id }, data });
-    await cache.invalidate(CACHE_KEY);
+    await invalidateCache(CACHE_KEY);
     return result;
   },
   remove: async (id: string) => {
     const result = await prisma.websiteConsultoria.delete({ where: { id } });
-    await cache.invalidate(CACHE_KEY);
+    await invalidateCache(CACHE_KEY);
     return result;
   },
 };

--- a/src/modules/website/services/depoimentos.service.ts
+++ b/src/modules/website/services/depoimentos.service.ts
@@ -1,6 +1,6 @@
 import { prisma } from "../../../config/prisma";
 import { WebsiteStatus } from "@prisma/client";
-import cache from "../../../utils/cache";
+import { getCache, setCache, invalidateCache } from "../../../utils/cache";
 
 const CACHE_KEY = "website:depoimentos:list";
 
@@ -27,7 +27,7 @@ export const depoimentosService = {
         },
       });
     }
-    const cached = await cache.get<
+    const cached = await getCache<
       Awaited<ReturnType<typeof prisma.websiteDepoimentoOrdem.findMany>>
     >(CACHE_KEY);
     if (cached) return cached;
@@ -49,7 +49,7 @@ export const depoimentosService = {
         },
       },
     });
-    await cache.set(CACHE_KEY, result);
+    await setCache(CACHE_KEY, result);
     return result;
   },
   get: (id: string) =>
@@ -109,7 +109,7 @@ export const depoimentosService = {
         },
       },
     });
-    await cache.invalidate(CACHE_KEY);
+    await invalidateCache(CACHE_KEY);
     return result;
   },
   update: async (
@@ -184,7 +184,7 @@ export const depoimentosService = {
         },
       });
     });
-    await cache.invalidate(CACHE_KEY);
+    await invalidateCache(CACHE_KEY);
     return result;
   },
   reorder: async (ordemId: string, novaOrdem: number) => {
@@ -246,7 +246,7 @@ export const depoimentosService = {
 
       return current;
     });
-    await cache.invalidate(CACHE_KEY);
+    await invalidateCache(CACHE_KEY);
     return result;
   },
   remove: async (depoimentoId: string) => {
@@ -263,7 +263,7 @@ export const depoimentosService = {
         data: { ordem: { decrement: 1 } },
       });
     });
-    await cache.invalidate(CACHE_KEY);
+    await invalidateCache(CACHE_KEY);
   },
 };
 

--- a/src/modules/website/services/diferenciais.service.ts
+++ b/src/modules/website/services/diferenciais.service.ts
@@ -1,15 +1,15 @@
 import { prisma } from "../../../config/prisma";
 import { WebsiteDiferenciais } from "@prisma/client";
-import cache from "../../../utils/cache";
+import { getCache, setCache, invalidateCache } from "../../../utils/cache";
 
 const CACHE_KEY = "website:diferenciais:list";
 
 export const diferenciaisService = {
   list: async () => {
-    const cached = await cache.get(CACHE_KEY);
+    const cached = await getCache(CACHE_KEY);
     if (cached) return cached;
     const result = await prisma.websiteDiferenciais.findMany();
-    await cache.set(CACHE_KEY, result);
+    await setCache(CACHE_KEY, result);
     return result;
   },
   get: (id: string) =>
@@ -18,17 +18,17 @@ export const diferenciaisService = {
     data: Omit<WebsiteDiferenciais, "id" | "criadoEm" | "atualizadoEm">
   ) => {
     const result = await prisma.websiteDiferenciais.create({ data });
-    await cache.invalidate(CACHE_KEY);
+    await invalidateCache(CACHE_KEY);
     return result;
   },
   update: async (id: string, data: Partial<WebsiteDiferenciais>) => {
     const result = await prisma.websiteDiferenciais.update({ where: { id }, data });
-    await cache.invalidate(CACHE_KEY);
+    await invalidateCache(CACHE_KEY);
     return result;
   },
   remove: async (id: string) => {
     const result = await prisma.websiteDiferenciais.delete({ where: { id } });
-    await cache.invalidate(CACHE_KEY);
+    await invalidateCache(CACHE_KEY);
     return result;
   },
 };

--- a/src/modules/website/services/header-pages.service.ts
+++ b/src/modules/website/services/header-pages.service.ts
@@ -1,15 +1,15 @@
 import { prisma } from "../../../config/prisma";
 import { WebsiteHeaderPage } from "@prisma/client";
-import cache from "../../../utils/cache";
+import { getCache, setCache, invalidateCache } from "../../../utils/cache";
 
 const CACHE_KEY = "website:headerPages:list";
 
 export const headerPagesService = {
   list: async () => {
-    const cached = await cache.get(CACHE_KEY);
+    const cached = await getCache(CACHE_KEY);
     if (cached) return cached;
     const result = await prisma.websiteHeaderPage.findMany();
-    await cache.set(CACHE_KEY, result);
+    await setCache(CACHE_KEY, result);
     return result;
   },
   get: (id: string) =>
@@ -18,17 +18,17 @@ export const headerPagesService = {
     data: Omit<WebsiteHeaderPage, "id" | "criadoEm" | "atualizadoEm">
   ) => {
     const result = await prisma.websiteHeaderPage.create({ data });
-    await cache.invalidate(CACHE_KEY);
+    await invalidateCache(CACHE_KEY);
     return result;
   },
   update: async (id: string, data: Partial<WebsiteHeaderPage>) => {
     const result = await prisma.websiteHeaderPage.update({ where: { id }, data });
-    await cache.invalidate(CACHE_KEY);
+    await invalidateCache(CACHE_KEY);
     return result;
   },
   remove: async (id: string) => {
     const result = await prisma.websiteHeaderPage.delete({ where: { id } });
-    await cache.invalidate(CACHE_KEY);
+    await invalidateCache(CACHE_KEY);
     return result;
   },
 };

--- a/src/modules/website/services/imagem-login.service.ts
+++ b/src/modules/website/services/imagem-login.service.ts
@@ -1,15 +1,15 @@
 import { prisma } from "../../../config/prisma";
 import { WebsiteImagemLogin } from "@prisma/client";
-import cache from "../../../utils/cache";
+import { getCache, setCache, invalidateCache } from "../../../utils/cache";
 
 const CACHE_KEY = "website:imagemLogin:list";
 
 export const imagemLoginService = {
   list: async () => {
-    const cached = await cache.get(CACHE_KEY);
+    const cached = await getCache(CACHE_KEY);
     if (cached) return cached;
     const result = await prisma.websiteImagemLogin.findMany();
-    await cache.set(CACHE_KEY, result);
+    await setCache(CACHE_KEY, result);
     return result;
   },
   get: (id: string) => prisma.websiteImagemLogin.findUnique({ where: { id } }),
@@ -17,17 +17,17 @@ export const imagemLoginService = {
     data: Omit<WebsiteImagemLogin, "id" | "criadoEm" | "atualizadoEm">
   ) => {
     const result = await prisma.websiteImagemLogin.create({ data });
-    await cache.invalidate(CACHE_KEY);
+    await invalidateCache(CACHE_KEY);
     return result;
   },
   update: async (id: string, data: Partial<WebsiteImagemLogin>) => {
     const result = await prisma.websiteImagemLogin.update({ where: { id }, data });
-    await cache.invalidate(CACHE_KEY);
+    await invalidateCache(CACHE_KEY);
     return result;
   },
   remove: async (id: string) => {
     const result = await prisma.websiteImagemLogin.delete({ where: { id } });
-    await cache.invalidate(CACHE_KEY);
+    await invalidateCache(CACHE_KEY);
     return result;
   },
 };

--- a/src/modules/website/services/informacoes-gerais.service.ts
+++ b/src/modules/website/services/informacoes-gerais.service.ts
@@ -1,12 +1,12 @@
 import { prisma } from "../../../config/prisma";
 import { Prisma } from "@prisma/client";
-import cache from "../../../utils/cache";
+import { getCache, setCache, invalidateCache } from "../../../utils/cache";
 
 const CACHE_KEY = "website:informacoesGerais:list";
 
 export const informacoesGeraisService = {
   list: async () => {
-    const cached = await cache.get(CACHE_KEY);
+    const cached = await getCache(CACHE_KEY);
     if (cached) return cached;
     const result = await prisma.websiteInformacoes.findMany({
       select: {
@@ -33,7 +33,7 @@ export const informacoesGeraisService = {
         },
       },
     });
-    await cache.set(CACHE_KEY, result);
+    await setCache(CACHE_KEY, result);
     return result;
   },
   get: (id: string) =>
@@ -90,7 +90,7 @@ export const informacoesGeraisService = {
         },
       },
     });
-    await cache.invalidate(CACHE_KEY);
+    await invalidateCache(CACHE_KEY);
     return result;
   },
   update: async (id: string, data: Prisma.WebsiteInformacoesUpdateInput) => {
@@ -121,7 +121,7 @@ export const informacoesGeraisService = {
         },
       },
     });
-    await cache.invalidate(CACHE_KEY);
+    await invalidateCache(CACHE_KEY);
     return result;
   },
   remove: async (id: string) => {
@@ -129,7 +129,7 @@ export const informacoesGeraisService = {
       where: { id },
       select: { id: true },
     });
-    await cache.invalidate(CACHE_KEY);
+    await invalidateCache(CACHE_KEY);
     return result;
   },
 };

--- a/src/modules/website/services/logoEnterprise.service.ts
+++ b/src/modules/website/services/logoEnterprise.service.ts
@@ -1,12 +1,12 @@
 import { prisma } from "../../../config/prisma";
 import { WebsiteStatus } from "@prisma/client";
-import cache from "../../../utils/cache";
+import { getCache, setCache, invalidateCache } from "../../../utils/cache";
 
 const CACHE_KEY = "website:logoEnterprise:list";
 
 export const logoEnterpriseService = {
   list: async () => {
-    const cached = await cache.get<
+    const cached = await getCache<
       Awaited<ReturnType<typeof prisma.websiteLogoEnterpriseOrdem.findMany>>
     >(CACHE_KEY);
     if (cached) return cached;
@@ -28,7 +28,7 @@ export const logoEnterpriseService = {
         },
       },
     });
-    await cache.set(CACHE_KEY, result);
+    await setCache(CACHE_KEY, result);
     return result;
   },
 
@@ -93,7 +93,7 @@ export const logoEnterpriseService = {
         },
       });
     });
-    await cache.invalidate(CACHE_KEY);
+    await invalidateCache(CACHE_KEY);
     return result;
   },
 
@@ -168,7 +168,7 @@ export const logoEnterpriseService = {
         },
       });
     });
-    await cache.invalidate(CACHE_KEY);
+    await invalidateCache(CACHE_KEY);
     return result;
   },
 
@@ -231,7 +231,7 @@ export const logoEnterpriseService = {
 
       return current;
     });
-    await cache.invalidate(CACHE_KEY);
+    await invalidateCache(CACHE_KEY);
     return result;
   },
 
@@ -249,6 +249,6 @@ export const logoEnterpriseService = {
         data: { ordem: { decrement: 1 } },
       });
     });
-    await cache.invalidate(CACHE_KEY);
+    await invalidateCache(CACHE_KEY);
   },
 };

--- a/src/modules/website/services/planinhas.service.ts
+++ b/src/modules/website/services/planinhas.service.ts
@@ -1,15 +1,15 @@
 import { prisma } from "../../../config/prisma";
 import { WebsitePlaninhas } from "@prisma/client";
-import cache from "../../../utils/cache";
+import { getCache, setCache, invalidateCache } from "../../../utils/cache";
 
 const CACHE_KEY = "website:planinhas:list";
 
 export const planinhasService = {
   list: async () => {
-    const cached = await cache.get(CACHE_KEY);
+    const cached = await getCache(CACHE_KEY);
     if (cached) return cached;
     const result = await prisma.websitePlaninhas.findMany();
-    await cache.set(CACHE_KEY, result);
+    await setCache(CACHE_KEY, result);
     return result;
   },
   get: (id: string) =>
@@ -18,17 +18,17 @@ export const planinhasService = {
     data: Omit<WebsitePlaninhas, "id" | "criadoEm" | "atualizadoEm">
   ) => {
     const result = await prisma.websitePlaninhas.create({ data });
-    await cache.invalidate(CACHE_KEY);
+    await invalidateCache(CACHE_KEY);
     return result;
   },
   update: async (id: string, data: Partial<WebsitePlaninhas>) => {
     const result = await prisma.websitePlaninhas.update({ where: { id }, data });
-    await cache.invalidate(CACHE_KEY);
+    await invalidateCache(CACHE_KEY);
     return result;
   },
   remove: async (id: string) => {
     const result = await prisma.websitePlaninhas.delete({ where: { id } });
-    await cache.invalidate(CACHE_KEY);
+    await invalidateCache(CACHE_KEY);
     return result;
   },
 };

--- a/src/modules/website/services/recrutamento.service.ts
+++ b/src/modules/website/services/recrutamento.service.ts
@@ -1,15 +1,15 @@
 import { prisma } from "../../../config/prisma";
 import { WebsiteRecrutamento } from "@prisma/client";
-import cache from "../../../utils/cache";
+import { getCache, setCache, invalidateCache } from "../../../utils/cache";
 
 const CACHE_KEY = "website:recrutamento:list";
 
 export const recrutamentoService = {
   list: async () => {
-    const cached = await cache.get(CACHE_KEY);
+    const cached = await getCache(CACHE_KEY);
     if (cached) return cached;
     const result = await prisma.websiteRecrutamento.findMany();
-    await cache.set(CACHE_KEY, result);
+    await setCache(CACHE_KEY, result);
     return result;
   },
   get: (id: string) =>
@@ -18,17 +18,17 @@ export const recrutamentoService = {
     data: Omit<WebsiteRecrutamento, "id" | "criadoEm" | "atualizadoEm">
   ) => {
     const result = await prisma.websiteRecrutamento.create({ data });
-    await cache.invalidate(CACHE_KEY);
+    await invalidateCache(CACHE_KEY);
     return result;
   },
   update: async (id: string, data: Partial<WebsiteRecrutamento>) => {
     const result = await prisma.websiteRecrutamento.update({ where: { id }, data });
-    await cache.invalidate(CACHE_KEY);
+    await invalidateCache(CACHE_KEY);
     return result;
   },
   remove: async (id: string) => {
     const result = await prisma.websiteRecrutamento.delete({ where: { id } });
-    await cache.invalidate(CACHE_KEY);
+    await invalidateCache(CACHE_KEY);
     return result;
   },
 };

--- a/src/modules/website/services/recrutamentoSelecao.service.ts
+++ b/src/modules/website/services/recrutamentoSelecao.service.ts
@@ -1,15 +1,15 @@
 import { prisma } from "../../../config/prisma";
 import { WebsiteRecrutamentoSelecao } from "@prisma/client";
-import cache from "../../../utils/cache";
+import { getCache, setCache, invalidateCache } from "../../../utils/cache";
 
 const CACHE_KEY = "website:recrutamentoSelecao:list";
 
 export const recrutamentoSelecaoService = {
   list: async () => {
-    const cached = await cache.get(CACHE_KEY);
+    const cached = await getCache(CACHE_KEY);
     if (cached) return cached;
     const result = await prisma.websiteRecrutamentoSelecao.findMany();
-    await cache.set(CACHE_KEY, result);
+    await setCache(CACHE_KEY, result);
     return result;
   },
   get: (id: string) =>
@@ -18,17 +18,17 @@ export const recrutamentoSelecaoService = {
     data: Omit<WebsiteRecrutamentoSelecao, "id" | "criadoEm" | "atualizadoEm">
   ) => {
     const result = await prisma.websiteRecrutamentoSelecao.create({ data });
-    await cache.invalidate(CACHE_KEY);
+    await invalidateCache(CACHE_KEY);
     return result;
   },
   update: async (id: string, data: Partial<WebsiteRecrutamentoSelecao>) => {
     const result = await prisma.websiteRecrutamentoSelecao.update({ where: { id }, data });
-    await cache.invalidate(CACHE_KEY);
+    await invalidateCache(CACHE_KEY);
     return result;
   },
   remove: async (id: string) => {
     const result = await prisma.websiteRecrutamentoSelecao.delete({ where: { id } });
-    await cache.invalidate(CACHE_KEY);
+    await invalidateCache(CACHE_KEY);
     return result;
   },
 };

--- a/src/modules/website/services/sistema.service.ts
+++ b/src/modules/website/services/sistema.service.ts
@@ -1,15 +1,15 @@
 import { prisma } from "../../../config/prisma";
 import { WebsiteSistema } from "@prisma/client";
-import cache from "../../../utils/cache";
+import { getCache, setCache, invalidateCache } from "../../../utils/cache";
 
 const CACHE_KEY = "website:sistema:list";
 
 export const sistemaService = {
   list: async () => {
-    const cached = await cache.get(CACHE_KEY);
+    const cached = await getCache(CACHE_KEY);
     if (cached) return cached;
     const result = await prisma.websiteSistema.findMany();
-    await cache.set(CACHE_KEY, result);
+    await setCache(CACHE_KEY, result);
     return result;
   },
   get: (id: string) =>
@@ -18,17 +18,17 @@ export const sistemaService = {
     data: Omit<WebsiteSistema, "id" | "criadoEm" | "atualizadoEm">
   ) => {
     const result = await prisma.websiteSistema.create({ data });
-    await cache.invalidate(CACHE_KEY);
+    await invalidateCache(CACHE_KEY);
     return result;
   },
   update: async (id: string, data: Partial<WebsiteSistema>) => {
     const result = await prisma.websiteSistema.update({ where: { id }, data });
-    await cache.invalidate(CACHE_KEY);
+    await invalidateCache(CACHE_KEY);
     return result;
   },
   remove: async (id: string) => {
     const result = await prisma.websiteSistema.delete({ where: { id } });
-    await cache.invalidate(CACHE_KEY);
+    await invalidateCache(CACHE_KEY);
     return result;
   },
 };

--- a/src/modules/website/services/slider.service.ts
+++ b/src/modules/website/services/slider.service.ts
@@ -1,12 +1,12 @@
 import { prisma } from "../../../config/prisma";
 import { SliderOrientation, WebsiteStatus } from "@prisma/client";
-import cache from "../../../utils/cache";
+import { getCache, setCache, invalidateCache } from "../../../utils/cache";
 
 const CACHE_KEY = "website:slider:list";
 
 export const sliderService = {
   list: async () => {
-    const cached = await cache.get<
+    const cached = await getCache<
       Awaited<ReturnType<typeof prisma.websiteSliderOrdem.findMany>>
     >(CACHE_KEY);
     if (cached) return cached;
@@ -28,7 +28,7 @@ export const sliderService = {
         },
       },
     });
-    await cache.set(CACHE_KEY, result);
+    await setCache(CACHE_KEY, result);
     return result;
   },
 
@@ -92,7 +92,7 @@ export const sliderService = {
         },
       },
     });
-    await cache.invalidate(CACHE_KEY);
+    await invalidateCache(CACHE_KEY);
     return result;
   },
 
@@ -193,7 +193,7 @@ export const sliderService = {
         },
       });
     });
-    await cache.invalidate(CACHE_KEY);
+    await invalidateCache(CACHE_KEY);
     return result;
   },
 
@@ -262,7 +262,7 @@ export const sliderService = {
 
       return current;
     });
-    await cache.invalidate(CACHE_KEY);
+    await invalidateCache(CACHE_KEY);
     return result;
   },
 
@@ -280,7 +280,7 @@ export const sliderService = {
         data: { ordem: { decrement: 1 } },
       });
     });
-    await cache.invalidate(CACHE_KEY);
+    await invalidateCache(CACHE_KEY);
   },
 };
 

--- a/src/modules/website/services/sobre.service.ts
+++ b/src/modules/website/services/sobre.service.ts
@@ -1,31 +1,31 @@
 import { prisma } from "../../../config/prisma";
 import { WebsiteSobre } from "@prisma/client";
-import cache from "../../../utils/cache";
+import { getCache, setCache, invalidateCache } from "../../../utils/cache";
 
 const CACHE_KEY = "website:sobre:list";
 
 export const sobreService = {
   list: async () => {
-    const cached = await cache.get(CACHE_KEY);
+    const cached = await getCache(CACHE_KEY);
     if (cached) return cached;
     const result = await prisma.websiteSobre.findMany();
-    await cache.set(CACHE_KEY, result);
+    await setCache(CACHE_KEY, result);
     return result;
   },
   get: (id: string) => prisma.websiteSobre.findUnique({ where: { id } }),
   create: async (data: Omit<WebsiteSobre, "id" | "criadoEm" | "atualizadoEm">) => {
     const result = await prisma.websiteSobre.create({ data });
-    await cache.invalidate(CACHE_KEY);
+    await invalidateCache(CACHE_KEY);
     return result;
   },
   update: async (id: string, data: Partial<WebsiteSobre>) => {
     const result = await prisma.websiteSobre.update({ where: { id }, data });
-    await cache.invalidate(CACHE_KEY);
+    await invalidateCache(CACHE_KEY);
     return result;
   },
   remove: async (id: string) => {
     const result = await prisma.websiteSobre.delete({ where: { id } });
-    await cache.invalidate(CACHE_KEY);
+    await invalidateCache(CACHE_KEY);
     return result;
   },
 };

--- a/src/modules/website/services/sobreEmpresa.service.ts
+++ b/src/modules/website/services/sobreEmpresa.service.ts
@@ -1,15 +1,15 @@
 import { prisma } from "../../../config/prisma";
 import { WebsiteSobreEmpresa } from "@prisma/client";
-import cache from "../../../utils/cache";
+import { getCache, setCache, invalidateCache } from "../../../utils/cache";
 
 const CACHE_KEY = "website:sobreEmpresa:list";
 
 export const sobreEmpresaService = {
   list: async () => {
-    const cached = await cache.get(CACHE_KEY);
+    const cached = await getCache(CACHE_KEY);
     if (cached) return cached;
     const result = await prisma.websiteSobreEmpresa.findMany();
-    await cache.set(CACHE_KEY, result);
+    await setCache(CACHE_KEY, result);
     return result;
   },
   get: (id: string) => prisma.websiteSobreEmpresa.findUnique({ where: { id } }),
@@ -17,17 +17,17 @@ export const sobreEmpresaService = {
     data: Omit<WebsiteSobreEmpresa, "id" | "criadoEm" | "atualizadoEm">
   ) => {
     const result = await prisma.websiteSobreEmpresa.create({ data });
-    await cache.invalidate(CACHE_KEY);
+    await invalidateCache(CACHE_KEY);
     return result;
   },
   update: async (id: string, data: Partial<WebsiteSobreEmpresa>) => {
     const result = await prisma.websiteSobreEmpresa.update({ where: { id }, data });
-    await cache.invalidate(CACHE_KEY);
+    await invalidateCache(CACHE_KEY);
     return result;
   },
   remove: async (id: string) => {
     const result = await prisma.websiteSobreEmpresa.delete({ where: { id } });
-    await cache.invalidate(CACHE_KEY);
+    await invalidateCache(CACHE_KEY);
     return result;
   },
 };

--- a/src/modules/website/services/team.service.ts
+++ b/src/modules/website/services/team.service.ts
@@ -1,6 +1,6 @@
 import { prisma } from "../../../config/prisma";
 import { WebsiteStatus } from "@prisma/client";
-import cache from "../../../utils/cache";
+import { getCache, setCache, invalidateCache } from "../../../utils/cache";
 
 const CACHE_KEY = "website:team:list";
 
@@ -21,7 +21,7 @@ export const teamService = {
         },
       });
     }
-    const cached = await cache.get<
+    const cached = await getCache<
       Awaited<ReturnType<typeof prisma.websiteTeamOrdem.findMany>>
     >(CACHE_KEY);
     if (cached) return cached;
@@ -37,7 +37,7 @@ export const teamService = {
         },
       },
     });
-    await cache.set(CACHE_KEY, result);
+    await setCache(CACHE_KEY, result);
     return result;
   },
   get: (id: string) =>
@@ -83,7 +83,7 @@ export const teamService = {
         },
       },
     });
-    await cache.invalidate(CACHE_KEY);
+    await invalidateCache(CACHE_KEY);
     return result;
   },
   update: async (
@@ -147,7 +147,7 @@ export const teamService = {
         },
       });
     });
-    await cache.invalidate(CACHE_KEY);
+    await invalidateCache(CACHE_KEY);
     return result;
   },
   reorder: async (ordemId: string, novaOrdem: number) => {
@@ -195,7 +195,7 @@ export const teamService = {
 
       return current;
     });
-    await cache.invalidate(CACHE_KEY);
+    await invalidateCache(CACHE_KEY);
     return result;
   },
   remove: async (teamId: string) => {
@@ -212,7 +212,7 @@ export const teamService = {
         data: { ordem: { decrement: 1 } },
       });
     });
-    await cache.invalidate(CACHE_KEY);
+    await invalidateCache(CACHE_KEY);
   },
 };
 

--- a/src/modules/website/services/treinamentoCompany.service.ts
+++ b/src/modules/website/services/treinamentoCompany.service.ts
@@ -1,15 +1,15 @@
 import { prisma } from "../../../config/prisma";
 import { WebsiteTreinamentoCompany } from "@prisma/client";
-import cache from "../../../utils/cache";
+import { getCache, setCache, invalidateCache } from "../../../utils/cache";
 
 const CACHE_KEY = "website:treinamentoCompany:list";
 
 export const treinamentoCompanyService = {
   list: async () => {
-    const cached = await cache.get(CACHE_KEY);
+    const cached = await getCache(CACHE_KEY);
     if (cached) return cached;
     const result = await prisma.websiteTreinamentoCompany.findMany();
-    await cache.set(CACHE_KEY, result);
+    await setCache(CACHE_KEY, result);
     return result;
   },
   get: (id: string) =>
@@ -18,17 +18,17 @@ export const treinamentoCompanyService = {
     data: Omit<WebsiteTreinamentoCompany, "id" | "criadoEm" | "atualizadoEm">
   ) => {
     const result = await prisma.websiteTreinamentoCompany.create({ data });
-    await cache.invalidate(CACHE_KEY);
+    await invalidateCache(CACHE_KEY);
     return result;
   },
   update: async (id: string, data: Partial<WebsiteTreinamentoCompany>) => {
     const result = await prisma.websiteTreinamentoCompany.update({ where: { id }, data });
-    await cache.invalidate(CACHE_KEY);
+    await invalidateCache(CACHE_KEY);
     return result;
   },
   remove: async (id: string) => {
     const result = await prisma.websiteTreinamentoCompany.delete({ where: { id } });
-    await cache.invalidate(CACHE_KEY);
+    await invalidateCache(CACHE_KEY);
     return result;
   },
 };

--- a/src/modules/website/services/treinamentosInCompany.service.ts
+++ b/src/modules/website/services/treinamentosInCompany.service.ts
@@ -1,15 +1,15 @@
 import { prisma } from "../../../config/prisma";
 import { WebsiteTreinamentosInCompany } from "@prisma/client";
-import cache from "../../../utils/cache";
+import { getCache, setCache, invalidateCache } from "../../../utils/cache";
 
 const CACHE_KEY = "website:treinamentosInCompany:list";
 
 export const treinamentosInCompanyService = {
   list: async () => {
-    const cached = await cache.get(CACHE_KEY);
+    const cached = await getCache(CACHE_KEY);
     if (cached) return cached;
     const result = await prisma.websiteTreinamentosInCompany.findMany();
-    await cache.set(CACHE_KEY, result);
+    await setCache(CACHE_KEY, result);
     return result;
   },
   get: (id: string) =>
@@ -18,17 +18,17 @@ export const treinamentosInCompanyService = {
     data: Omit<WebsiteTreinamentosInCompany, "id" | "criadoEm" | "atualizadoEm">
   ) => {
     const result = await prisma.websiteTreinamentosInCompany.create({ data });
-    await cache.invalidate(CACHE_KEY);
+    await invalidateCache(CACHE_KEY);
     return result;
   },
   update: async (id: string, data: Partial<WebsiteTreinamentosInCompany>) => {
     const result = await prisma.websiteTreinamentosInCompany.update({ where: { id }, data });
-    await cache.invalidate(CACHE_KEY);
+    await invalidateCache(CACHE_KEY);
     return result;
   },
   remove: async (id: string) => {
     const result = await prisma.websiteTreinamentosInCompany.delete({ where: { id } });
-    await cache.invalidate(CACHE_KEY);
+    await invalidateCache(CACHE_KEY);
     return result;
   },
 };


### PR DESCRIPTION
## Summary
- add `getCache`/`setCache` utility using redis or memory fallback
- reuse cache in website services and set cache headers on GET controllers

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68c37425fc348325b62fafa63be535cb