### PR TITLE
Allow vagas update to accept null deadline

### DIFF
--- a/src/modules/empresas/vagas/services/vagas.service.ts
+++ b/src/modules/empresas/vagas/services/vagas.service.ts
@@ -18,7 +18,7 @@ export type CreateVagaData = {
   status?: StatusVaga;
 };
 
-export type UpdateVagaData = Partial<CreateVagaData> & {
+export type UpdateVagaData = Omit<Partial<CreateVagaData>, 'inscricoesAte'> & {
   inscricoesAte?: Date | null;
 };
 


### PR DESCRIPTION
## Summary
- update `UpdateVagaData` to omit the inherited `inscricoesAte` type
- allow passing `null` for the deadline when updating vagas

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68c9aa1ca6f083328884a0b73527cd0b