### PR TITLE
Remove CodigoUsuario table usage

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -51,8 +51,7 @@ model Usuario {
   ultimaTentativaVerificacao DateTime?
 
   // RELACIONAMENTOS EXISTENTES
-  enderecos       Endereco[]
-  codigoUsuario   CodigoUsuario?
+  enderecos         Endereco[]
   vagasCriadas      Vaga[]         @relation("UsuarioVagas")
   planosContratados EmpresaPlano[] @relation("UsuarioPlanos")
 
@@ -120,29 +119,29 @@ model Vaga {
 }
 
 model EmpresaPlano {
-  id                 String          @id @default(uuid())
+  id                 String        @id @default(uuid())
   usuarioId          String
   planoEmpresarialId String
   tipo               PlanoParceiro
   inicio             DateTime?
   fim                DateTime?
-  ativo              Boolean         @default(false)
-  observacao         String?         @db.Text
-  criadoEm           DateTime        @default(now())
-  atualizadoEm       DateTime        @updatedAt
+  ativo              Boolean       @default(false)
+  observacao         String?       @db.Text
+  criadoEm           DateTime      @default(now())
+  atualizadoEm       DateTime      @updatedAt
 
   // Integração de pagamentos/assinaturas (Mercado Pago)
-  modeloPagamento   MODELO_PAGAMENTO?
-  metodoPagamento   METODO_PAGAMENTO?
-  statusPagamento   STATUS_PAGAMENTO? @default(PENDENTE)
-  mpPreapprovalId   String?           @unique
-  mpSubscriptionId  String?           @unique
-  mpPayerId         String?
-  mpPaymentId       String?
-  proximaCobranca   DateTime?
-  graceUntil        DateTime?
+  modeloPagamento  MODELO_PAGAMENTO?
+  metodoPagamento  METODO_PAGAMENTO?
+  statusPagamento  STATUS_PAGAMENTO? @default(PENDENTE)
+  mpPreapprovalId  String?           @unique
+  mpSubscriptionId String?           @unique
+  mpPayerId        String?
+  mpPaymentId      String?
+  proximaCobranca  DateTime?
+  graceUntil       DateTime?
 
-  empresa Usuario        @relation("UsuarioPlanos", fields: [usuarioId], references: [id], onDelete: Cascade)
+  empresa Usuario          @relation("UsuarioPlanos", fields: [usuarioId], references: [id], onDelete: Cascade)
   plano   PlanoEmpresarial @relation(fields: [planoEmpresarialId], references: [id])
 
   @@index([usuarioId, ativo])
@@ -168,17 +167,17 @@ model LogPagamento {
 }
 
 model PlanoEmpresarial {
-  id                       String   @id @default(uuid())
-  icon                     String
-  nome                     String
-  descricao                String
-  valor                    String
-  desconto                 Float?
-  quantidadeVagas          Int
-  vagaEmDestaque           Boolean  @default(false)
-  quantidadeVagasDestaque  Int?
-  criadoEm                 DateTime @default(now())
-  atualizadoEm             DateTime @updatedAt
+  id                      String   @id @default(uuid())
+  icon                    String
+  nome                    String
+  descricao               String
+  valor                   String
+  desconto                Float?
+  quantidadeVagas         Int
+  vagaEmDestaque          Boolean  @default(false)
+  quantidadeVagasDestaque Int?
+  criadoEm                DateTime @default(now())
+  atualizadoEm            DateTime @updatedAt
 
   empresas EmpresaPlano[]
 
@@ -234,17 +233,6 @@ model LogSMS {
   @@index([telefone])
   @@index([tipoSMS])
   @@index([criadoEm])
-}
-
-model CodigoUsuario {
-  codigo    Int        @id @default(autoincrement())
-  usuarioId String     @unique
-  tipo      CodigoTipo @default(USUARIO)
-  criadoEm  DateTime   @default(now())
-
-  usuario Usuario @relation(fields: [usuarioId], references: [id])
-
-  @@map("codigo_usuario")
 }
 
 model WebsiteSobre {
@@ -655,11 +643,6 @@ enum StatusSMS {
   ENVIADO
   FALHA
   PENDENTE
-}
-
-enum CodigoTipo {
-  USUARIO
-  EMPRESA
 }
 
 // Métodos de pagamento aceitos para planos

--- a/src/modules/usuarios/register/register-controller.ts
+++ b/src/modules/usuarios/register/register-controller.ts
@@ -3,15 +3,11 @@ import bcrypt from 'bcrypt';
 import { prisma } from '../../../config/prisma';
 import { invalidateCacheByPrefix } from '../../../utils/cache';
 import { invalidateUserCache } from '../utils/cache';
-import { Prisma, CodigoTipo } from '@prisma/client';
+import { Prisma } from '@prisma/client';
 import { TipoUsuario, Role } from '../enums';
 import {
   validarCPF,
   validarCNPJ,
-  validarEmail,
-  validarSenha,
-  validarConfirmacaoSenha,
-  validarTelefone,
   validarDataNascimento,
   validarGenero,
   limparDocumento,
@@ -212,7 +208,7 @@ export const criarUsuario = async (req: Request, res: Response, next: NextFuncti
         role: usuario.role,
         status: usuario.status,
         criadoEm: usuario.criadoEm,
-        codigoUsuario: usuario.codigoUsuario,
+        codUsuario: usuario.codUsuario,
       },
       // Metadados para debugging
       correlationId,
@@ -244,7 +240,7 @@ export const criarUsuario = async (req: Request, res: Response, next: NextFuncti
         role: usuario.role,
         status: usuario.status,
         criadoEm: usuario.criadoEm,
-        codigoUsuario: usuario.codigoUsuario,
+        codUsuario: usuario.codUsuario,
       },
       correlationId,
       duration: `${duration}ms`,
@@ -564,17 +560,7 @@ async function createUserWithTransaction(userData: any, correlationId: string) {
 
       log.info({ userId: usuario.id }, '✅ Usuário inserido com sucesso');
 
-      const codigo = await tx.codigoUsuario.create({
-        data: {
-          usuarioId: usuario.id,
-          tipo:
-            userData.tipoUsuario === TipoUsuario.PESSOA_JURIDICA
-              ? CodigoTipo.EMPRESA
-              : CodigoTipo.USUARIO,
-        },
-      });
-
-      return { ...usuario, codigoUsuario: codigo.codigo };
+      return usuario;
     });
   } catch (error) {
     const err = error instanceof Error ? error : new Error(String(error));


### PR DESCRIPTION
## Summary
- drop the CodigoUsuario relation and enum from the Prisma schema now that the user code lives on Usuario
- update user registration to rely on the codUsuario field directly and tidy unused validation imports

## Testing
- pnpm exec prisma format
- pnpm prisma:generate
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68cac80dfc68832584c966ebf6fc90d8