### PR TITLE
fix: avoid permissive proxy setting for rate limiting

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -24,8 +24,9 @@ import { prisma } from "./config/prisma";
  */
 
 const app = express();
-// Confia no proxy para que req.protocol reflita corretamente HTTPS
-app.set("trust proxy", true);
+// Confia apenas no primeiro proxy para que req.protocol reflita corretamente HTTPS
+// evita configuração permissiva que permitiria bypass de rate limiting
+app.set("trust proxy", 1);
 
 // =============================================
 // MIDDLEWARES GLOBAIS


### PR DESCRIPTION
## Summary
- ensure Express only trusts the first proxy to avoid rate limit bypass

## Testing
- `pnpm lint`
- `pnpm format`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68c38830e09c83259e7b5ef39cea9715