### PR TITLE
feat: add plan limits and vacancy workflow statuses

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -29,27 +29,25 @@ model Usuario {
   atualizadoEm  DateTime    @updatedAt
   ultimoLogin   DateTime?
   refreshToken  String?
-  
+
   // CAMPOS PARA RECUPERAÇÃO DE SENHA
-  tokenRecuperacao           String?   
-  tokenRecuperacaoExp        DateTime? 
+  tokenRecuperacao           String?
+  tokenRecuperacaoExp        DateTime?
   tentativasRecuperacao      Int       @default(0)
   ultimaTentativaRecuperacao DateTime?
-  
+
   // CAMPOS PARA VERIFICAÇÃO DE EMAIL (NOVOS)
-  emailVerificado              Boolean   @default(false)
-  emailVerificadoEm            DateTime?
-  emailVerificationToken       String?   @unique
-  emailVerificationTokenExp    DateTime?
-  emailVerificationAttempts    Int       @default(0)
-  ultimaTentativaVerificacao   DateTime?
+  emailVerificado            Boolean   @default(false)
+  emailVerificadoEm          DateTime?
+  emailVerificationToken     String?   @unique
+  emailVerificationTokenExp  DateTime?
+  emailVerificationAttempts  Int       @default(0)
+  ultimaTentativaVerificacao DateTime?
 
   // RELACIONAMENTOS EXISTENTES
   enderecos     Endereco[]
-  empresa       Empresa?    @relation(fields: [codEmpresa], references: [id])
+  empresa       Empresa?       @relation(fields: [codEmpresa], references: [id])
   codigoUsuario CodigoUsuario?
-
-
 
   @@index([tokenRecuperacao])
   @@index([emailVerificationToken])
@@ -65,9 +63,68 @@ model Empresa {
   logoUrl   String?
   cidade    String?
   estado    String?
+  descricao String?   @db.VarChar(500)
   criadoEm  DateTime  @default(now())
   usuarios  Usuario[]
-  
+  vagas     Vaga[]
+}
+
+enum RegimeTrabalho {
+  CLT
+  TEMPORARIO
+  ESTAGIO
+  PJ
+  HOME_OFFICE
+  JOVEM_APRENDIZ
+}
+
+enum ModalidadeVaga {
+  PRESENCIAL
+  REMOTO
+  HIBRIDO
+}
+
+enum StatusVaga {
+  RASCUNHO
+  EM_ANALISE
+  PUBLICADO
+  EXPIRADO
+}
+
+model Vaga {
+  id               String         @id @default(uuid())
+  empresaId        String
+  modoAnonimo      Boolean        @default(false)
+  regimeDeTrabalho RegimeTrabalho
+  modalidade       ModalidadeVaga
+  paraPcd          Boolean        @default(false)
+  requisitos       String         @db.Text
+  atividades       String         @db.Text
+  beneficios       String         @db.Text
+  observacoes      String?        @db.Text
+  cargaHoraria     String
+  inscricoesAte    DateTime?
+  inseridaEm       DateTime       @default(now())
+  atualizadoEm     DateTime       @updatedAt
+  status           StatusVaga     @default(RASCUNHO)
+
+  empresa Empresa @relation(fields: [empresaId], references: [id], onDelete: Cascade)
+
+  @@index([empresaId])
+}
+
+model PlanoEmpresarial {
+  id                       String   @id @default(uuid())
+  icon                     String
+  nome                     String
+  descricao                String
+  valor                    String
+  desconto                 Float?
+  quantidadeVagas          Int
+  vagaEmDestaque           Boolean  @default(false)
+  quantidadeVagasDestaque  Int?
+  criadoEm                 DateTime @default(now())
+  atualizadoEm             DateTime @updatedAt
 }
 
 model Endereco {
@@ -85,16 +142,16 @@ model Endereco {
 }
 
 model LogEmail {
-  id          String      @id @default(uuid())
-  usuarioId   String?
-  email       String
-  tipoEmail   TipoEmail
-  status      StatusEmail
-  tentativas  Int         @default(1)
-  erro        String?
-  messageId   String?
-  criadoEm    DateTime    @default(now())
-  atualizadoEm DateTime   @updatedAt
+  id           String      @id @default(uuid())
+  usuarioId    String?
+  email        String
+  tipoEmail    TipoEmail
+  status       StatusEmail
+  tentativas   Int         @default(1)
+  erro         String?
+  messageId    String?
+  criadoEm     DateTime    @default(now())
+  atualizadoEm DateTime    @updatedAt
 
   @@index([usuarioId])
   @@index([email])
@@ -103,16 +160,16 @@ model LogEmail {
 }
 
 model LogSMS {
-  id          String    @id @default(uuid())
-  usuarioId   String?
-  telefone    String
-  tipoSMS     TipoSMS
-  status      StatusSMS
-  tentativas  Int       @default(1)
-  erro        String?
-  messageId   String?
-  criadoEm    DateTime  @default(now())
-  atualizadoEm DateTime @updatedAt
+  id           String    @id @default(uuid())
+  usuarioId    String?
+  telefone     String
+  tipoSMS      TipoSMS
+  status       StatusSMS
+  tentativas   Int       @default(1)
+  erro         String?
+  messageId    String?
+  criadoEm     DateTime  @default(now())
+  atualizadoEm DateTime  @updatedAt
 
   @@index([usuarioId])
   @@index([telefone])
@@ -126,7 +183,7 @@ model CodigoUsuario {
   tipo      CodigoTipo @default(USUARIO)
   criadoEm  DateTime   @default(now())
 
-  usuario   Usuario    @relation(fields: [usuarioId], references: [id])
+  usuario Usuario @relation(fields: [usuarioId], references: [id])
 
   @@map("codigo_usuario")
 }
@@ -178,24 +235,24 @@ model WebsiteSobreEmpresa {
 }
 
 model WebsiteTeam {
-  id        String   @id @default(uuid())
-  photoUrl  String
-  nome      String
-  cargo     String
-  criadoEm  DateTime @default(now())
+  id           String   @id @default(uuid())
+  photoUrl     String
+  nome         String
+  cargo        String
+  criadoEm     DateTime @default(now())
   atualizadoEm DateTime @updatedAt
 
-  ordem     WebsiteTeamOrdem?
+  ordem WebsiteTeamOrdem?
 }
 
 model WebsiteTeamOrdem {
-  id            String       @id @default(uuid())
-  websiteTeamId String       @unique
+  id            String        @id @default(uuid())
+  websiteTeamId String        @unique
   ordem         Int
   status        WebsiteStatus @default(RASCUNHO)
-  criadoEm      DateTime     @default(now())
+  criadoEm      DateTime      @default(now())
 
-  team          WebsiteTeam  @relation(fields: [websiteTeamId], references: [id], onDelete: Cascade)
+  team WebsiteTeam @relation(fields: [websiteTeamId], references: [id], onDelete: Cascade)
 
   @@unique([ordem])
   @@index([ordem])
@@ -203,25 +260,25 @@ model WebsiteTeamOrdem {
 }
 
 model WebsiteDepoimento {
-  id          String   @id @default(uuid())
-  depoimento  String
-  nome        String
-  cargo       String
-  fotoUrl     String
-  criadoEm    DateTime @default(now())
+  id           String   @id @default(uuid())
+  depoimento   String
+  nome         String
+  cargo        String
+  fotoUrl      String
+  criadoEm     DateTime @default(now())
   atualizadoEm DateTime @updatedAt
 
-  ordem       WebsiteDepoimentoOrdem?
+  ordem WebsiteDepoimentoOrdem?
 }
 
 model WebsiteDepoimentoOrdem {
-  id                   String       @id @default(uuid())
-  websiteDepoimentoId  String       @unique
-  ordem                Int
-  status               WebsiteStatus @default(RASCUNHO)
-  criadoEm             DateTime     @default(now())
+  id                  String        @id @default(uuid())
+  websiteDepoimentoId String        @unique
+  ordem               Int
+  status              WebsiteStatus @default(RASCUNHO)
+  criadoEm            DateTime      @default(now())
 
-  depoimento           WebsiteDepoimento @relation(fields: [websiteDepoimentoId], references: [id], onDelete: Cascade)
+  depoimento WebsiteDepoimento @relation(fields: [websiteDepoimentoId], references: [id], onDelete: Cascade)
 
   @@unique([ordem])
   @@index([ordem])
@@ -250,25 +307,25 @@ model WebsiteDiferenciais {
 }
 
 model WebsiteSlider {
-  id          String   @id @default(uuid())
-  sliderName  String
-  imagemUrl   String
-  link        String?
-  criadoEm    DateTime @default(now())
+  id           String   @id @default(uuid())
+  sliderName   String
+  imagemUrl    String
+  link         String?
+  criadoEm     DateTime @default(now())
   atualizadoEm DateTime @updatedAt
 
-  ordem       WebsiteSliderOrdem?
+  ordem WebsiteSliderOrdem?
 }
 
 model WebsiteSliderOrdem {
-  id              String             @id @default(uuid())
-  websiteSliderId String             @unique
+  id              String            @id @default(uuid())
+  websiteSliderId String            @unique
   ordem           Int
   orientacao      SliderOrientation
-  status          WebsiteStatus      @default(RASCUNHO)
-  criadoEm        DateTime           @default(now())
+  status          WebsiteStatus     @default(RASCUNHO)
+  criadoEm        DateTime          @default(now())
 
-  slider          WebsiteSlider      @relation(fields: [websiteSliderId], references: [id], onDelete: Cascade)
+  slider WebsiteSlider @relation(fields: [websiteSliderId], references: [id], onDelete: Cascade)
 
   @@unique([ordem, orientacao])
   @@index([ordem])
@@ -282,17 +339,17 @@ model WebsiteBanner {
   criadoEm     DateTime @default(now())
   atualizadoEm DateTime @updatedAt
 
-  ordem        WebsiteBannerOrdem?
+  ordem WebsiteBannerOrdem?
 }
 
 model WebsiteBannerOrdem {
-  id              String       @id @default(uuid())
-  websiteBannerId String       @unique
+  id              String        @id @default(uuid())
+  websiteBannerId String        @unique
   ordem           Int
   status          WebsiteStatus @default(RASCUNHO)
-  criadoEm        DateTime     @default(now())
+  criadoEm        DateTime      @default(now())
 
-  banner          WebsiteBanner @relation(fields: [websiteBannerId], references: [id], onDelete: Cascade)
+  banner WebsiteBanner @relation(fields: [websiteBannerId], references: [id], onDelete: Cascade)
 
   @@unique([ordem])
   @@index([ordem])
@@ -300,23 +357,23 @@ model WebsiteBannerOrdem {
 }
 
 model WebsiteLogoEnterprise {
-  id         String   @id @default(uuid())
-  nome       String
-  imagemUrl  String
-  imagemAlt  String
-  website    String?
-  criadoEm   DateTime @default(now())
+  id           String   @id @default(uuid())
+  nome         String
+  imagemUrl    String
+  imagemAlt    String
+  website      String?
+  criadoEm     DateTime @default(now())
   atualizadoEm DateTime @updatedAt
 
-  ordem      WebsiteLogoEnterpriseOrdem?
+  ordem WebsiteLogoEnterpriseOrdem?
 }
 
 model WebsiteLogoEnterpriseOrdem {
-  id                     String       @id @default(uuid())
-  websiteLogoEnterpriseId String       @unique
-  ordem                  Int
-  status                 WebsiteStatus @default(RASCUNHO)
-  criadoEm               DateTime     @default(now())
+  id                      String        @id @default(uuid())
+  websiteLogoEnterpriseId String        @unique
+  ordem                   Int
+  status                  WebsiteStatus @default(RASCUNHO)
+  criadoEm                DateTime      @default(now())
 
   logo WebsiteLogoEnterprise @relation(fields: [websiteLogoEnterpriseId], references: [id], onDelete: Cascade)
 
@@ -335,65 +392,65 @@ model WebsiteImagemLogin {
 }
 
 model WebsitePlaninhas {
-  id        String @id @default(uuid())
-  titulo    String
-  descricao String
-  icone1    String
-  titulo1   String
-  descricao1 String
-  icone2    String
-  titulo2   String
-  descricao2 String
-  icone3    String
-  titulo3   String
-  descricao3 String
+  id           String   @id @default(uuid())
+  titulo       String
+  descricao    String
+  icone1       String
+  titulo1      String
+  descricao1   String
+  icone2       String
+  titulo2      String
+  descricao2   String
+  icone3       String
+  titulo3      String
+  descricao3   String
   criadoEm     DateTime @default(now())
   atualizadoEm DateTime @updatedAt
 }
 
 model WebsiteAdvanceAjuda {
-  id         String @id @default(uuid())
-  titulo     String
-  descricao  String
-  imagemUrl  String
+  id           String   @id @default(uuid())
+  titulo       String
+  descricao    String
+  imagemUrl    String
   imagemTitulo String
-  titulo1    String
-  descricao1 String
-  titulo2    String
-  descricao2 String
-  titulo3    String
-  descricao3 String
+  titulo1      String
+  descricao1   String
+  titulo2      String
+  descricao2   String
+  titulo3      String
+  descricao3   String
   criadoEm     DateTime @default(now())
   atualizadoEm DateTime @updatedAt
 }
 
 model WebsiteRecrutamentoSelecao {
-  id         String @id @default(uuid())
-  titulo     String
-  descricao  String
-  imagemUrl  String
+  id           String   @id @default(uuid())
+  titulo       String
+  descricao    String
+  imagemUrl    String
   imagemTitulo String
-  titulo1    String
-  titulo2    String
-  titulo3    String
-  titulo4    String
+  titulo1      String
+  titulo2      String
+  titulo3      String
+  titulo4      String
   criadoEm     DateTime @default(now())
   atualizadoEm DateTime @updatedAt
 }
 
 model WebsiteSistema {
-  id             String @id @default(uuid())
-  titulo         String
-  descricao      String
-  subtitulo      String
-  etapa1Titulo   String
+  id              String   @id @default(uuid())
+  titulo          String
+  descricao       String
+  subtitulo       String
+  etapa1Titulo    String
   etapa1Descricao String
-  etapa2Titulo   String
+  etapa2Titulo    String
   etapa2Descricao String
-  etapa3Titulo   String
+  etapa3Titulo    String
   etapa3Descricao String
-  criadoEm       DateTime @default(now())
-  atualizadoEm   DateTime @updatedAt
+  criadoEm        DateTime @default(now())
+  atualizadoEm    DateTime @updatedAt
 }
 
 model WebsiteTreinamentoCompany {
@@ -411,34 +468,34 @@ model WebsiteTreinamentoCompany {
 }
 
 model WebsiteConexaoForte {
-  id           String @id @default(uuid())
-  titulo       String
-  descricao    String
-  imagemUrl1   String
+  id            String   @id @default(uuid())
+  titulo        String
+  descricao     String
+  imagemUrl1    String
   imagemTitulo1 String
-  imagemUrl2   String
+  imagemUrl2    String
   imagemTitulo2 String
-  imagemUrl3   String
+  imagemUrl3    String
   imagemTitulo3 String
-  imagemUrl4   String
+  imagemUrl4    String
   imagemTitulo4 String
-  criadoEm     DateTime @default(now())
-  atualizadoEm DateTime @updatedAt
+  criadoEm      DateTime @default(now())
+  atualizadoEm  DateTime @updatedAt
 }
 
 model WebsiteTreinamentosInCompany {
-  id         String   @id @default(uuid())
-  titulo     String
-  icone1     String
-  descricao1 String
-  icone2     String
-  descricao2 String
-  icone3     String
-  descricao3 String
-  icone4     String
-  descricao4 String
-  icone5     String
-  descricao5 String
+  id           String   @id @default(uuid())
+  titulo       String
+  icone1       String
+  descricao1   String
+  icone2       String
+  descricao2   String
+  icone3       String
+  descricao3   String
+  icone4       String
+  descricao4   String
+  icone5       String
+  descricao5   String
   criadoEm     DateTime @default(now())
   atualizadoEm DateTime @updatedAt
 }
@@ -464,27 +521,27 @@ model WebsiteInformacoes {
 }
 
 model WebsiteHorarioFuncionamento {
-  id            String   @id @default(uuid())
+  id            String             @id @default(uuid())
   diaDaSemana   String
   horarioInicio String
   horarioFim    String
   informacoes   WebsiteInformacoes @relation(fields: [informacoesId], references: [id], onDelete: Cascade)
   informacoesId String
-  criadoEm      DateTime @default(now())
-  atualizadoEm  DateTime @updatedAt
+  criadoEm      DateTime           @default(now())
+  atualizadoEm  DateTime           @updatedAt
 }
 
 model WebsiteHeaderPage {
-  id          String               @id @default(uuid())
-  subtitulo   String
-  titulo      String
-  descricao   String
-  imagemUrl   String
-  buttonLabel String
-  buttonLink  String
-  page        WebsiteHeaderPageType @unique
-  criadoEm    DateTime              @default(now())
-  atualizadoEm DateTime             @updatedAt
+  id           String                @id @default(uuid())
+  subtitulo    String
+  titulo       String
+  descricao    String
+  imagemUrl    String
+  buttonLabel  String
+  buttonLink   String
+  page         WebsiteHeaderPageType @unique
+  criadoEm     DateTime              @default(now())
+  atualizadoEm DateTime              @updatedAt
 }
 
 // =============================================
@@ -548,7 +605,6 @@ enum CodigoTipo {
 
 // Métodos de pagamento aceitos para planos
 
-
 enum SliderOrientation {
   DESKTOP
   TABLET_MOBILE
@@ -570,4 +626,3 @@ enum WebsiteHeaderPageType {
   POLITICA_PRIVACIDADE
   OUVIDORIA
 }
-

--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -102,6 +102,14 @@ const options: Options = {
         name: 'Website - Header Pages',
         description: 'Cabeçalhos de páginas',
       },
+      {
+        name: 'Empresas - Planos Empresariais',
+        description: 'Gestão dos planos empresariais corporativos',
+      },
+      {
+        name: 'Empresas - Vagas',
+        description: 'Administração de vagas corporativas vinculadas às empresas',
+      },
     ],
     'x-tagGroups': [
       { name: 'Default', tags: ['Default'] },
@@ -136,6 +144,10 @@ const options: Options = {
           'Website - Header Pages',
         ],
       },
+      {
+        name: 'Empresas',
+        tags: ['Empresas - Planos Empresariais', 'Empresas - Vagas'],
+      },
     ],
     components: {
       schemas: {
@@ -145,6 +157,28 @@ const options: Options = {
             success: { type: 'boolean', example: false },
             message: { type: 'string', example: 'Erro de validação' },
             code: { type: 'string', example: 'VALIDATION_ERROR' },
+            error: { type: 'string', example: 'Detalhes adicionais do erro' },
+          },
+        },
+        ValidationErrorResponse: {
+          type: 'object',
+          properties: {
+            success: { type: 'boolean', example: false },
+            code: { type: 'string', example: 'VALIDATION_ERROR' },
+            message: {
+              type: 'string',
+              example: 'Dados inválidos para criação do recurso',
+            },
+            issues: {
+              type: 'object',
+              additionalProperties: {
+                type: 'array',
+                items: { type: 'string' },
+              },
+              example: {
+                campo: ['Este campo é obrigatório'],
+              },
+            },
           },
         },
         UserLoginRequest: {
@@ -2782,6 +2816,392 @@ const options: Options = {
                 'OUVIDORIA',
               ],
               example: 'SOBRE',
+            },
+          },
+        },
+        PlanoEmpresarial: {
+          type: 'object',
+          properties: {
+            id: { type: 'string', example: 'plano-uuid' },
+            icon: { type: 'string', example: 'ph-buildings' },
+            nome: { type: 'string', example: 'Plano Corporativo' },
+            descricao: {
+              type: 'string',
+              example: 'Soluções completas de RH e treinamento para empresas.',
+            },
+            valor: { type: 'string', example: '199.90' },
+            desconto: {
+              type: 'number',
+              nullable: true,
+              example: 10,
+              description: 'Percentual de desconto aplicado sobre o valor do plano',
+            },
+            quantidadeVagas: {
+              type: 'integer',
+              example: 10,
+              description: 'Quantidade de vagas que a empresa pode manter entre PUBLICADO e EM_ANALISE',
+            },
+            vagaEmDestaque: {
+              type: 'boolean',
+              example: true,
+              description: 'Indica se o plano permite vagas em destaque no site',
+            },
+            quantidadeVagasDestaque: {
+              type: 'integer',
+              nullable: true,
+              example: 2,
+              description: 'Limite de vagas simultâneas com destaque quando habilitado',
+            },
+            criadoEm: {
+              type: 'string',
+              format: 'date-time',
+              example: '2024-01-01T12:00:00Z',
+            },
+            atualizadoEm: {
+              type: 'string',
+              format: 'date-time',
+              example: '2024-01-02T12:00:00Z',
+            },
+          },
+        },
+        PlanoEmpresarialCreateInput: {
+          type: 'object',
+          required: ['icon', 'nome', 'descricao', 'valor', 'quantidadeVagas', 'vagaEmDestaque'],
+          properties: {
+            icon: {
+              type: 'string',
+              example: 'ph-buildings',
+              description: 'Identificador do ícone exibido no site',
+            },
+            nome: {
+              type: 'string',
+              example: 'Plano Corporativo',
+              description: 'Nome comercial do plano',
+            },
+            descricao: {
+              type: 'string',
+              example: 'Soluções completas de RH e treinamento para empresas.',
+            },
+            valor: {
+              type: 'string',
+              example: '199.90',
+              description: 'Valor monetário com até duas casas decimais',
+            },
+            desconto: {
+              type: 'number',
+              nullable: true,
+              example: 10,
+              description: 'Percentual de desconto opcional aplicado sobre o valor do plano',
+            },
+            quantidadeVagas: {
+              type: 'integer',
+              example: 10,
+              description: 'Quantidade total de vagas permitidas no plano (PUBLICADO + EM_ANALISE)',
+            },
+            vagaEmDestaque: {
+              type: 'boolean',
+              example: true,
+              description: 'Define se o plano permite cadastrar vagas em destaque',
+            },
+            quantidadeVagasDestaque: {
+              type: 'integer',
+              nullable: true,
+              example: 2,
+              description: 'Quantidade de vagas em destaque permitidas quando habilitado',
+            },
+          },
+        },
+        PlanoEmpresarialUpdateInput: {
+          type: 'object',
+          properties: {
+            icon: { type: 'string', example: 'ph-shield-check' },
+            nome: { type: 'string', example: 'Plano Enterprise' },
+            descricao: {
+              type: 'string',
+              example: 'Atualização do pacote com suporte dedicado para grandes contas.',
+            },
+            valor: {
+              type: 'string',
+              example: '249.90',
+              description: 'Novo valor monetário do plano',
+            },
+            desconto: {
+              type: 'number',
+              nullable: true,
+              example: 15,
+              description: 'Percentual de desconto aplicado sobre o valor do plano',
+            },
+            quantidadeVagas: {
+              type: 'integer',
+              example: 15,
+              description: 'Atualização da quantidade total de vagas permitidas',
+            },
+            vagaEmDestaque: {
+              type: 'boolean',
+              example: false,
+              description: 'Permite habilitar ou desabilitar vagas em destaque',
+            },
+            quantidadeVagasDestaque: {
+              type: 'integer',
+              nullable: true,
+              example: 0,
+              description: 'Limite de vagas em destaque. Deve ser omitido quando vagaEmDestaque for falso',
+            },
+          },
+        },
+        PlanoEmpresarialLimitResponse: {
+          type: 'object',
+          properties: {
+            success: { type: 'boolean', example: false },
+            code: {
+              type: 'string',
+              example: 'PLANOS_EMPRESARIAIS_LIMIT_REACHED',
+            },
+            message: {
+              type: 'string',
+              example: 'Limite máximo de 4 planos empresariais atingido',
+            },
+            limite: { type: 'integer', example: 4 },
+          },
+        },
+        StatusVaga: {
+          type: 'string',
+          description: 'Etapas do fluxo de publicação da vaga',
+          enum: ['RASCUNHO', 'EM_ANALISE', 'PUBLICADO', 'EXPIRADO'],
+          example: 'EM_ANALISE',
+        },
+        EmpresaResumo: {
+          type: 'object',
+          description: 'Informações públicas da empresa vinculada à vaga',
+          properties: {
+            id: { type: 'string', example: 'empresa-uuid' },
+            nome: { type: 'string', example: 'Advance Tech Consultoria' },
+            logoUrl: {
+              type: 'string',
+              nullable: true,
+              example: 'https://cdn.advance.com.br/assets/empresa/logo.png',
+            },
+            cidade: { type: 'string', nullable: true, example: 'São Paulo' },
+            estado: { type: 'string', nullable: true, example: 'SP' },
+            descricao: {
+              type: 'string',
+              nullable: true,
+              example: 'Consultoria em RH e tecnologia especializada em recrutamento.',
+            },
+            criadoEm: {
+              type: 'string',
+              format: 'date-time',
+              example: '2024-01-05T12:00:00Z',
+            },
+          },
+        },
+        Vaga: {
+          type: 'object',
+          description: 'Representação completa da vaga cadastrada pela empresa',
+          properties: {
+            id: { type: 'string', example: 'vaga-uuid' },
+            empresaId: { type: 'string', example: 'empresa-uuid' },
+            empresa: {
+              allOf: [{ $ref: '#/components/schemas/EmpresaResumo' }],
+              nullable: true,
+            },
+            modoAnonimo: { type: 'boolean', example: true },
+            regimeDeTrabalho: {
+              type: 'string',
+              enum: ['CLT', 'TEMPORARIO', 'ESTAGIO', 'PJ', 'HOME_OFFICE', 'JOVEM_APRENDIZ'],
+              example: 'CLT',
+            },
+            modalidade: {
+              type: 'string',
+              enum: ['PRESENCIAL', 'REMOTO', 'HIBRIDO'],
+              example: 'PRESENCIAL',
+            },
+            paraPcd: { type: 'boolean', example: false },
+            requisitos: {
+              type: 'string',
+              example: 'Experiência com atendimento ao cliente e pacote Office avançado.',
+            },
+            atividades: {
+              type: 'string',
+              example: 'Atendimento a clientes, elaboração de relatórios e acompanhamento de indicadores.',
+            },
+            beneficios: {
+              type: 'string',
+              example: 'Vale transporte, vale alimentação, plano de saúde e day-off no aniversário.',
+            },
+            observacoes: {
+              type: 'string',
+              nullable: true,
+              example: 'Processo seletivo confidencial com etapas online.',
+            },
+            cargaHoraria: {
+              type: 'string',
+              example: '44 horas semanais (segunda a sexta-feira)',
+            },
+            inscricoesAte: {
+              type: 'string',
+              format: 'date-time',
+              nullable: true,
+              example: '2024-12-20T23:59:59Z',
+            },
+            inseridaEm: {
+              type: 'string',
+              format: 'date-time',
+              example: '2024-10-01T09:00:00Z',
+            },
+            atualizadoEm: {
+              type: 'string',
+              format: 'date-time',
+              example: '2024-10-05T09:00:00Z',
+            },
+            status: {
+              allOf: [{ $ref: '#/components/schemas/StatusVaga' }],
+              description: 'Status atual da vaga dentro do fluxo de aprovação',
+            },
+            nomeExibicao: {
+              type: 'string',
+              nullable: true,
+              example: 'Oportunidade Confidencial #A1B2C',
+            },
+            logoExibicao: {
+              type: 'string',
+              nullable: true,
+              example: null,
+            },
+            mensagemAnonimato: {
+              type: 'string',
+              nullable: true,
+              example:
+                'Esta empresa optou por manter suas informações confidenciais até avançar nas etapas do processo seletivo.',
+            },
+            descricaoExibicao: {
+              type: 'string',
+              nullable: true,
+              example: 'Consultoria em RH e tecnologia especializada em recrutamento.',
+            },
+          },
+        },
+        VagaCreateInput: {
+          type: 'object',
+          description: 'Dados necessários para cadastrar uma vaga. O status inicial é definido automaticamente como EM_ANALISE.',
+          required: [
+            'empresaId',
+            'regimeDeTrabalho',
+            'modalidade',
+            'requisitos',
+            'atividades',
+            'beneficios',
+            'cargaHoraria',
+          ],
+          properties: {
+            empresaId: {
+              type: 'string',
+              format: 'uuid',
+              example: 'f1d7a9c2-4e0b-4f6d-90ad-8c6b84a0f1a1',
+            },
+            modoAnonimo: {
+              type: 'boolean',
+              example: true,
+              description: 'Quando verdadeiro, oculta o nome e a logo da empresa nas listagens públicas',
+            },
+            regimeDeTrabalho: {
+              type: 'string',
+              enum: ['CLT', 'TEMPORARIO', 'ESTAGIO', 'PJ', 'HOME_OFFICE', 'JOVEM_APRENDIZ'],
+              example: 'CLT',
+            },
+            modalidade: {
+              type: 'string',
+              enum: ['PRESENCIAL', 'REMOTO', 'HIBRIDO'],
+              example: 'PRESENCIAL',
+            },
+            paraPcd: { type: 'boolean', example: false },
+            requisitos: {
+              type: 'string',
+              example: 'Experiência com atendimento ao cliente e pacote Office avançado.',
+            },
+            atividades: {
+              type: 'string',
+              example: 'Atendimento a clientes, elaboração de relatórios e acompanhamento de indicadores.',
+            },
+            beneficios: {
+              type: 'string',
+              example: 'Vale transporte, vale alimentação, plano de saúde e day-off no aniversário.',
+            },
+            observacoes: {
+              type: 'string',
+              example: 'Processo seletivo confidencial com etapas online.',
+            },
+            cargaHoraria: {
+              type: 'string',
+              example: '44 horas semanais (segunda a sexta-feira)',
+            },
+            inscricoesAte: {
+              type: 'string',
+              format: 'date-time',
+              example: '2024-12-20T23:59:59Z',
+            },
+            inseridaEm: {
+              type: 'string',
+              format: 'date-time',
+              example: '2024-10-01T09:00:00Z',
+            },
+          },
+        },
+        VagaUpdateInput: {
+          type: 'object',
+          description: 'Campos permitidos para atualização da vaga, inclusive o status do fluxo de aprovação.',
+          properties: {
+            empresaId: {
+              type: 'string',
+              format: 'uuid',
+              example: 'f1d7a9c2-4e0b-4f6d-90ad-8c6b84a0f1a1',
+            },
+            modoAnonimo: { type: 'boolean', example: false },
+            regimeDeTrabalho: {
+              type: 'string',
+              enum: ['CLT', 'TEMPORARIO', 'ESTAGIO', 'PJ', 'HOME_OFFICE', 'JOVEM_APRENDIZ'],
+              example: 'PJ',
+            },
+            modalidade: {
+              type: 'string',
+              enum: ['PRESENCIAL', 'REMOTO', 'HIBRIDO'],
+              example: 'HIBRIDO',
+            },
+            paraPcd: { type: 'boolean', example: true },
+            requisitos: {
+              type: 'string',
+              example: 'Vivência em rotinas administrativas e atendimento ao cliente.',
+            },
+            atividades: {
+              type: 'string',
+              example: 'Gestão de indicadores, acompanhamento de metas e organização de agendas.',
+            },
+            beneficios: {
+              type: 'string',
+              example: 'Vale transporte, auxílio home office e plano odontológico.',
+            },
+            observacoes: {
+              type: 'string',
+              example: 'Processo seletivo com etapas online.',
+            },
+            cargaHoraria: {
+              type: 'string',
+              example: '30 horas semanais (segunda a sexta-feira)',
+            },
+            inscricoesAte: {
+              type: 'string',
+              format: 'date-time',
+              nullable: true,
+              example: '2024-11-15T23:59:59Z',
+            },
+            inseridaEm: {
+              type: 'string',
+              format: 'date-time',
+              example: '2024-10-05T09:00:00Z',
+            },
+            status: {
+              allOf: [{ $ref: '#/components/schemas/StatusVaga' }],
+              description: 'Atualização manual do status da vaga',
             },
           },
         },

--- a/src/modules/empresas/index.ts
+++ b/src/modules/empresas/index.ts
@@ -1,0 +1,1 @@
+export { empresasRoutes } from './routes';

--- a/src/modules/empresas/planos-empresarial/controllers/planos-empresariais.controller.ts
+++ b/src/modules/empresas/planos-empresarial/controllers/planos-empresariais.controller.ts
@@ -1,0 +1,150 @@
+import { Request, Response } from 'express';
+import { ZodError } from 'zod';
+
+import {
+  MAX_PLANOS_EMPRESARIAIS,
+  PlanoEmpresarialLimitError,
+  planosEmpresariaisService,
+} from '@/modules/empresas/planos-empresarial/services/planos-empresariais.service';
+import {
+  createPlanoEmpresarialSchema,
+  updatePlanoEmpresarialSchema,
+} from '@/modules/empresas/planos-empresarial/validators/planos-empresariais.schema';
+
+export class PlanosEmpresariaisController {
+  static list = async (_req: Request, res: Response) => {
+    try {
+      const planos = await planosEmpresariaisService.list();
+      res.json(planos);
+    } catch (error: any) {
+      res.status(500).json({
+        success: false,
+        code: 'PLANOS_EMPRESARIAIS_LIST_ERROR',
+        message: 'Erro ao listar planos empresariais',
+        error: error?.message,
+      });
+    }
+  };
+
+  static get = async (req: Request, res: Response) => {
+    try {
+      const { id } = req.params;
+      const plano = await planosEmpresariaisService.get(id);
+
+      if (!plano) {
+        return res.status(404).json({
+          success: false,
+          code: 'PLANOS_EMPRESARIAIS_NOT_FOUND',
+          message: 'Plano empresarial não encontrado',
+        });
+      }
+
+      res.json(plano);
+    } catch (error: any) {
+      res.status(500).json({
+        success: false,
+        code: 'PLANOS_EMPRESARIAIS_GET_ERROR',
+        message: 'Erro ao buscar plano empresarial',
+        error: error?.message,
+      });
+    }
+  };
+
+  static create = async (req: Request, res: Response) => {
+    try {
+      const data = createPlanoEmpresarialSchema.parse(req.body);
+      const plano = await planosEmpresariaisService.create(data);
+      res.status(201).json(plano);
+    } catch (error: any) {
+      if (error instanceof ZodError) {
+        return res.status(400).json({
+          success: false,
+          code: 'VALIDATION_ERROR',
+          message: 'Dados inválidos para criação do plano empresarial',
+          issues: error.flatten().fieldErrors,
+        });
+      }
+
+      if (error instanceof PlanoEmpresarialLimitError) {
+        return res.status(409).json({
+          success: false,
+          code: 'PLANOS_EMPRESARIAIS_LIMIT_REACHED',
+          message: error.message,
+          limite: MAX_PLANOS_EMPRESARIAIS,
+        });
+      }
+
+      res.status(500).json({
+        success: false,
+        code: 'PLANOS_EMPRESARIAIS_CREATE_ERROR',
+        message: 'Erro ao criar plano empresarial',
+        error: error?.message,
+      });
+    }
+  };
+
+  static update = async (req: Request, res: Response) => {
+    try {
+      const { id } = req.params;
+      const data = updatePlanoEmpresarialSchema.parse(req.body);
+
+      if (Object.keys(data).length === 0) {
+        return res.status(400).json({
+          success: false,
+          code: 'VALIDATION_ERROR',
+          message: 'Informe ao menos um campo para atualização do plano empresarial',
+        });
+      }
+
+      const plano = await planosEmpresariaisService.update(id, data);
+      res.json(plano);
+    } catch (error: any) {
+      if (error instanceof ZodError) {
+        return res.status(400).json({
+          success: false,
+          code: 'VALIDATION_ERROR',
+          message: 'Dados inválidos para atualização do plano empresarial',
+          issues: error.flatten().fieldErrors,
+        });
+      }
+
+      if (error.code === 'P2025') {
+        return res.status(404).json({
+          success: false,
+          code: 'PLANOS_EMPRESARIAIS_NOT_FOUND',
+          message: 'Plano empresarial não encontrado',
+        });
+      }
+
+      res.status(500).json({
+        success: false,
+        code: 'PLANOS_EMPRESARIAIS_UPDATE_ERROR',
+        message: 'Erro ao atualizar plano empresarial',
+        error: error?.message,
+      });
+    }
+  };
+
+  static remove = async (req: Request, res: Response) => {
+    try {
+      const { id } = req.params;
+      await planosEmpresariaisService.remove(id);
+      res.status(204).send();
+    } catch (error: any) {
+      if (error.code === 'P2025') {
+        return res.status(404).json({
+          success: false,
+          code: 'PLANOS_EMPRESARIAIS_NOT_FOUND',
+          message: 'Plano empresarial não encontrado',
+        });
+      }
+
+      res.status(500).json({
+        success: false,
+        code: 'PLANOS_EMPRESARIAIS_DELETE_ERROR',
+        message: 'Erro ao remover plano empresarial',
+        error: error?.message,
+      });
+    }
+  };
+}

--- a/src/modules/empresas/planos-empresarial/index.ts
+++ b/src/modules/empresas/planos-empresarial/index.ts
@@ -1,0 +1,1 @@
+export { planosEmpresariaisRoutes } from './routes';

--- a/src/modules/empresas/planos-empresarial/routes/index.ts
+++ b/src/modules/empresas/planos-empresarial/routes/index.ts
@@ -1,0 +1,237 @@
+import { Router } from 'express';
+
+import { publicCache } from '@/middlewares/cache-control';
+import { supabaseAuthMiddleware } from '@/modules/usuarios/auth';
+import { PlanosEmpresariaisController } from '@/modules/empresas/planos-empresarial/controllers/planos-empresariais.controller';
+
+const router = Router();
+
+/**
+ * @openapi
+ * /api/v1/empresas/planos-empresarial:
+ *   get:
+ *     summary: Listar planos empresariais disponíveis
+ *     description: Retorna todos os planos empresariais configurados, incluindo regras de publicação de vagas. A tabela está limitada a no máximo 4 registros.
+ *     tags: [Empresas - Planos Empresariais]
+ *     responses:
+ *       200:
+ *         description: Lista de planos empresariais
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 $ref: '#/components/schemas/PlanoEmpresarial'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X GET "http://localhost:3000/api/v1/empresas/planos-empresarial"
+ */
+router.get('/', publicCache, PlanosEmpresariaisController.list);
+
+/**
+ * @openapi
+ * /api/v1/empresas/planos-empresarial/{id}:
+ *   get:
+ *     summary: Obter plano empresarial por ID
+ *     tags: [Empresas - Planos Empresariais]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Plano empresarial encontrado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/PlanoEmpresarial'
+ *       404:
+ *         description: Plano não encontrado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X GET "http://localhost:3000/api/v1/empresas/planos-empresarial/{id}"
+ */
+router.get('/:id', publicCache, PlanosEmpresariaisController.get);
+
+/**
+ * @openapi
+ * /api/v1/empresas/planos-empresarial:
+ *   post:
+ *     summary: Criar um novo plano empresarial
+ *     description: Disponível apenas para administradores e moderadores. A criação respeita o limite máximo de 4 planos ativos e permite definir descontos percentuais e regras de publicação de vagas.
+ *     tags: [Empresas - Planos Empresariais]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/PlanoEmpresarialCreateInput'
+ *     responses:
+ *       201:
+ *         description: Plano empresarial criado com sucesso
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/PlanoEmpresarial'
+ *       400:
+ *         description: Dados inválidos
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ValidationErrorResponse'
+ *       409:
+ *         description: Limite máximo de planos atingido
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/PlanoEmpresarialLimitResponse'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X POST "http://localhost:3000/api/v1/empresas/planos-empresarial" \
+ *            -H "Authorization: Bearer <TOKEN>" \
+ *            -H "Content-Type: application/json" \
+ *            -d '{
+ *                  "icon": "ph-buildings",
+ *                  "nome": "Plano Corporativo",
+ *                  "descricao": "Soluções completas para empresas",
+ *                  "valor": "199.90",
+ *                  "desconto": 10,
+ *                  "quantidadeVagas": 10,
+ *                  "vagaEmDestaque": true,
+ *                  "quantidadeVagasDestaque": 2
+ *                }'
+ */
+router.post('/', supabaseAuthMiddleware(['ADMIN', 'MODERADOR']), PlanosEmpresariaisController.create);
+
+/**
+ * @openapi
+ * /api/v1/empresas/planos-empresarial/{id}:
+ *   put:
+ *     summary: Atualizar plano empresarial
+ *     tags: [Empresas - Planos Empresariais]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/PlanoEmpresarialUpdateInput'
+ *     responses:
+ *       200:
+ *         description: Plano empresarial atualizado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/PlanoEmpresarial'
+ *       400:
+ *         description: Dados inválidos
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ValidationErrorResponse'
+ *       404:
+ *         description: Plano não encontrado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X PUT "http://localhost:3000/api/v1/empresas/planos-empresarial/{id}" \
+ *            -H "Authorization: Bearer <TOKEN>" \
+ *            -H "Content-Type: application/json" \
+ *            -d '{
+ *                  "descricao": "Atualização do pacote corporativo",
+ *                  "valor": "249.90",
+ *                  "desconto": null,
+ *                  "vagaEmDestaque": false
+ *                }'
+ */
+router.put('/:id', supabaseAuthMiddleware(['ADMIN', 'MODERADOR']), PlanosEmpresariaisController.update);
+
+/**
+ * @openapi
+ * /api/v1/empresas/planos-empresarial/{id}:
+ *   delete:
+ *     summary: Remover plano empresarial
+ *     tags: [Empresas - Planos Empresariais]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       204:
+ *         description: Plano removido com sucesso
+ *       404:
+ *         description: Plano não encontrado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X DELETE "http://localhost:3000/api/v1/empresas/planos-empresarial/{id}" \
+ *            -H "Authorization: Bearer <TOKEN>"
+ */
+router.delete('/:id', supabaseAuthMiddleware(['ADMIN', 'MODERADOR']), PlanosEmpresariaisController.remove);
+
+export { router as planosEmpresariaisRoutes };

--- a/src/modules/empresas/planos-empresarial/services/planos-empresariais.service.ts
+++ b/src/modules/empresas/planos-empresarial/services/planos-empresariais.service.ts
@@ -1,0 +1,96 @@
+import { Prisma } from '@prisma/client';
+
+import { prisma } from '@/config/prisma';
+
+export const MAX_PLANOS_EMPRESARIAIS = 4;
+
+export class PlanoEmpresarialLimitError extends Error {
+  constructor() {
+    super(`Limite máximo de ${MAX_PLANOS_EMPRESARIAIS} planos empresariais atingido`);
+    this.name = 'PlanoEmpresarialLimitError';
+  }
+}
+
+type CreatePlanoEmpresarialData = {
+  icon: string;
+  nome: string;
+  descricao: string;
+  valor: string;
+  desconto?: number | null;
+  quantidadeVagas: number;
+  vagaEmDestaque: boolean;
+  quantidadeVagasDestaque?: number | null;
+};
+
+type UpdatePlanoEmpresarialData = Partial<CreatePlanoEmpresarialData>;
+
+const sanitizeCreateData = (data: CreatePlanoEmpresarialData): Prisma.PlanoEmpresarialUncheckedCreateInput => ({
+  icon: data.icon.trim(),
+  nome: data.nome.trim(),
+  descricao: data.descricao.trim(),
+  valor: data.valor,
+  desconto: data.desconto ?? null,
+  quantidadeVagas: data.quantidadeVagas,
+  vagaEmDestaque: data.vagaEmDestaque,
+  quantidadeVagasDestaque: data.vagaEmDestaque ? data.quantidadeVagasDestaque ?? null : null,
+});
+
+const sanitizeUpdateData = (
+  data: UpdatePlanoEmpresarialData,
+): Prisma.PlanoEmpresarialUncheckedUpdateInput => {
+  const update: Prisma.PlanoEmpresarialUncheckedUpdateInput = {};
+
+  if (data.icon !== undefined) {
+    update.icon = data.icon.trim();
+  }
+  if (data.nome !== undefined) {
+    update.nome = data.nome.trim();
+  }
+  if (data.descricao !== undefined) {
+    update.descricao = data.descricao.trim();
+  }
+  if (data.valor !== undefined) {
+    update.valor = data.valor;
+  }
+  if (data.desconto !== undefined) {
+    update.desconto = data.desconto ?? null;
+  }
+  if (data.quantidadeVagas !== undefined) {
+    update.quantidadeVagas = data.quantidadeVagas;
+  }
+  if (data.vagaEmDestaque !== undefined) {
+    update.vagaEmDestaque = data.vagaEmDestaque;
+    if (!data.vagaEmDestaque) {
+      update.quantidadeVagasDestaque = null;
+    } else if (data.quantidadeVagasDestaque !== undefined) {
+      update.quantidadeVagasDestaque = data.quantidadeVagasDestaque;
+    }
+  } else if (data.quantidadeVagasDestaque !== undefined) {
+    update.quantidadeVagasDestaque = data.quantidadeVagasDestaque;
+  }
+
+  return update;
+};
+
+export const planosEmpresariaisService = {
+  list: () =>
+    prisma.planoEmpresarial.findMany({
+      orderBy: { criadoEm: 'asc' },
+    }),
+
+  get: (id: string) => prisma.planoEmpresarial.findUnique({ where: { id } }),
+
+  create: async (data: CreatePlanoEmpresarialData) => {
+    const totalPlanos = await prisma.planoEmpresarial.count();
+    if (totalPlanos >= MAX_PLANOS_EMPRESARIAIS) {
+      throw new PlanoEmpresarialLimitError();
+    }
+
+    return prisma.planoEmpresarial.create({ data: sanitizeCreateData(data) });
+  },
+
+  update: (id: string, data: UpdatePlanoEmpresarialData) =>
+    prisma.planoEmpresarial.update({ where: { id }, data: sanitizeUpdateData(data) }),
+
+  remove: (id: string) => prisma.planoEmpresarial.delete({ where: { id } }),
+};

--- a/src/modules/empresas/planos-empresarial/validators/planos-empresariais.schema.ts
+++ b/src/modules/empresas/planos-empresarial/validators/planos-empresariais.schema.ts
@@ -1,0 +1,204 @@
+import { RefinementCtx, z } from 'zod';
+
+const valorPlanoSchema = z
+  .union([z.string(), z.number()])
+  .transform((value, ctx) => {
+    if (typeof value === 'number') {
+      if (!Number.isFinite(value) || value < 0) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'O valor do plano deve ser um número positivo',
+        });
+        return z.NEVER;
+      }
+      return value.toFixed(2);
+    }
+
+    const sanitized = value.replace(/R\$/gi, '').replace(/\s+/g, '');
+
+    if (!/^\d+(?:[.,]\d{1,2})?$/.test(sanitized)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Informe um valor monetário válido. Ex: 199.90 ou 199,90',
+      });
+      return z.NEVER;
+    }
+
+    const normalized = sanitized.replace(',', '.');
+    const parsed = Number(normalized);
+
+    if (!Number.isFinite(parsed) || parsed < 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'O valor do plano deve ser um número válido',
+      });
+      return z.NEVER;
+    }
+
+    return parsed.toFixed(2);
+  })
+  .refine((value) => value.length > 0, {
+    message: 'O valor do plano é obrigatório',
+  });
+
+const percentualDescontoSchema = z.preprocess(
+  (value) => {
+    if (value === undefined || value === '') return undefined;
+
+    if (value === null) {
+      return null;
+    }
+
+    if (typeof value === 'number') {
+      return value;
+    }
+
+    if (typeof value === 'string') {
+      const sanitized = value.replace('%', '').trim().replace(',', '.');
+      if (sanitized.length === 0) {
+        return undefined;
+      }
+
+      const parsed = Number(sanitized);
+      return Number.isFinite(parsed) ? parsed : value;
+    }
+
+    return value;
+  },
+  z.union([
+    z
+      .number({ invalid_type_error: 'O desconto deve ser um número' })
+      .min(0, 'O desconto deve ser no mínimo 0%')
+      .max(100, 'O desconto deve ser no máximo 100%'),
+    z.null(),
+    z.undefined(),
+  ]),
+);
+
+const quantidadeVagasSchema = z.preprocess(
+  (value) => {
+    if (typeof value === 'string') {
+      const trimmed = value.trim();
+      if (trimmed.length === 0) {
+        return value;
+      }
+
+      const parsed = Number(trimmed);
+      return Number.isFinite(parsed) ? parsed : value;
+    }
+
+    return value;
+  },
+  z
+    .number({
+      required_error: 'A quantidade de vagas é obrigatória',
+      invalid_type_error: 'A quantidade de vagas deve ser um número',
+    })
+    .int('A quantidade de vagas deve ser um número inteiro')
+    .min(1, 'A quantidade de vagas deve ser no mínimo 1'),
+);
+
+const quantidadeVagasDestaqueSchema = z.preprocess(
+  (value) => {
+    if (value === undefined || value === null || value === '') {
+      return value === null ? null : undefined;
+    }
+
+    if (typeof value === 'string') {
+      const trimmed = value.trim();
+      if (trimmed.length === 0) {
+        return undefined;
+      }
+
+      const parsed = Number(trimmed);
+      return Number.isFinite(parsed) ? parsed : value;
+    }
+
+    return value;
+  },
+  z.union([
+    z
+      .number({ invalid_type_error: 'A quantidade de vagas em destaque deve ser um número' })
+      .int('A quantidade de vagas em destaque deve ser um número inteiro')
+      .min(1, 'A quantidade de vagas em destaque deve ser no mínimo 1'),
+    z.null(),
+    z.undefined(),
+  ]),
+);
+
+const planoEmpresarialSchema = z
+  .object({
+    icon: z.string().trim().min(1, 'O ícone do plano é obrigatório'),
+    nome: z.string().trim().min(1, 'O nome do plano é obrigatório'),
+    descricao: z.string().trim().min(1, 'A descrição do plano é obrigatória'),
+    valor: valorPlanoSchema,
+    desconto: percentualDescontoSchema,
+    quantidadeVagas: quantidadeVagasSchema,
+    vagaEmDestaque: z.boolean({ invalid_type_error: 'vagaEmDestaque deve ser verdadeiro ou falso' }),
+    quantidadeVagasDestaque: quantidadeVagasDestaqueSchema,
+  })
+  .strict();
+
+const validatePlanoRegras = (data: z.infer<typeof planoEmpresarialSchema>, ctx: RefinementCtx) => {
+  if (data.vagaEmDestaque) {
+    if (data.quantidadeVagasDestaque === undefined || data.quantidadeVagasDestaque === null) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['quantidadeVagasDestaque'],
+        message: 'Informe a quantidade de vagas em destaque quando vagaEmDestaque for verdadeiro',
+      });
+    } else if (data.quantidadeVagas !== undefined && data.quantidadeVagasDestaque > data.quantidadeVagas) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['quantidadeVagasDestaque'],
+        message: 'A quantidade de vagas em destaque não pode superar a quantidade total de vagas do plano',
+      });
+    }
+  } else if (data.quantidadeVagasDestaque !== undefined && data.quantidadeVagasDestaque !== null) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['quantidadeVagasDestaque'],
+      message: 'Remova a quantidade de vagas em destaque quando vagaEmDestaque for falso',
+    });
+  }
+};
+
+export const createPlanoEmpresarialSchema = planoEmpresarialSchema.superRefine(validatePlanoRegras);
+
+export const updatePlanoEmpresarialSchema = planoEmpresarialSchema
+  .partial()
+  .superRefine((data, ctx) => {
+    if (data.vagaEmDestaque === true) {
+      if (data.quantidadeVagasDestaque === undefined || data.quantidadeVagasDestaque === null) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['quantidadeVagasDestaque'],
+          message: 'Informe a quantidade de vagas em destaque quando vagaEmDestaque for verdadeiro',
+        });
+      }
+    }
+
+    if (data.vagaEmDestaque === false && data.quantidadeVagasDestaque !== undefined && data.quantidadeVagasDestaque !== null) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['quantidadeVagasDestaque'],
+        message: 'Remova a quantidade de vagas em destaque quando vagaEmDestaque for falso',
+      });
+    }
+
+    if (
+      data.quantidadeVagas !== undefined &&
+      data.quantidadeVagasDestaque !== undefined &&
+      data.quantidadeVagasDestaque !== null &&
+      data.quantidadeVagasDestaque > data.quantidadeVagas
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['quantidadeVagasDestaque'],
+        message: 'A quantidade de vagas em destaque não pode superar a quantidade total de vagas do plano',
+      });
+    }
+  });
+
+export type CreatePlanoEmpresarialInput = z.infer<typeof createPlanoEmpresarialSchema>;
+export type UpdatePlanoEmpresarialInput = z.infer<typeof updatePlanoEmpresarialSchema>;

