### PR TITLE
fix: support path aliases in compiled build

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "supertest": "^6.3.4",
     "ts-jest": "^29.4.1",
     "ts-node-dev": "^2.0.0",
-    "tsconfig-paths": "^4.2.0",
     "typescript": "^5.9.2"
   },
   "dependencies": {
@@ -79,6 +78,7 @@
     "multer": "^2.0.2",
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.1",
+    "tsconfig-paths": "^4.2.0",
     "zod": "^3.25.76"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       swagger-ui-express:
         specifier: ^5.0.1
         version: 5.0.1(express@4.21.2)
+      tsconfig-paths:
+        specifier: ^4.2.0
+        version: 4.2.0
       zod:
         specifier: ^3.25.76
         version: 3.25.76
@@ -120,9 +123,6 @@ importers:
       ts-node-dev:
         specifier: ^2.0.0
         version: 2.0.0(@types/node@24.3.1)(typescript@5.9.2)
-      tsconfig-paths:
-        specifier: ^4.2.0
-        version: 4.2.0
       typescript:
         specifier: ^5.9.2
         version: 5.9.2

--- a/src/config/module-alias.ts
+++ b/src/config/module-alias.ts
@@ -1,0 +1,41 @@
+import Module from "node:module";
+import path from "node:path";
+
+type ModuleWithResolve = typeof Module & {
+  _resolveFilename(
+    request: string,
+    parent?: NodeModule | null,
+    isMain?: boolean,
+    options?: {
+      paths?: string[];
+    }
+  ): string;
+};
+
+const globalFlag = "__advancemaisModuleAliasRegistered";
+
+const globalContext = globalThis as Record<string, unknown>;
+
+if (!globalContext[globalFlag]) {
+  const moduleConstructor = Module as ModuleWithResolve;
+  const originalResolveFilename = moduleConstructor._resolveFilename.bind(Module);
+  const baseDir = path.resolve(__dirname, "..");
+  const aliasPrefix = "@/";
+
+  moduleConstructor._resolveFilename = function patchedResolveFilename(
+    request,
+    parent,
+    isMain,
+    options
+  ) {
+    if (typeof request === "string" && request.startsWith(aliasPrefix)) {
+      const relativePath = request.slice(aliasPrefix.length);
+      const absolutePath = path.resolve(baseDir, relativePath);
+      return originalResolveFilename(absolutePath, parent ?? undefined, isMain, options);
+    }
+
+    return originalResolveFilename(request, parent ?? undefined, isMain, options);
+  };
+
+  globalContext[globalFlag] = true;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import "./config/module-alias";
 import "./config/env";
 
 import express from "express";


### PR DESCRIPTION
## Summary
- add a runtime module alias hook so compiled code resolves `@/` imports correctly
- ensure tsconfig-paths is available in production builds so existing scripts still work
- bootstrap the hook before the application loads to prevent module resolution failures

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68c9688412b48325a28dd1f74ce5a1f7