### PR TITLE
Add global rate limiting and structured logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "ioredis": "^5.7.0",
     "jsonwebtoken": "^9.0.2",
     "jwks-rsa": "^3.2.0",
+    "pino": "^9.9.5",
     "multer": "^2.0.2",
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       multer:
         specifier: ^2.0.2
         version: 2.0.2
+      pino:
+        specifier: ^9.9.5
+        version: 9.9.5
       swagger-jsdoc:
         specifier: ^6.2.8
         version: 6.2.8(openapi-types@12.1.3)
@@ -735,6 +738,10 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
+  atomic-sleep@1.0.0:
+    resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
+    engines: {node: '>=8.0.0'}
+
   aws-sign2@0.7.0:
     resolution: {integrity: sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==}
 
@@ -1246,6 +1253,10 @@ packages:
 
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fast-redact@3.5.0:
+    resolution: {integrity: sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==}
+    engines: {node: '>=6'}
 
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
@@ -1957,6 +1968,10 @@ packages:
   ohash@2.0.11:
     resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
 
+  on-exit-leak-free@2.1.2:
+    resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
+    engines: {node: '>=14.0.0'}
+
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
     engines: {node: '>= 0.8'}
@@ -2045,6 +2060,16 @@ packages:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
 
+  pino-abstract-transport@2.0.0:
+    resolution: {integrity: sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==}
+
+  pino-std-serializers@7.0.0:
+    resolution: {integrity: sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==}
+
+  pino@9.9.5:
+    resolution: {integrity: sha512-d1s98p8/4TfYhsJ09r/Azt30aYELRi6NNnZtEbqFw6BoGsdPVf5lKNK3kUwH8BmJJfpTLNuicjUQjaMbd93dVg==}
+    hasBin: true
+
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
@@ -2073,6 +2098,9 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  process-warning@5.0.0:
+    resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
 
   prompts@2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
@@ -2107,6 +2135,9 @@ packages:
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
+  quick-format-unescaped@4.0.4:
+    resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
+
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
@@ -2132,6 +2163,10 @@ packages:
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
+
+  real-require@0.2.0:
+    resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
+    engines: {node: '>= 12.13.0'}
 
   redis-errors@1.2.0:
     resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
@@ -2194,6 +2229,10 @@ packages:
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
+  safe-stable-stringify@2.5.0:
+    resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
+    engines: {node: '>=10'}
+
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
@@ -2251,6 +2290,9 @@ packages:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
 
+  sonic-boom@4.2.0:
+    resolution: {integrity: sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==}
+
   source-map-support@0.5.13:
     resolution: {integrity: sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==}
 
@@ -2260,6 +2302,10 @@ packages:
   source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
+
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
 
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
@@ -2365,6 +2411,9 @@ packages:
 
   text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
+
+  thread-stream@3.1.0:
+    resolution: {integrity: sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==}
 
   tinyexec@1.0.1:
     resolution: {integrity: sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw==}
@@ -3417,6 +3466,8 @@ snapshots:
 
   asynckit@0.4.0: {}
 
+  atomic-sleep@1.0.0: {}
+
   aws-sign2@0.7.0: {}
 
   aws4@1.13.2: {}
@@ -3989,6 +4040,8 @@ snapshots:
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
+
+  fast-redact@3.5.0: {}
 
   fast-safe-stringify@2.1.1: {}
 
@@ -4866,6 +4919,8 @@ snapshots:
 
   ohash@2.0.11: {}
 
+  on-exit-leak-free@2.1.2: {}
+
   on-finished@2.4.1:
     dependencies:
       ee-first: 1.1.1
@@ -4942,6 +4997,26 @@ snapshots:
 
   picomatch@2.3.1: {}
 
+  pino-abstract-transport@2.0.0:
+    dependencies:
+      split2: 4.2.0
+
+  pino-std-serializers@7.0.0: {}
+
+  pino@9.9.5:
+    dependencies:
+      atomic-sleep: 1.0.0
+      fast-redact: 3.5.0
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 2.0.0
+      pino-std-serializers: 7.0.0
+      process-warning: 5.0.0
+      quick-format-unescaped: 4.0.4
+      real-require: 0.2.0
+      safe-stable-stringify: 2.5.0
+      sonic-boom: 4.2.0
+      thread-stream: 3.1.0
+
   pirates@4.0.7: {}
 
   pkg-dir@4.2.0:
@@ -4970,6 +5045,8 @@ snapshots:
       typescript: 5.9.2
     transitivePeerDependencies:
       - magicast
+
+  process-warning@5.0.0: {}
 
   prompts@2.4.2:
     dependencies:
@@ -5001,6 +5078,8 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
+  quick-format-unescaped@4.0.4: {}
+
   range-parser@1.2.1: {}
 
   raw-body@2.5.2:
@@ -5028,6 +5107,8 @@ snapshots:
       picomatch: 2.3.1
 
   readdirp@4.1.2: {}
+
+  real-require@0.2.0: {}
 
   redis-errors@1.2.0: {}
 