--- a/src/modules/empresas/routes/index.ts
+++ b/src/modules/empresas/routes/index.ts
@@ -1,0 +1,11 @@
+import { Router } from 'express';
+
+import { planosEmpresariaisRoutes } from '@/modules/empresas/planos-empresarial';
+import { vagasRoutes } from '@/modules/empresas/vagas';
+
+const router = Router();
+
+router.use('/planos-empresarial', planosEmpresariaisRoutes);
+router.use('/vagas', vagasRoutes);
+
+export { router as empresasRoutes };

--- a/src/modules/empresas/vagas/controllers/vagas.controller.ts
+++ b/src/modules/empresas/vagas/controllers/vagas.controller.ts
@@ -1,0 +1,151 @@
+import { Request, Response } from 'express';
+import { ZodError } from 'zod';
+
+import { vagasService } from '@/modules/empresas/vagas/services/vagas.service';
+import { createVagaSchema, updateVagaSchema } from '@/modules/empresas/vagas/validators/vagas.schema';
+
+export class VagasController {
+  static list = async (_req: Request, res: Response) => {
+    try {
+      const vagas = await vagasService.list();
+      res.json(vagas);
+    } catch (error: any) {
+      res.status(500).json({
+        success: false,
+        code: 'VAGAS_LIST_ERROR',
+        message: 'Erro ao listar vagas',
+        error: error?.message,
+      });
+    }
+  };
+
+  static get = async (req: Request, res: Response) => {
+    try {
+      const { id } = req.params;
+      const vaga = await vagasService.get(id);
+
+      if (!vaga) {
+        return res.status(404).json({
+          success: false,
+          code: 'VAGA_NOT_FOUND',
+          message: 'Vaga não encontrada',
+        });
+      }
+
+      res.json(vaga);
+    } catch (error: any) {
+      res.status(500).json({
+        success: false,
+        code: 'VAGAS_GET_ERROR',
+        message: 'Erro ao buscar vaga',
+        error: error?.message,
+      });
+    }
+  };
+
+  static create = async (req: Request, res: Response) => {
+    try {
+      const data = createVagaSchema.parse(req.body);
+      const vaga = await vagasService.create(data);
+      res.status(201).json(vaga);
+    } catch (error: any) {
+      if (error instanceof ZodError) {
+        return res.status(400).json({
+          success: false,
+          code: 'VALIDATION_ERROR',
+          message: 'Dados inválidos para criação da vaga',
+          issues: error.flatten().fieldErrors,
+        });
+      }
+
+      if (error?.code === 'P2003') {
+        return res.status(404).json({
+          success: false,
+          code: 'EMPRESA_NOT_FOUND',
+          message: 'Empresa não encontrada para vincular à vaga',
+        });
+      }
+
+      res.status(500).json({
+        success: false,
+        code: 'VAGAS_CREATE_ERROR',
+        message: 'Erro ao criar vaga',
+        error: error?.message,
+      });
+    }
+  };
+
+  static update = async (req: Request, res: Response) => {
+    try {
+      const { id } = req.params;
+      const payload = updateVagaSchema.parse(req.body);
+
+      const hasUpdates = Object.values(payload).some((value) => value !== undefined);
+      if (!hasUpdates) {
+        return res.status(400).json({
+          success: false,
+          code: 'VALIDATION_ERROR',
+          message: 'Informe ao menos um campo para atualização da vaga',
+        });
+      }
+
+      const vaga = await vagasService.update(id, payload);
+      res.json(vaga);
+    } catch (error: any) {
+      if (error instanceof ZodError) {
+        return res.status(400).json({
+          success: false,
+          code: 'VALIDATION_ERROR',
+          message: 'Dados inválidos para atualização da vaga',
+          issues: error.flatten().fieldErrors,
+        });
+      }
+
+      if (error?.code === 'P2003') {
+        return res.status(404).json({
+          success: false,
+          code: 'EMPRESA_NOT_FOUND',
+          message: 'Empresa não encontrada para vincular à vaga',
+        });
+      }
+
+      if (error?.code === 'P2025') {
+        return res.status(404).json({
+          success: false,
+          code: 'VAGA_NOT_FOUND',
+          message: 'Vaga não encontrada',
+        });
+      }
+
+      res.status(500).json({
+        success: false,
+        code: 'VAGAS_UPDATE_ERROR',
+        message: 'Erro ao atualizar vaga',
+        error: error?.message,
+      });
+    }
+  };
+
+  static remove = async (req: Request, res: Response) => {
+    try {
+      const { id } = req.params;
+      await vagasService.remove(id);
+      res.status(204).send();
+    } catch (error: any) {
+      if (error?.code === 'P2025') {
+        return res.status(404).json({
+          success: false,
+          code: 'VAGA_NOT_FOUND',
+          message: 'Vaga não encontrada',
+        });
+      }
+
+      res.status(500).json({
+        success: false,
+        code: 'VAGAS_DELETE_ERROR',
+        message: 'Erro ao remover vaga',
+        error: error?.message,
+      });
+    }
+  };
+}

