### PR TITLE
refactor: centralize supabase client and add status indexes

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -199,6 +199,7 @@ model WebsiteTeamOrdem {
 
   @@unique([ordem])
   @@index([ordem])
+  @@index([status])
 }
 
 model WebsiteDepoimento {
@@ -295,6 +296,7 @@ model WebsiteBannerOrdem {
 
   @@unique([ordem])
   @@index([ordem])
+  @@index([status])
 }
 
 model WebsiteLogoEnterprise {
@@ -320,6 +322,7 @@ model WebsiteLogoEnterpriseOrdem {
 
   @@unique([ordem])
   @@index([ordem])
+  @@index([status])
 }
 
 model WebsiteImagemLogin {

--- a/src/config/supabase.ts
+++ b/src/config/supabase.ts
@@ -1,0 +1,12 @@
+import { createClient } from "@supabase/supabase-js";
+import { supabaseConfig } from "./env";
+
+/**
+ * Supabase client centralizado
+ * Utiliza as configurações validadas em src/config/env
+ */
+export const supabase = createClient(
+  supabaseConfig.url,
+  supabaseConfig.key
+);
+

--- a/src/modules/superbase/client.ts
+++ b/src/modules/superbase/client.ts
@@ -1,5 +1,0 @@
-import { createClient } from "@supabase/supabase-js";
-
-const supabaseUrl = process.env.SUPABASE_URL!;
-const supabaseKey = process.env.SUPABASE_KEY!;
-export const supabase = createClient(supabaseUrl, supabaseKey);

--- a/src/modules/usuarios/auth/index.ts
+++ b/src/modules/usuarios/auth/index.ts
@@ -1,2 +1,2 @@
-export { supabase } from "./supabase-client";
+export { supabase } from "../../../config/supabase";
 export { supabaseAuthMiddleware } from "./supabase-middleware";

--- a/src/modules/usuarios/auth/supabase-client.ts
+++ b/src/modules/usuarios/auth/supabase-client.ts
@@ -1,8 +1,0 @@
-import { createClient } from "@supabase/supabase-js";
-import { supabaseConfig } from "../../../config/env";
-
-/**
- * Cliente Supabase configurado para autenticação
- * Utiliza configurações centralizadas e validadas
- */
-export const supabase = createClient(supabaseConfig.url, supabaseConfig.key);

--- a/src/modules/website/__tests__/consultoria.test.ts
+++ b/src/modules/website/__tests__/consultoria.test.ts
@@ -2,7 +2,7 @@ import express from "express";
 import request from "supertest";
 import { consultoriaService } from "../services/consultoria.service";
 
-jest.mock("../../superbase/client", () => ({
+jest.mock("../../../config/supabase", () => ({
   supabase: {
     storage: {
       from: () => ({

--- a/src/modules/website/controllers/advanceAjuda.controller.ts
+++ b/src/modules/website/controllers/advanceAjuda.controller.ts
@@ -1,7 +1,7 @@
 import { Request, Response } from "express";
 import { setCacheHeaders } from '../../../utils/cache';
 import path from "path";
-import { supabase } from "../../superbase/client";
+import { supabase } from "../../../config/supabase";
 import { advanceAjudaService } from "../services/advanceAjuda.service";
 
 function generateImageTitle(url: string): string {

--- a/src/modules/website/controllers/banner.controller.ts
+++ b/src/modules/website/controllers/banner.controller.ts
@@ -1,7 +1,7 @@
 import { Request, Response } from "express";
 import { setCacheHeaders } from '../../../utils/cache';
 import path from "path";
-import { supabase } from "../../superbase/client";
+import { supabase } from "../../../config/supabase";
 import { bannerService } from "../services/banner.service";
 import { WebsiteStatus } from "@prisma/client";
 

--- a/src/modules/website/controllers/conexaoForte.controller.ts
+++ b/src/modules/website/controllers/conexaoForte.controller.ts
@@ -1,7 +1,7 @@
 import { Request, Response } from "express";
 import { setCacheHeaders } from '../../../utils/cache';
 import path from "path";
-import { supabase } from "../../superbase/client";
+import { supabase } from "../../../config/supabase";
 import { conexaoForteService } from "../services/conexaoForte.service";
 
 function generateImageTitle(url: string): string {

--- a/src/modules/website/controllers/consultoria.controller.ts
+++ b/src/modules/website/controllers/consultoria.controller.ts
@@ -1,7 +1,7 @@
 import { Request, Response } from "express";
 import { setCacheHeaders } from '../../../utils/cache';
 import path from "path";
-import { supabase } from "../../superbase/client";
+import { supabase } from "../../../config/supabase";
 import { consultoriaService } from "../services/consultoria.service";
 
 function generateImageTitle(url: string): string {

--- a/src/modules/website/controllers/imagemLogin.controller.ts
+++ b/src/modules/website/controllers/imagemLogin.controller.ts
@@ -1,7 +1,7 @@
 import { Request, Response } from "express";
 import { setCacheHeaders } from '../../../utils/cache';
 import path from "path";
-import { supabase } from "../../superbase/client";
+import { supabase } from "../../../config/supabase";
 import { imagemLoginService } from "../services/imagem-login.service";
 
 function generateImageTitle(url: string): string {

--- a/src/modules/website/controllers/logoEnterprise.controller.ts
+++ b/src/modules/website/controllers/logoEnterprise.controller.ts
@@ -1,7 +1,7 @@
 import { Request, Response } from "express";
 import { setCacheHeaders } from '../../../utils/cache';
 import path from "path";
-import { supabase } from "../../superbase/client";
+import { supabase } from "../../../config/supabase";
 import { logoEnterpriseService } from "../services/logoEnterprise.service";
 import { WebsiteStatus } from "@prisma/client";
 

--- a/src/modules/website/controllers/recrutamento.controller.ts
+++ b/src/modules/website/controllers/recrutamento.controller.ts
@@ -1,7 +1,7 @@
 import { Request, Response } from "express";
 import { setCacheHeaders } from '../../../utils/cache';
 import path from "path";
-import { supabase } from "../../superbase/client";
+import { supabase } from "../../../config/supabase";
 import { recrutamentoService } from "../services/recrutamento.service";
 
 function generateImageTitle(url: string): string {

--- a/src/modules/website/controllers/recrutamentoSelecao.controller.ts
+++ b/src/modules/website/controllers/recrutamentoSelecao.controller.ts
@@ -1,7 +1,7 @@
 import { Request, Response } from "express";
 import { setCacheHeaders } from '../../../utils/cache';
 import path from "path";
-import { supabase } from "../../superbase/client";
+import { supabase } from "../../../config/supabase";
 import { recrutamentoSelecaoService } from "../services/recrutamentoSelecao.service";
 
 function generateImageTitle(url: string): string {

--- a/src/modules/website/controllers/slider.controller.ts
+++ b/src/modules/website/controllers/slider.controller.ts
@@ -1,7 +1,7 @@
 import { Request, Response } from "express";
 import { setCacheHeaders } from '../../../utils/cache';
 import path from "path";
-import { supabase } from "../../superbase/client";
+import { supabase } from "../../../config/supabase";
 import { sliderService } from "../services/slider.service";
 
 /**

--- a/src/modules/website/controllers/treinamentoCompany.controller.ts
+++ b/src/modules/website/controllers/treinamentoCompany.controller.ts
@@ -1,7 +1,7 @@
 import { Request, Response } from "express";
 import { setCacheHeaders } from '../../../utils/cache';
 import path from "path";
-import { supabase } from "../../superbase/client";
+import { supabase } from "../../../config/supabase";
 import { treinamentoCompanyService } from "../services/treinamentoCompany.service";
 
 function generateImageTitle(url: string): string {


### PR DESCRIPTION
## Summary
- centralize Supabase client and remove duplicated modules
- index `status` in website order tables for faster lookups

## Testing
- `pnpm lint`
- `DATABASE_URL=postgres://localhost:5432/test DIRECT_URL=postgres://localhost:5432/test JWT_SECRET=test JWT_REFRESH_SECRET=test pnpm test`
- `DATABASE_URL=postgresql://postgres:postgres@localhost:5432/postgres DIRECT_URL=postgresql://postgres:postgres@localhost:5432/postgres pnpm prisma:migrate --name add-status-index --create-only` *(fails: Can't reach database server)*
- `psql postgresql://postgres:postgres@localhost:5432/postgres -c "EXPLAIN ANALYZE SELECT 1"` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68c3945b3d0c8325bd0b78f7d5bd589f