### PR TITLE
chore: improve redis cache handling

### DIFF
--- a/src/config/redis.ts
+++ b/src/config/redis.ts
@@ -2,4 +2,10 @@ import Redis from 'ioredis';
 
 const redis = new Redis(process.env.REDIS_URL || '', { lazyConnect: true });
 
+if (process.env.REDIS_URL) {
+  redis
+    .connect()
+    .catch((err) => console.error('Redis connection error:', err));
+}
+
 export default redis;

--- a/src/modules/usuarios/register/register-controller.ts
+++ b/src/modules/usuarios/register/register-controller.ts
@@ -1,7 +1,7 @@
 import { Request, Response, NextFunction } from "express";
 import bcrypt from "bcrypt";
 import { prisma } from "../../../config/prisma";
-import redis from "../../../config/redis";
+import { invalidateCacheByPrefix } from "../../../utils/cache";
 import { Prisma, CodigoTipo } from "@prisma/client";
 import { TipoUsuario, Role } from "../enums";
 import {
@@ -193,7 +193,7 @@ export const criarUsuario = async (
     console.log(`💾 [${correlationId}] Iniciando transação de banco`);
     const usuario = await createUserWithTransaction(userData, correlationId);
     try {
-      await redis.del("dashboard:stats");
+      await invalidateCacheByPrefix("dashboard:");
     } catch (cacheError) {
       console.warn(
         `⚠️ [${correlationId}] Falha ao invalidar cache do dashboard`,


### PR DESCRIPTION
## Summary
- ensure Redis connects on startup
- add cache invalidation by prefix and update user registration to use it

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68c385f55e908325a0907fa785face7f