--- a/src/modules/empresas/vagas/index.ts
+++ b/src/modules/empresas/vagas/index.ts
@@ -1,0 +1,1 @@
+export { vagasRoutes } from './routes';

--- a/src/modules/empresas/vagas/routes/index.ts
+++ b/src/modules/empresas/vagas/routes/index.ts
@@ -1,0 +1,244 @@
+import { Router } from 'express';
+
+import { publicCache } from '@/middlewares/cache-control';
+import { supabaseAuthMiddleware } from '@/modules/usuarios/auth';
+import { VagasController } from '@/modules/empresas/vagas/controllers/vagas.controller';
+
+const router = Router();
+const protectedRoles = ['ADMIN', 'MODERADOR', 'EMPRESA', 'RECRUTADOR'];
+
+/**
+ * @openapi
+ * /api/v1/empresas/vagas:
+ *   get:
+ *     summary: Listar vagas publicadas
+ *     description: Retorna apenas as vagas com status PUBLICADO disponíveis para visualização pública.
+ *     tags: [Empresas - Vagas]
+ *     responses:
+ *       200:
+ *         description: Lista de vagas cadastradas
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 $ref: '#/components/schemas/Vaga'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X GET "http://localhost:3000/api/v1/empresas/vagas"
+ */
+router.get('/', publicCache, VagasController.list);
+
+/**
+ * @openapi
+ * /api/v1/empresas/vagas/{id}:
+ *   get:
+ *     summary: Obter vaga por ID
+ *     description: Recupera os detalhes de uma vaga PUBLICADA. O conteúdo é público e preserva o anonimato das empresas quando configurado.
+ *     tags: [Empresas - Vagas]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Vaga encontrada
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Vaga'
+ *       404:
+ *         description: Vaga não encontrada
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X GET "http://localhost:3000/api/v1/empresas/vagas/{id}"
+ */
+router.get('/:id', publicCache, VagasController.get);
+
+/**
+ * @openapi
+ * /api/v1/empresas/vagas:
+ *   post:
+ *     summary: Criar uma nova vaga
+ *     description: Disponível para administradores, moderadores, empresas e recrutadores autenticados. Permite cadastrar vagas vinculadas a uma empresa e envia automaticamente o registro para a fila de revisão com status EM_ANALISE.
+ *     tags: [Empresas - Vagas]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/VagaCreateInput'
+ *     responses:
+ *       201:
+ *         description: Vaga criada com sucesso
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Vaga'
+ *       400:
+ *         description: Dados inválidos
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ValidationErrorResponse'
+ *       404:
+ *         description: Empresa não encontrada para vinculação
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X POST "http://localhost:3000/api/v1/empresas/vagas" \
+ *            -H "Authorization: Bearer <TOKEN>" \
+ *            -H "Content-Type: application/json" \
+ *            -d '{
+ *                  "empresaId": "f1d7a9c2-4e0b-4f6d-90ad-8c6b84a0f1a1",
+ *                  "modoAnonimo": true,
+ *                  "regimeDeTrabalho": "CLT",
+ *                  "modalidade": "PRESENCIAL",
+ *                  "paraPcd": true,
+ *                  "requisitos": "Experiência prévia com atendimento ao cliente e pacote Office.",
+ *                  "atividades": "Atendimento ao público, abertura de chamados e acompanhamento de demandas.",
+ *                  "beneficios": "Vale transporte, vale alimentação e plano de saúde.",
+ *                  "observacoes": "Processo seletivo confidencial.",
+ *                  "cargaHoraria": "44 horas semanais (segunda a sexta)",
+ *                  "inscricoesAte": "2024-12-20T23:59:59.000Z"
+ *                }'
+ */
+router.post('/', supabaseAuthMiddleware(protectedRoles), VagasController.create);
+
+/**
+ * @openapi
+ * /api/v1/empresas/vagas/{id}:
+ *   put:
+ *     summary: Atualizar vaga
+ *     description: Permite editar os dados de uma vaga existente, incluindo o status do fluxo (RASCUNHO, EM_ANALISE, PUBLICADO ou EXPIRADO). Requer autenticação com perfil autorizado.
+ *     tags: [Empresas - Vagas]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/VagaUpdateInput'
+ *     responses:
+ *       200:
+ *         description: Vaga atualizada
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Vaga'
+ *       400:
+ *         description: Dados inválidos
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ValidationErrorResponse'
+ *       404:
+ *         description: Vaga ou empresa não encontrada
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X PUT "http://localhost:3000/api/v1/empresas/vagas/{id}" \
+ *            -H "Authorization: Bearer <TOKEN>" \
+ *            -H "Content-Type: application/json" \
+ *            -d '{
+ *                  "modoAnonimo": false,
+ *                  "beneficios": "Vale transporte, vale alimentação, plano de saúde e day-off no aniversário.",
+ *                  "observacoes": "Processo seletivo com etapas online.",
+ *                  "status": "PUBLICADO"
+ *                }'
+ */
+router.put('/:id', supabaseAuthMiddleware(protectedRoles), VagasController.update);
+
+/**
+ * @openapi
+ * /api/v1/empresas/vagas/{id}:
+ *   delete:
+ *     summary: Remover vaga
+ *     description: Exclui uma vaga cadastrada. Requer autenticação com perfil autorizado.
+ *     tags: [Empresas - Vagas]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       204:
+ *         description: Vaga removida com sucesso
+ *       404:
+ *         description: Vaga não encontrada
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X DELETE "http://localhost:3000/api/v1/empresas/vagas/{id}" \
+ *            -H "Authorization: Bearer <TOKEN>"
+ */
+router.delete('/:id', supabaseAuthMiddleware(protectedRoles), VagasController.remove);
+
+export { router as vagasRoutes };

