### PR TITLE
Fix plano parceiro update relation mapping

### DIFF
--- a/src/modules/empresas/planos-parceiro/services/planos-parceiro.service.ts
+++ b/src/modules/empresas/planos-parceiro/services/planos-parceiro.service.ts
@@ -178,7 +178,7 @@ export const planosParceiroService = {
     const updates: Prisma.EmpresaPlanoUpdateInput = {};
 
     if (data.planoEmpresarialId !== undefined) {
-      updates.planoEmpresarialId = data.planoEmpresarialId;
+      updates.plano = { connect: { id: data.planoEmpresarialId } };
     }
 
     let inicio = planoAtual.inicio;
@@ -191,13 +191,10 @@ export const planosParceiroService = {
     if (data.tipo !== undefined) {
       tipo = mapTipoToPrisma(data.tipo);
       updates.tipo = tipo;
-      if (updates.inicio === undefined) {
-        updates.inicio = inicio;
-      }
     }
 
     if (data.tipo !== undefined || data.iniciarEm !== undefined) {
-      updates.fim = calcularDataFim(tipo, updates.inicio ? (updates.inicio as Date) : inicio);
+      updates.fim = calcularDataFim(tipo, inicio);
     }
 
     if (data.observacao !== undefined) {


### PR DESCRIPTION
## Summary
- update plano parceiro service to connect plano empresarial relations when updating
- simplify fim recalculation to use the computed inicio value

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68c9b6ccde7c8332b8e5c69975ababd0