@@ -5097,6 +5178,8 @@ snapshots:
       queue-microtask: 1.2.3
 
   safe-buffer@5.2.1: {}
+
+  safe-stable-stringify@2.5.0: {}
 
   safer-buffer@2.1.2: {}
 
@@ -5173,6 +5256,10 @@ snapshots:
 
   slash@3.0.0: {}
 
+  sonic-boom@4.2.0:
+    dependencies:
+      atomic-sleep: 1.0.0
+
   source-map-support@0.5.13:
     dependencies:
       buffer-from: 1.1.2
@@ -5184,6 +5271,8 @@ snapshots:
       source-map: 0.6.1
 
   source-map@0.6.1: {}
+
+  split2@4.2.0: {}
 
   sprintf-js@1.0.3: {}
 
@@ -5303,6 +5392,10 @@ snapshots:
       minimatch: 3.1.2
 
   text-table@0.2.0: {}
+
+  thread-stream@3.1.0:
+    dependencies:
+      real-require: 0.2.0
 
   tinyexec@1.0.1: {}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,8 @@ import type { CorsOptions, CorsOptionsDelegate } from "cors";
 import helmet from "helmet";
 import cookieParser from "cookie-parser";
 import { compressionMiddleware } from "./middlewares/compression";
+import { rateLimitMiddleware } from "./middlewares/rate-limit";
+import { correlationIdMiddleware } from "./middlewares/correlation-id";
 import { serverConfig } from "./config/env";
 import { appRoutes } from "./routes";
 import { startExpiredUserCleanupJob } from "./modules/usuarios/services/user-cleanup-service";
@@ -105,6 +107,9 @@ app.use(express.urlencoded({ extended: true }));
  * Necessário para autenticação via cookies no Swagger
  */
 app.use(cookieParser());