--- a/src/modules/empresas/vagas/services/vagas.service.ts
+++ b/src/modules/empresas/vagas/services/vagas.service.ts
@@ -1,0 +1,176 @@
+import { ModalidadeVaga, Prisma, RegimeTrabalho, StatusVaga } from '@prisma/client';
+
+import { prisma } from '@/config/prisma';
+
+export type CreateVagaData = {
+  empresaId: string;
+  modoAnonimo?: boolean;
+  regimeDeTrabalho: RegimeTrabalho;
+  modalidade: ModalidadeVaga;
+  paraPcd?: boolean;
+  requisitos: string;
+  atividades: string;
+  beneficios: string;
+  observacoes?: string;
+  cargaHoraria: string;
+  inscricoesAte?: Date;
+  inseridaEm?: Date;
+  status?: StatusVaga;
+};
+
+export type UpdateVagaData = Partial<CreateVagaData> & {
+  inscricoesAte?: Date | null;
+};
+
+const ANON_DESCRIPTION =
+  'Esta empresa optou por manter suas informações confidenciais até avançar nas etapas do processo seletivo.';
+
+const includeEmpresa = { include: { empresa: true } } as const;
+
+type VagaWithEmpresa = Prisma.VagaGetPayload<typeof includeEmpresa>;
+
+const anonymizedName = (vagaId: string) => `Oportunidade Confidencial #${vagaId.slice(0, 5).toUpperCase()}`;
+
+const nullableText = (value?: string) => {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+};
+
+const sanitizeCreateData = (data: CreateVagaData): Prisma.VagaUncheckedCreateInput => ({
+  empresaId: data.empresaId,
+  modoAnonimo: data.modoAnonimo ?? false,
+  regimeDeTrabalho: data.regimeDeTrabalho,
+  modalidade: data.modalidade,
+  paraPcd: data.paraPcd ?? false,
+  requisitos: data.requisitos.trim(),
+  atividades: data.atividades.trim(),
+  beneficios: data.beneficios.trim(),
+  observacoes: nullableText(data.observacoes),
+  cargaHoraria: data.cargaHoraria.trim(),
+  inscricoesAte: data.inscricoesAte ?? null,
+  inseridaEm: data.inseridaEm ?? new Date(),
+  status: data.status ?? StatusVaga.EM_ANALISE,
+});
+
+const sanitizeUpdateData = (data: UpdateVagaData): Prisma.VagaUncheckedUpdateInput => {
+  const update: Prisma.VagaUncheckedUpdateInput = {};
+
+  if (data.empresaId !== undefined) {
+    update.empresaId = data.empresaId;
+  }
+  if (data.modoAnonimo !== undefined) {
+    update.modoAnonimo = data.modoAnonimo;
+  }
+  if (data.regimeDeTrabalho !== undefined) {
+    update.regimeDeTrabalho = data.regimeDeTrabalho;
+  }
+  if (data.modalidade !== undefined) {
+    update.modalidade = data.modalidade;
+  }
+  if (data.paraPcd !== undefined) {
+    update.paraPcd = data.paraPcd;
+  }
+  if (data.requisitos !== undefined) {
+    update.requisitos = data.requisitos.trim();
+  }
+  if (data.atividades !== undefined) {
+    update.atividades = data.atividades.trim();
+  }
+  if (data.beneficios !== undefined) {
+    update.beneficios = data.beneficios.trim();
+  }
+  if (data.observacoes !== undefined) {
+    update.observacoes = nullableText(data.observacoes);
+  }
+  if (data.cargaHoraria !== undefined) {
+    update.cargaHoraria = data.cargaHoraria.trim();
+  }
+  if (data.inscricoesAte !== undefined) {
+    update.inscricoesAte = data.inscricoesAte ?? null;
+  }
+  if (data.inseridaEm !== undefined) {
+    update.inseridaEm = data.inseridaEm;
+  }
+  if (data.status !== undefined) {
+    update.status = data.status;
+    if (data.status === StatusVaga.PUBLICADO && data.inseridaEm === undefined) {
+      update.inseridaEm = new Date();
+    }
+  }
+
+  return update;
+};
+
+const transformVaga = (vaga: VagaWithEmpresa) => {
+  if (!vaga) return null;
+
+  const displayName = vaga.modoAnonimo ? anonymizedName(vaga.id) : vaga.empresa?.nome ?? null;
+  const displayLogo = vaga.modoAnonimo ? null : vaga.empresa?.logoUrl ?? null;
+  const rawDescricao = vaga.empresa?.descricao;
+  const displayDescription = vaga.modoAnonimo
+    ? ANON_DESCRIPTION
+    : typeof rawDescricao === 'string' && rawDescricao.trim().length > 0
+      ? rawDescricao.trim()
+      : rawDescricao ?? null;
+
+  const empresa = vaga.empresa
+    ? {
+        ...vaga.empresa,
+        nome: displayName ?? vaga.empresa.nome,
+        logoUrl: vaga.modoAnonimo ? null : vaga.empresa.logoUrl,
+        descricao: displayDescription,
+      }
+    : null;
+
+  return {
+    ...vaga,
+    empresa,
+    nomeExibicao: displayName,
+    logoExibicao: displayLogo,
+    mensagemAnonimato: vaga.modoAnonimo ? ANON_DESCRIPTION : null,
+    descricaoExibicao: displayDescription,
+  };
+};
+
+export const vagasService = {
+  list: async () => {
+    const vagas = await prisma.vaga.findMany({
+      where: { status: StatusVaga.PUBLICADO },
+      ...includeEmpresa,
+      orderBy: { inseridaEm: 'desc' },
+    });
+
+    return vagas.map((vaga) => transformVaga(vaga));
+  },
+
+  get: async (id: string) => {
+    const vaga = await prisma.vaga.findFirst({
+      where: { id, status: StatusVaga.PUBLICADO },
+      ...includeEmpresa,
+    });
+
+    return vaga ? transformVaga(vaga) : null;
+  },
+
+  create: async (data: CreateVagaData) => {
+    const vaga = await prisma.vaga.create({
+      data: sanitizeCreateData(data),
+      ...includeEmpresa,
+    });
+
+    return transformVaga(vaga);
+  },
+
+  update: async (id: string, data: UpdateVagaData) => {
+    const vaga = await prisma.vaga.update({
+      where: { id },
+      data: sanitizeUpdateData(data),
+      ...includeEmpresa,
+    });
+
+    return transformVaga(vaga);
+  },
+
+  remove: (id: string) => prisma.vaga.delete({ where: { id } }),
+};

