### PR TITLE
Ensure Mercado Pago checkout has valid return URLs

### DIFF
--- a/src/modules/mercadopago/assinaturas/services/__tests__/extract-init-point.test.ts
+++ b/src/modules/mercadopago/assinaturas/services/__tests__/extract-init-point.test.ts
@@ -1,0 +1,35 @@
+import { extractInitPoint } from '@/modules/mercadopago/assinaturas/services/assinaturas.service';
+
+describe('extractInitPoint', () => {
+  it('prioritizes production init_point from body over sandbox url', () => {
+    const result = {
+      body: {
+        init_point: 'https://prod.example.com',
+        sandbox_init_point: 'https://sandbox.example.com',
+      },
+    } as any;
+
+    expect(extractInitPoint(result)).toBe('https://prod.example.com');
+  });
+
+  it('falls back to camelCase initPoint before sandbox urls', () => {
+    const result = {
+      body: {
+        initPoint: 'https://prod-camel.example.com',
+        sandbox_init_point: 'https://sandbox.example.com',
+      },
+    } as any;
+
+    expect(extractInitPoint(result)).toBe('https://prod-camel.example.com');
+  });
+
+  it('returns sandbox init point when production urls are missing', () => {
+    const result = {
+      body: {
+        sandbox_init_point: 'https://sandbox.example.com',
+      },
+    } as any;
+
+    expect(extractInitPoint(result)).toBe('https://sandbox.example.com');
+  });
+});

--- a/src/modules/mercadopago/assinaturas/services/__tests__/resolve-return-urls.test.ts
+++ b/src/modules/mercadopago/assinaturas/services/__tests__/resolve-return-urls.test.ts
@@ -1,0 +1,61 @@
+import { resolveCheckoutReturnUrls } from '@/modules/mercadopago/assinaturas/services/assinaturas.service';
+import { mercadopagoConfig, serverConfig } from '@/config/env';
+
+describe('resolveCheckoutReturnUrls', () => {
+  const originalReturnUrls = {
+    success: mercadopagoConfig.returnUrls.success,
+    failure: mercadopagoConfig.returnUrls.failure,
+    pending: mercadopagoConfig.returnUrls.pending,
+  };
+  const originalFrontendUrl = serverConfig.frontendUrl;
+
+  afterEach(() => {
+    (mercadopagoConfig.returnUrls as any).success = originalReturnUrls.success;
+    (mercadopagoConfig.returnUrls as any).failure = originalReturnUrls.failure;
+    (mercadopagoConfig.returnUrls as any).pending = originalReturnUrls.pending;
+    (serverConfig as any).frontendUrl = originalFrontendUrl;
+  });
+
+  it('prefers explicit checkout URLs when provided', () => {
+    const urls = resolveCheckoutReturnUrls({
+      successUrl: 'https://app.example.com/success',
+      failureUrl: 'https://app.example.com/failure',
+      pendingUrl: 'https://app.example.com/pending',
+    });
+
+    expect(urls).toEqual({
+      success: 'https://app.example.com/success',
+      failure: 'https://app.example.com/failure',
+      pending: 'https://app.example.com/pending',
+    });
+  });
+
+  it('falls back to configured Mercado Pago return URLs', () => {
+    (mercadopagoConfig.returnUrls as any).success = 'https://config.example.com/success';
+    (mercadopagoConfig.returnUrls as any).failure = 'https://config.example.com/failure';
+    (mercadopagoConfig.returnUrls as any).pending = 'https://config.example.com/pending';
+
+    const urls = resolveCheckoutReturnUrls();
+
+    expect(urls).toEqual({
+      success: 'https://config.example.com/success',
+      failure: 'https://config.example.com/failure',
+      pending: 'https://config.example.com/pending',
+    });
+  });
+
+  it('uses the frontend URL as a final fallback when configuration is missing', () => {
+    (mercadopagoConfig.returnUrls as any).success = '';
+    (mercadopagoConfig.returnUrls as any).failure = '  ';
+    (mercadopagoConfig.returnUrls as any).pending = null;
+    (serverConfig as any).frontendUrl = 'https://app.advancemais.com';
+
+    const urls = resolveCheckoutReturnUrls();
+
+    expect(urls).toEqual({
+      success: 'https://app.advancemais.com',
+      failure: 'https://app.advancemais.com',
+      pending: 'https://app.advancemais.com',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a resolver that guarantees Mercado Pago return URLs always yield a usable value
- use the resolver in checkout/preapproval and reminder flows so back_url/back_urls are never empty
- cover the resolver with unit tests, including fallback behavior when configuration is missing

## Testing
- pnpm test -- resolve-return-urls extract-init-point

------
https://chatgpt.com/codex/tasks/task_e_68ca3b0804548325a1d92cc84631f8e0