### PR TITLE
Adjust Mercado Pago PIX checkout payment methods

### DIFF
--- a/src/modules/mercadopago/assinaturas/services/assinaturas.service.ts
+++ b/src/modules/mercadopago/assinaturas/services/assinaturas.service.ts
@@ -250,13 +250,22 @@ export const assinaturasService = {
       } else {
         // Checkout Pro (PIX/BOLETO ou cartão via preference) - recorrência assistida
         const preference = new Preference(mp);
-        const payment_methods = ((): any => {
-          const excludeCards = { excluded_payment_types: [{ id: 'credit_card' }, { id: 'debit_card' }] };
+        const payment_methods = ((): Record<string, unknown> | undefined => {
+          const excludedPaymentTypesBase = [{ id: 'credit_card' }, { id: 'debit_card' }];
           if (params.metodoPagamento === METODO_PAGAMENTO.PIX) {
-            return { ...excludeCards, excluded_payment_types: [...excludeCards.excluded_payment_types, { id: 'ticket' }] , default_payment_method_id: 'pix' };
+            return {
+              excluded_payment_types: [...excludedPaymentTypesBase, { id: 'ticket' }],
+              default_payment_type_id: 'bank_transfer',
+            };
           }
           if (params.metodoPagamento === METODO_PAGAMENTO.BOLETO) {
-            return { ...excludeCards, default_payment_type_id: 'ticket' } as any;
+            return {
+              excluded_payment_types: [...excludedPaymentTypesBase, { id: 'bank_transfer' }],
+              default_payment_type_id: 'ticket',
+            };
+          }
+          if (excludedPaymentTypesBase.length) {
+            return { excluded_payment_types: excludedPaymentTypesBase };
           }
           return undefined;
         })();


### PR DESCRIPTION
## Summary
- avoid setting PIX as default payment method when creating Mercado Pago preferences to prevent the 400 invalid default error
- tune excluded payment types per method so PIX forces bank transfer and boleto keeps ticket defaults while still filtering cards

## Testing
- pnpm lint


------
https://chatgpt.com/codex/tasks/task_e_68ca354f69c88325ac0a64dd81ab0b1e