--- a/src/modules/empresas/vagas/validators/vagas.schema.ts
+++ b/src/modules/empresas/vagas/validators/vagas.schema.ts
@@ -1,0 +1,70 @@
+import { ModalidadeVaga, RegimeTrabalho, StatusVaga } from '@prisma/client';
+import { z } from 'zod';
+
+const longTextField = (field: string) =>
+  z
+    .string({ required_error: `${field} é obrigatório`, invalid_type_error: `${field} deve ser um texto` })
+    .trim()
+    .min(1, `${field} é obrigatório`)
+    .max(5000, `${field} deve ter no máximo 5000 caracteres`);
+
+const optionalLongTextField = (field: string) =>
+  z
+    .string({ invalid_type_error: `${field} deve ser um texto` })
+    .trim()
+    .max(5000, `${field} deve ter no máximo 5000 caracteres`)
+    .optional();
+
+const dateField = (field: string) =>
+  z.coerce.date({ invalid_type_error: `${field} deve ser uma data válida`, required_error: `${field} é obrigatório` });
+
+const baseVagaSchema = z.object({
+  empresaId: z
+    .string({ required_error: 'O ID da empresa é obrigatório', invalid_type_error: 'O ID da empresa deve ser uma string' })
+    .uuid('O ID da empresa deve ser um UUID válido'),
+  modoAnonimo: z.boolean({ invalid_type_error: 'modoAnonimo deve ser verdadeiro ou falso' }).optional(),
+  regimeDeTrabalho: z.nativeEnum(RegimeTrabalho, {
+    required_error: 'O regime de trabalho é obrigatório',
+    invalid_type_error: 'regimeDeTrabalho inválido',
+  }),
+  modalidade: z.nativeEnum(ModalidadeVaga, {
+    required_error: 'A modalidade da vaga é obrigatória',
+    invalid_type_error: 'modalidade inválida',
+  }),
+  paraPcd: z.boolean({ invalid_type_error: 'paraPcd deve ser verdadeiro ou falso' }).optional(),
+  requisitos: longTextField('Os requisitos da vaga'),
+  atividades: longTextField('As atividades da vaga'),
+  beneficios: longTextField('Os benefícios da vaga'),
+  observacoes: optionalLongTextField('As observações da vaga'),
+  cargaHoraria: z
+    .string({
+      required_error: 'A carga horária é obrigatória',
+      invalid_type_error: 'A carga horária deve ser um texto',
+    })
+    .trim()
+    .min(1, 'A carga horária é obrigatória')
+    .max(255, 'A carga horária deve ter no máximo 255 caracteres'),
+  inscricoesAte: dateField('A data limite de inscrições').optional(),
+  inseridaEm: dateField('A data de publicação da vaga').optional(),
+});
+
+export const createVagaSchema = baseVagaSchema;
+
+export const updateVagaSchema = baseVagaSchema.partial().extend({
+  inscricoesAte: z
+    .union([
+      dateField('A data limite de inscrições'),
+      z.null(),
+    ])
+    .optional(),
+  inseridaEm: dateField('A data de publicação da vaga').optional(),
+  status: z
+    .nativeEnum(StatusVaga, {
+      invalid_type_error: 'status inválido',
+      required_error: 'O status da vaga é obrigatório',
+    })
+    .optional(),
+});
+
+export type CreateVagaInput = z.infer<typeof createVagaSchema>;
+export type UpdateVagaInput = z.infer<typeof updateVagaSchema>;

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -7,6 +7,7 @@ import { brevoRoutes } from '@/modules/brevo/routes';
 import { EmailVerificationController } from '@/modules/brevo/controllers/email-verification-controller';
 import { usuarioRoutes } from '@/modules/usuarios';
 import { websiteRoutes } from '@/modules/website';