+
+app.use(correlationIdMiddleware);
+app.use(rateLimitMiddleware);
 
 if (serverConfig.enableCompression) {
   app.use(compressionMiddleware);

--- a/src/middlewares/correlation-id.ts
+++ b/src/middlewares/correlation-id.ts
@@ -1,0 +1,18 @@
+import { randomUUID } from "crypto";
+import { NextFunction, Request, Response } from "express";
+
+export const correlationIdMiddleware = (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  const headerId = req.header("x-correlation-id");
+  const correlationId =
+    headerId && headerId.trim().length > 0 ? headerId : randomUUID();
+
+  req.id = correlationId;
+  res.setHeader("X-Correlation-Id", correlationId);
+  res.locals.correlationId = correlationId;
+
+  next();
+};

--- a/src/modules/usuarios/controllers/admin-controller.ts
+++ b/src/modules/usuarios/controllers/admin-controller.ts
@@ -7,12 +7,20 @@
  */
 import { Request, Response } from "express";
 import { AdminService } from "../services/admin-service";
+import { logger } from "../../../utils/logger";
 
 export class AdminController {
   private adminService: AdminService;
 
   constructor() {
     this.adminService = new AdminService();
+  }
+
+  private getLogger(req: Request) {
+    return logger.child({
+      controller: "AdminController",
+      correlationId: req.id,
+    });
   }
 
   /**
@@ -38,11 +46,12 @@ export class AdminController {
    * Lista usuários com paginação e filtros
    */
   public listarUsuarios = async (req: Request, res: Response) => {
+    const log = this.getLogger(req);
     try {
       const result = await this.adminService.listarUsuarios(req.query);
       res.json(result);
     } catch (error) {
-      console.error("Erro ao listar usuários:", error);
+      log.error({ err: error }, "Erro ao listar usuários");
       res.status(500).json({
         message: "Erro ao listar usuários",
         error: error instanceof Error ? error.message : "Erro desconhecido",
@@ -54,6 +63,7 @@ export class AdminController {
    * Busca usuário específico
    */
   public buscarUsuario = async (req: Request, res: Response) => {
+    const log = this.getLogger(req);
     try {
       const { userId } = req.params;
       const result = await this.adminService.buscarUsuario(userId);
@@ -69,7 +79,7 @@ export class AdminController {
         usuario: result,
       });
     } catch (error) {
-      console.error("Erro ao buscar usuário:", error);
+      log.error({ err: error }, "Erro ao buscar usuário");
       res.status(500).json({
         message: "Erro ao buscar usuário",
         error: error instanceof Error ? error.message : "Erro desconhecido",
@@ -81,6 +91,7 @@ export class AdminController {
    * Atualiza status do usuário
    */
   public atualizarStatus = async (req: Request, res: Response) => {
+    const log = this.getLogger(req);
     try {
       const { userId } = req.params;
       const { status, motivo } = req.body;
@@ -92,7 +103,7 @@ export class AdminController {
       );
       res.json(result);
     } catch (error) {
-      console.error("Erro ao atualizar status:", error);
+      log.error({ err: error }, "Erro ao atualizar status");
       res.status(500).json({
         message: "Erro ao atualizar status do usuário",
         error: error instanceof Error ? error.message : "Erro desconhecido",
@@ -104,6 +115,7 @@ export class AdminController {
    * Atualiza role do usuário
    */
   public atualizarRole = async (req: Request, res: Response) => {
+    const log = this.getLogger(req);
     try {
       const { userId } = req.params;
       const { role, motivo } = req.body;
@@ -117,7 +129,7 @@ export class AdminController {
       );
       res.json(result);
     } catch (error) {
-      console.error("Erro ao atualizar role:", error);
+      log.error({ err: error }, "Erro ao atualizar role");
       res.status(500).json({
         message: "Erro ao atualizar role do usuário",
         error: error instanceof Error ? error.message : "Erro desconhecido",

--- a/src/modules/usuarios/controllers/stats-controller.ts
+++ b/src/modules/usuarios/controllers/stats-controller.ts
@@ -7,6 +7,7 @@
  */
 import { Request, Response } from "express";
 import { StatsService } from "../services/stats-service";
+import { logger } from "../../../utils/logger";
 
 export class StatsController {
   private statsService: StatsService;
@@ -15,11 +16,19 @@ export class StatsController {
     this.statsService = new StatsService();
   }
 
+  private getLogger(req: Request) {
+    return logger.child({
+      controller: "StatsController",
+      correlationId: req.id,
+    });
+  }
+
   /**
    * Estatísticas do dashboard principal
    * GET /stats/dashboard
    */
   public getDashboardStats = async (req: Request, res: Response) => {
+    const log = this.getLogger(req);
     try {
       const stats = await this.statsService.getDashboardStats();
 
@@ -29,7 +38,7 @@ export class StatsController {
         timestamp: new Date().toISOString(),
       });
     } catch (error) {
-      console.error("Erro ao obter estatísticas:", error);
+      log.error({ err: error }, "Erro ao obter estatísticas");
       res.status(500).json({
         message: "Erro ao obter estatísticas",
         error: error instanceof Error ? error.message : "Erro desconhecido",
@@ -42,6 +51,7 @@ export class StatsController {
    * GET /stats/usuarios
    */
   public getUserStats = async (req: Request, res: Response) => {
+    const log = this.getLogger(req);
     try {
       const { periodo = "30d" } = req.query;
       const stats = await this.statsService.getUserStats(periodo as string);
@@ -53,7 +63,10 @@ export class StatsController {
         timestamp: new Date().toISOString(),
       });
     } catch (error) {
-      console.error("Erro ao obter estatísticas de usuários:", error);
+      log.error(
+        { err: error },
+        "Erro ao obter estatísticas de usuários"
+      );
       res.status(500).json({
         message: "Erro ao obter estatísticas de usuários",
         error: error instanceof Error ? error.message : "Erro desconhecido",

--- a/src/modules/website/routes/advance-ajuda.ts
+++ b/src/modules/website/routes/advance-ajuda.ts
@@ -1,5 +1,4 @@
 import { Router } from "express";
-import { rateLimitMiddleware } from "../../../middlewares/rate-limit";
 import { publicCache } from "../../../middlewares/cache-control";
 import multer from "multer";
 import { supabaseAuthMiddleware } from "../../usuarios/auth";
@@ -35,7 +34,7 @@ const upload = multer({ storage: multer.memoryStorage() });
  *         source: |
  *           curl -X GET "http://localhost:3000/api/v1/website/advance-ajuda"
  */
-router.get("/", rateLimitMiddleware, publicCache, AdvanceAjudaController.list);
+router.get("/", publicCache, AdvanceAjudaController.list);
 
 /**
  * @openapi
@@ -74,7 +73,7 @@ router.get("/", rateLimitMiddleware, publicCache, AdvanceAjudaController.list);
  *         source: |
  *           curl -X GET "http://localhost:3000/api/v1/website/advance-ajuda/{id}"
  */
-router.get("/:id", rateLimitMiddleware, publicCache, AdvanceAjudaController.get);
+router.get("/:id", publicCache, AdvanceAjudaController.get);
 
 /**
  * @openapi

--- a/src/modules/website/routes/banner.ts
+++ b/src/modules/website/routes/banner.ts
@@ -1,5 +1,4 @@
 import { Router } from "express";
-import { rateLimitMiddleware } from "../../../middlewares/rate-limit";
 import { publicCache } from "../../../middlewares/cache-control";
 import multer from "multer";
 import { supabaseAuthMiddleware } from "../../usuarios/auth";
@@ -35,7 +34,7 @@ const upload = multer({ storage: multer.memoryStorage() });
  *         source: |
  *           curl -X GET "http://localhost:3000/api/v1/website/banner"
  */
-router.get("/", rateLimitMiddleware, publicCache, BannerController.list);
+router.get("/", publicCache, BannerController.list);
 
 /**
  * @openapi
@@ -75,7 +74,7 @@ router.get("/", rateLimitMiddleware, publicCache, BannerController.list);
  *         source: |
  *           curl -X GET "http://localhost:3000/api/v1/website/banner/{ordemId}"
  */
-router.get("/:id", rateLimitMiddleware, publicCache, BannerController.get);
+router.get("/:id", publicCache, BannerController.get);
 
 /**
  * @openapi

--- a/src/modules/website/routes/conexao-forte.ts
+++ b/src/modules/website/routes/conexao-forte.ts
@@ -1,5 +1,4 @@
 import { Router } from "express";
-import { rateLimitMiddleware } from "../../../middlewares/rate-limit";
 import { publicCache } from "../../../middlewares/cache-control";
 import multer from "multer";
 import { supabaseAuthMiddleware } from "../../usuarios/auth";
@@ -35,7 +34,7 @@ const upload = multer({ storage: multer.memoryStorage() });
  *         source: |
  *           curl -X GET "http://localhost:3000/api/v1/website/conexao-forte"
  */
-router.get("/", rateLimitMiddleware, publicCache, ConexaoForteController.list);
+router.get("/", publicCache, ConexaoForteController.list);
 
 /**
  * @openapi
@@ -74,7 +73,7 @@ router.get("/", rateLimitMiddleware, publicCache, ConexaoForteController.list);
  *         source: |
  *           curl -X GET "http://localhost:3000/api/v1/website/conexao-forte/{id}"
  */
-router.get("/:id", rateLimitMiddleware, publicCache, ConexaoForteController.get);
+router.get("/:id", publicCache, ConexaoForteController.get);
 
 /**
  * @openapi

--- a/src/modules/website/routes/consultoria.ts
+++ b/src/modules/website/routes/consultoria.ts
@@ -1,5 +1,4 @@
 import { Router } from "express";
-import { rateLimitMiddleware } from "../../../middlewares/rate-limit";
 import { publicCache } from "../../../middlewares/cache-control";
 import multer from "multer";
 import { supabaseAuthMiddleware } from "../../usuarios/auth";
@@ -35,7 +34,7 @@ const upload = multer({ storage: multer.memoryStorage() });
  *         source: |
  *           curl -X GET "http://localhost:3000/api/v1/website/consultoria"
  */
-router.get("/", rateLimitMiddleware, publicCache, ConsultoriaController.list);
+router.get("/", publicCache, ConsultoriaController.list);
 
 /**
  * @openapi
@@ -74,7 +73,7 @@ router.get("/", rateLimitMiddleware, publicCache, ConsultoriaController.list);
  *         source: |
  *           curl -X GET "http://localhost:3000/api/v1/website/consultoria/{id}"
  */
-router.get("/:id", rateLimitMiddleware, publicCache, ConsultoriaController.get);
+router.get("/:id", publicCache, ConsultoriaController.get);
 
 /**
  * @openapi

--- a/src/modules/website/routes/depoimentos.ts
+++ b/src/modules/website/routes/depoimentos.ts
@@ -1,5 +1,4 @@
 import { Router } from "express";
-import { rateLimitMiddleware } from "../../../middlewares/rate-limit";
 import { publicCache } from "../../../middlewares/cache-control";
 import { supabaseAuthMiddleware } from "../../usuarios/auth";
 import { DepoimentosController } from "../controllers/depoimentos.controller";
@@ -39,7 +38,7 @@ const router = Router();
  *         source: |
  *           curl -X GET "http://localhost:3000/api/v1/website/depoimentos"
  */
-router.get("/", rateLimitMiddleware, publicCache, DepoimentosController.list);
+router.get("/", publicCache, DepoimentosController.list);
 
 /**
  * @openapi
@@ -79,7 +78,7 @@ router.get("/", rateLimitMiddleware, publicCache, DepoimentosController.list);
  *         source: |
  *           curl -X GET "http://localhost:3000/api/v1/website/depoimentos/{ordemId}"
  */
-router.get("/:id", rateLimitMiddleware, publicCache, DepoimentosController.get);
+router.get("/:id", publicCache, DepoimentosController.get);
 
 /**
  * @openapi

--- a/src/modules/website/routes/diferenciais.ts
+++ b/src/modules/website/routes/diferenciais.ts
@@ -1,5 +1,4 @@
 import { Router } from "express";
-import { rateLimitMiddleware } from "../../../middlewares/rate-limit";
 import { publicCache } from "../../../middlewares/cache-control";
 import { supabaseAuthMiddleware } from "../../usuarios/auth";
 import { DiferenciaisController } from "../controllers/diferenciais.controller";
@@ -33,7 +32,7 @@ const router = Router();
  *         source: |
  *           curl -X GET "http://localhost:3000/api/v1/website/diferenciais"
  */
-router.get("/", rateLimitMiddleware, publicCache, DiferenciaisController.list);
+router.get("/", publicCache, DiferenciaisController.list);
 
 /**
  * @openapi
@@ -72,7 +71,7 @@ router.get("/", rateLimitMiddleware, publicCache, DiferenciaisController.list);
  *         source: |
  *           curl -X GET "http://localhost:3000/api/v1/website/diferenciais/{id}"
  */
-router.get("/:id", rateLimitMiddleware, publicCache, DiferenciaisController.get);
+router.get("/:id", publicCache, DiferenciaisController.get);
 
 /**
  * @openapi

--- a/src/modules/website/routes/header-pages.ts
+++ b/src/modules/website/routes/header-pages.ts
@@ -1,5 +1,4 @@
 import { Router } from "express";
-import { rateLimitMiddleware } from "../../../middlewares/rate-limit";
 import { publicCache } from "../../../middlewares/cache-control";
 import { supabaseAuthMiddleware } from "../../usuarios/auth";
 import { HeaderPageController } from "../controllers/header-pages.controller";
@@ -33,7 +32,7 @@ const router = Router();
  *         source: |
  *           curl -X GET "http://localhost:3000/api/v1/website/header-pages"
  */
-router.get("/", rateLimitMiddleware, publicCache, HeaderPageController.list);
+router.get("/", publicCache, HeaderPageController.list);
 
 /**
  * @openapi
@@ -72,7 +71,7 @@ router.get("/", rateLimitMiddleware, publicCache, HeaderPageController.list);
  *         source: |
  *           curl -X GET "http://localhost:3000/api/v1/website/header-pages/{id}"
  */
-router.get("/:id", rateLimitMiddleware, publicCache, HeaderPageController.get);
+router.get("/:id", publicCache, HeaderPageController.get);
 
 /**
  * @openapi

--- a/src/modules/website/routes/imagem-login.ts
+++ b/src/modules/website/routes/imagem-login.ts
@@ -1,5 +1,4 @@
 import { Router } from "express";
-import { rateLimitMiddleware } from "../../../middlewares/rate-limit";
 import { publicCache } from "../../../middlewares/cache-control";
 import multer from "multer";
 import { supabaseAuthMiddleware } from "../../usuarios/auth";
@@ -35,7 +34,7 @@ const upload = multer({ storage: multer.memoryStorage() });
  *         source: |
  *           curl -X GET "http://localhost:3000/api/v1/website/imagem-login"
  */
-router.get("/", rateLimitMiddleware, publicCache, ImagemLoginController.list);
+router.get("/", publicCache, ImagemLoginController.list);
 
 /**
  * @openapi
@@ -74,7 +73,7 @@ router.get("/", rateLimitMiddleware, publicCache, ImagemLoginController.list);
  *         source: |
  *           curl -X GET "http://localhost:3000/api/v1/website/imagem-login/{id}"
  */
-router.get("/:id", rateLimitMiddleware, publicCache, ImagemLoginController.get);
+router.get("/:id", publicCache, ImagemLoginController.get);
 
 /**
  * @openapi

--- a/src/modules/website/routes/index.ts
+++ b/src/modules/website/routes/index.ts
@@ -1,5 +1,4 @@
 import { Router } from "express";
-import { rateLimitMiddleware } from "../../../middlewares/rate-limit";
 import { publicCache } from "../../../middlewares/cache-control";
 import { sobreRoutes } from "./sobre";
 import { sliderRoutes } from "./slider";
@@ -49,7 +48,7 @@ const router = Router();
  *         source: |
  *           curl -X GET "http://localhost:3000/api/v1/website"
  */
-router.get("/", rateLimitMiddleware, publicCache, (req, res) => {
+router.get("/", publicCache, (req, res) => {
   res.json({
     message: "Website Module API",
     version: "v1",

--- a/src/modules/website/routes/informacoes-gerais.ts
+++ b/src/modules/website/routes/informacoes-gerais.ts
@@ -1,5 +1,4 @@
 import { Router } from "express";
-import { rateLimitMiddleware } from "../../../middlewares/rate-limit";
 import { publicCache } from "../../../middlewares/cache-control";
 import { supabaseAuthMiddleware } from "../../usuarios/auth";
 import { InformacoesGeraisController } from "../controllers/informacoes-gerais.controller";
@@ -33,7 +32,7 @@ const router = Router();
  *         source: |
  *           curl -X GET "http://localhost:3000/api/v1/website/informacoes-gerais"
  */
-router.get("/", rateLimitMiddleware, publicCache, InformacoesGeraisController.list);
+router.get("/", publicCache, InformacoesGeraisController.list);
 
 /**
  * @openapi
@@ -72,7 +71,7 @@ router.get("/", rateLimitMiddleware, publicCache, InformacoesGeraisController.li
  *         source: |
  *           curl -X GET "http://localhost:3000/api/v1/website/informacoes-gerais/{id}"
  */
-router.get("/:id", rateLimitMiddleware, publicCache, InformacoesGeraisController.get);
+router.get("/:id", publicCache, InformacoesGeraisController.get);
 
 /**
  * @openapi

--- a/src/modules/website/routes/logo-enterprises.ts
+++ b/src/modules/website/routes/logo-enterprises.ts
@@ -1,5 +1,4 @@
 import { Router } from "express";
-import { rateLimitMiddleware } from "../../../middlewares/rate-limit";
 import { publicCache } from "../../../middlewares/cache-control";
 import multer from "multer";
 import { supabaseAuthMiddleware } from "../../usuarios/auth";
@@ -35,7 +34,7 @@ const upload = multer({ storage: multer.memoryStorage() });
  *         source: |
  *           curl -X GET "http://localhost:3000/api/v1/website/logo-enterprises"
  */
-router.get("/", rateLimitMiddleware, publicCache, LogoEnterpriseController.list);
+router.get("/", publicCache, LogoEnterpriseController.list);
 
 /**
  * @openapi
@@ -75,7 +74,7 @@ router.get("/", rateLimitMiddleware, publicCache, LogoEnterpriseController.list)
  *         source: |
  *           curl -X GET "http://localhost:3000/api/v1/website/logo-enterprises/{id}"
  */
-router.get("/:id", rateLimitMiddleware, publicCache, LogoEnterpriseController.get);
+router.get("/:id", publicCache, LogoEnterpriseController.get);
 
 /**
  * @openapi

--- a/src/modules/website/routes/planinhas.ts
+++ b/src/modules/website/routes/planinhas.ts
@@ -1,5 +1,4 @@
 import { Router } from "express";
-import { rateLimitMiddleware } from "../../../middlewares/rate-limit";
 import { publicCache } from "../../../middlewares/cache-control";
 import { supabaseAuthMiddleware } from "../../usuarios/auth";
 import { PlaninhasController } from "../controllers/planinhas.controller";
@@ -33,7 +32,7 @@ const router = Router();
  *         source: |
  *           curl -X GET "http://localhost:3000/api/v1/website/planinhas"
  */
-router.get("/", rateLimitMiddleware, publicCache, PlaninhasController.list);
+router.get("/", publicCache, PlaninhasController.list);
 
 /**
  * @openapi
@@ -72,7 +71,7 @@ router.get("/", rateLimitMiddleware, publicCache, PlaninhasController.list);
  *         source: |
  *           curl -X GET "http://localhost:3000/api/v1/website/planinhas/{id}"
  */
-router.get("/:id", rateLimitMiddleware, publicCache, PlaninhasController.get);
+router.get("/:id", publicCache, PlaninhasController.get);
 
 /**
  * @openapi

--- a/src/modules/website/routes/recrutamento-selecao.ts
+++ b/src/modules/website/routes/recrutamento-selecao.ts
@@ -1,5 +1,4 @@
 import { Router } from "express";
-import { rateLimitMiddleware } from "../../../middlewares/rate-limit";
 import { publicCache } from "../../../middlewares/cache-control";
 import multer from "multer";
 import { supabaseAuthMiddleware } from "../../usuarios/auth";
@@ -35,7 +34,7 @@ const upload = multer({ storage: multer.memoryStorage() });
  *         source: |
  *           curl -X GET "http://localhost:3000/api/v1/website/recrutamento-selecao"
  */
-router.get("/", rateLimitMiddleware, publicCache, RecrutamentoSelecaoController.list);
+router.get("/", publicCache, RecrutamentoSelecaoController.list);
 
 /**
  * @openapi
@@ -74,7 +73,7 @@ router.get("/", rateLimitMiddleware, publicCache, RecrutamentoSelecaoController.
  *         source: |
  *           curl -X GET "http://localhost:3000/api/v1/website/recrutamento-selecao/{id}"
  */
-router.get("/:id", rateLimitMiddleware, publicCache, RecrutamentoSelecaoController.get);
+router.get("/:id", publicCache, RecrutamentoSelecaoController.get);
 
 /**
  * @openapi

--- a/src/modules/website/routes/recrutamento.ts
+++ b/src/modules/website/routes/recrutamento.ts
@@ -1,5 +1,4 @@
 import { Router } from "express";
-import { rateLimitMiddleware } from "../../../middlewares/rate-limit";
 import { publicCache } from "../../../middlewares/cache-control";
 import multer from "multer";
 import { supabaseAuthMiddleware } from "../../usuarios/auth";
@@ -35,7 +34,7 @@ const upload = multer({ storage: multer.memoryStorage() });
  *         source: |
  *           curl -X GET "http://localhost:3000/api/v1/website/recrutamento"
  */
-router.get("/", rateLimitMiddleware, publicCache, RecrutamentoController.list);
+router.get("/", publicCache, RecrutamentoController.list);
 
 /**
  * @openapi
@@ -74,7 +73,7 @@ router.get("/", rateLimitMiddleware, publicCache, RecrutamentoController.list);
  *         source: |
  *           curl -X GET "http://localhost:3000/api/v1/website/recrutamento/{id}"
  */
-router.get("/:id", rateLimitMiddleware, publicCache, RecrutamentoController.get);
+router.get("/:id", publicCache, RecrutamentoController.get);
 
 /**
  * @openapi

--- a/src/modules/website/routes/sistema.ts
+++ b/src/modules/website/routes/sistema.ts
@@ -1,5 +1,4 @@
 import { Router } from "express";
-import { rateLimitMiddleware } from "../../../middlewares/rate-limit";
 import { publicCache } from "../../../middlewares/cache-control";
 import { supabaseAuthMiddleware } from "../../usuarios/auth";
 import { SistemaController } from "../controllers/sistema.controller";
@@ -33,7 +32,7 @@ const router = Router();
  *         source: |
  *           curl -X GET "http://localhost:3000/api/v1/website/sistema"
  */
-router.get("/", rateLimitMiddleware, publicCache, SistemaController.list);
+router.get("/", publicCache, SistemaController.list);
 
 /**
  * @openapi
@@ -72,7 +71,7 @@ router.get("/", rateLimitMiddleware, publicCache, SistemaController.list);
  *         source: |
  *           curl -X GET "http://localhost:3000/api/v1/website/sistema/{id}"
  */
-router.get("/:id", rateLimitMiddleware, publicCache, SistemaController.get);
+router.get("/:id", publicCache, SistemaController.get);
 
 /**
  * @openapi

--- a/src/modules/website/routes/slider.ts
+++ b/src/modules/website/routes/slider.ts
@@ -1,5 +1,4 @@
 import { Router } from "express";
-import { rateLimitMiddleware } from "../../../middlewares/rate-limit";
 import { publicCache } from "../../../middlewares/cache-control";
 import multer from "multer";
 import { supabaseAuthMiddleware } from "../../usuarios/auth";
@@ -35,7 +34,7 @@ const upload = multer({ storage: multer.memoryStorage() });
  *         source: |
  *           curl -X GET "http://localhost:3000/api/v1/website/slider"
 */
-router.get("/", rateLimitMiddleware, publicCache, SliderController.list);
+router.get("/", publicCache, SliderController.list);
 
 /**
  * @openapi
@@ -75,7 +74,7 @@ router.get("/", rateLimitMiddleware, publicCache, SliderController.list);
  *         source: |
  *           curl -X GET "http://localhost:3000/api/v1/website/slider/{ordemId}"
 */
-router.get("/:id", rateLimitMiddleware, publicCache, SliderController.get);
+router.get("/:id", publicCache, SliderController.get);
 
 /**
  * @openapi

--- a/src/modules/website/routes/sobre-empresa.ts
+++ b/src/modules/website/routes/sobre-empresa.ts
@@ -1,5 +1,4 @@
 import { Router } from "express";
-import { rateLimitMiddleware } from "../../../middlewares/rate-limit";
 import { publicCache } from "../../../middlewares/cache-control";
 import { supabaseAuthMiddleware } from "../../usuarios/auth";
 import { SobreEmpresaController } from "../controllers/sobreEmpresa.controller";
@@ -33,7 +32,7 @@ const router = Router();
  *         source: |
  *           curl -X GET "http://localhost:3000/api/v1/website/sobre-empresa"
  */
-router.get("/", rateLimitMiddleware, publicCache, SobreEmpresaController.list);
+router.get("/", publicCache, SobreEmpresaController.list);
 
 /**
  * @openapi
@@ -72,7 +71,7 @@ router.get("/", rateLimitMiddleware, publicCache, SobreEmpresaController.list);
  *         source: |
  *           curl -X GET "http://localhost:3000/api/v1/website/sobre-empresa/{id}"
  */
-router.get("/:id", rateLimitMiddleware, publicCache, SobreEmpresaController.get);
+router.get("/:id", publicCache, SobreEmpresaController.get);
 
 /**
  * @openapi

--- a/src/modules/website/routes/sobre.ts
+++ b/src/modules/website/routes/sobre.ts
@@ -1,5 +1,4 @@
 import { Router } from "express";
-import { rateLimitMiddleware } from "../../../middlewares/rate-limit";
 import { publicCache } from "../../../middlewares/cache-control";
 import { supabaseAuthMiddleware } from "../../usuarios/auth";
 import { SobreController } from "../controllers/sobre.controller";
@@ -33,7 +32,7 @@ const router = Router();
  *         source: |
  *           curl -X GET "http://localhost:3000/api/v1/website/sobre"
  */
-router.get("/", rateLimitMiddleware, publicCache, SobreController.list);
+router.get("/", publicCache, SobreController.list);
 
 /**
  * @openapi
@@ -72,7 +71,7 @@ router.get("/", rateLimitMiddleware, publicCache, SobreController.list);
  *         source: |
  *           curl -X GET "http://localhost:3000/api/v1/website/sobre/{id}"
  */
-router.get("/:id", rateLimitMiddleware, publicCache, SobreController.get);
+router.get("/:id", publicCache, SobreController.get);
 
 /**
  * @openapi

--- a/src/modules/website/routes/team.ts
+++ b/src/modules/website/routes/team.ts
@@ -1,5 +1,4 @@
 import { Router } from "express";
-import { rateLimitMiddleware } from "../../../middlewares/rate-limit";
 import { publicCache } from "../../../middlewares/cache-control";
 import { supabaseAuthMiddleware } from "../../usuarios/auth";
 import { TeamController } from "../controllers/team.controller";
@@ -39,7 +38,7 @@ const router = Router();
  *         source: |
  *           curl -X GET "http://localhost:3000/api/v1/website/team"
  */
-router.get("/", rateLimitMiddleware, publicCache, TeamController.list);
+router.get("/", publicCache, TeamController.list);
 
 /**
  * @openapi
@@ -79,7 +78,7 @@ router.get("/", rateLimitMiddleware, publicCache, TeamController.list);
  *         source: |
  *           curl -X GET "http://localhost:3000/api/v1/website/team/{ordemId}"
  */
-router.get("/:id", rateLimitMiddleware, publicCache, TeamController.get);
+router.get("/:id", publicCache, TeamController.get);
 
 /**
  * @openapi

--- a/src/modules/website/routes/treinamento-company.ts
+++ b/src/modules/website/routes/treinamento-company.ts
@@ -1,5 +1,4 @@
 import { Router } from "express";
-import { rateLimitMiddleware } from "../../../middlewares/rate-limit";
 import { publicCache } from "../../../middlewares/cache-control";
 import multer from "multer";
 import { supabaseAuthMiddleware } from "../../usuarios/auth";
@@ -35,7 +34,7 @@ const upload = multer({ storage: multer.memoryStorage() });
  *         source: |
  *           curl -X GET "http://localhost:3000/api/v1/website/treinamento-company"
  */
-router.get("/", rateLimitMiddleware, publicCache, TreinamentoCompanyController.list);
+router.get("/", publicCache, TreinamentoCompanyController.list);
 
 /**
  * @openapi
@@ -74,7 +73,7 @@ router.get("/", rateLimitMiddleware, publicCache, TreinamentoCompanyController.l
  *         source: |
  *           curl -X GET "http://localhost:3000/api/v1/website/treinamento-company/{id}"
  */
-router.get("/:id", rateLimitMiddleware, publicCache, TreinamentoCompanyController.get);
+router.get("/:id", publicCache, TreinamentoCompanyController.get);
 
 /**
  * @openapi

--- a/src/modules/website/routes/treinamentos-in-company.ts
+++ b/src/modules/website/routes/treinamentos-in-company.ts
@@ -1,5 +1,4 @@
 import { Router } from "express";
-import { rateLimitMiddleware } from "../../../middlewares/rate-limit";
 import { publicCache } from "../../../middlewares/cache-control";
 import { supabaseAuthMiddleware } from "../../usuarios/auth";
 import { TreinamentosInCompanyController } from "../controllers/treinamentosInCompany.controller";
@@ -33,7 +32,7 @@ const router = Router();
  *         source: |
  *           curl -X GET "http://localhost:3000/api/v1/website/treinamentos-in-company"
  */
-router.get("/", rateLimitMiddleware, publicCache, TreinamentosInCompanyController.list);
+router.get("/", publicCache, TreinamentosInCompanyController.list);
 
 /**
  * @openapi
@@ -72,7 +71,7 @@ router.get("/", rateLimitMiddleware, publicCache, TreinamentosInCompanyControlle
  *         source: |
  *           curl -X GET "http://localhost:3000/api/v1/website/treinamentos-in-company/{id}"
  */
-router.get("/:id", rateLimitMiddleware, publicCache, TreinamentosInCompanyController.get);
+router.get("/:id", publicCache, TreinamentosInCompanyController.get);
 
 /**
  * @openapi

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,5 +1,4 @@
 import { Router } from "express";
-import { rateLimitMiddleware } from "../middlewares/rate-limit";
 import { publicCache } from "../middlewares/cache-control";
 import { usuarioRoutes } from "../modules/usuarios";
 import { brevoRoutes } from "../modules/brevo/routes";
@@ -39,7 +38,7 @@ const emailVerificationController = new EmailVerificationController();
  *         source: |
  *           curl -X GET "http://localhost:3000/"
  */
-router.get("/", rateLimitMiddleware, publicCache, (req, res) => {
+router.get("/", publicCache, (req, res) => {
   const data = {
     message: "Advance+ API",
     version: "v3.0.3",
@@ -120,7 +119,7 @@ router.get("/", rateLimitMiddleware, publicCache, (req, res) => {
  *         source: |
  *           curl -X GET "http://localhost:3000/health"
  */
-router.get("/health", rateLimitMiddleware, publicCache, async (req, res) => {
+router.get("/health", publicCache, async (req, res) => {
   let redisStatus = "⚠️ not configured";
   if (process.env.REDIS_URL) {
     try {
@@ -153,7 +152,6 @@ router.get("/health", rateLimitMiddleware, publicCache, async (req, res) => {
 // Rota pública para verificação de email
 router.get(
   "/verificar-email",
-  rateLimitMiddleware,
   emailVerificationController.verifyEmail
 );
 

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -3,6 +3,7 @@
  */
 declare namespace Express {
   interface Request {
+    id: string;
     user?: {
       id: string;
       email: string;

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,13 @@
+import pino from "pino";
+
+const level =
+  process.env.LOG_LEVEL ??
+  (process.env.NODE_ENV === "production" ? "info" : "debug");
+
+export const logger = pino({
+  level,
+  base: {
+    service: "advancemais-api",
+    environment: process.env.NODE_ENV,
+  },
+});


### PR DESCRIPTION
## Summary
- add a correlation-id middleware, enable the global rate limiter, and remove per-route rate limiter hooks so every request is consistently throttled
- introduce a shared pino logger utility and update controllers to rely on structured logging with the request correlation id

## Testing
- pnpm run build
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68c8be1d93688325aa6029783ba324fd