+import { empresasRoutes } from '@/modules/empresas';
 import { setCacheHeaders, DEFAULT_TTL } from '@/utils/cache';
 import { logger } from '@/utils/logger';
 
@@ -73,6 +74,9 @@ router.get('/', publicCache, (req, res) => {
       usuarios: '/api/v1/usuarios',
       brevo: '/api/v1/brevo',
       website: '/api/v1/website',
+      empresas: '/api/v1/empresas',
+      planosEmpresariais: '/api/v1/empresas/planos-empresarial',
+      vagasEmpresariais: '/api/v1/empresas/vagas',
       health: '/health',
     },
   };
@@ -110,6 +114,9 @@ router.get('/', publicCache, (req, res) => {
         <li>👥 Usuários: <code>${data.endpoints.usuarios}</code></li>
         <li>📧 Brevo: <code>${data.endpoints.brevo}</code></li>
         <li>🌐 Website: <code>${data.endpoints.website}</code></li>
+        <li>🏢 Empresas: <code>${data.endpoints.empresas}</code></li>
+        <li>📦 Planos empresariais: <code>${data.endpoints.planosEmpresariais}</code></li>
+        <li>💼 Vagas empresariais: <code>${data.endpoints.vagasEmpresariais}</code></li>
         <li>💚 Health: <code>${data.endpoints.health}</code></li>
       </ul>
       <footer>
@@ -175,6 +182,7 @@ router.get('/health', publicCache, async (req, res) => {
       usuarios: '✅ active',
       brevo: '✅ active',
       website: '✅ active',
+      empresas: '✅ active',
       redis: redisStatus,
     },
   };
@@ -237,6 +245,21 @@ if (websiteRoutes) {
   }
 } else {
   routesLogger.error({ feature: 'WebsiteModule' }, '❌ websiteRoutes não está definido');
+}
+
+/**
+ * Módulo Empresas - COM VALIDAÇÃO
+ * /api/v1/empresas/*
+ */
+if (empresasRoutes) {
+  try {
+    router.use('/api/v1/empresas', empresasRoutes);
+    routesLogger.info({ feature: 'EmpresasModule' }, '✅ Módulo Empresas registrado com sucesso');
+  } catch (error) {
+    routesLogger.error({ feature: 'EmpresasModule', err: error }, '❌ ERRO - Módulo Empresas');
+  }
+} else {
+  routesLogger.error({ feature: 'EmpresasModule' }, '❌ empresasRoutes não está definido');
 }
 
 /**


### PR DESCRIPTION
## Summary
- extend the Prisma models with StatusVaga and new PlanoEmpresarial rules for discounts, quotas and highlights
- harden PlanoEmpresarial validation/service logic to enforce the new constraints and update OpenAPI docs
- add vacancy status handling with public listing restrictions plus swagger/redoc updates describing the workflow

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68c98d7214948332a81ff70d48ba630f