### PR TITLE
feat: add admin endpoints to list company plans

### DIFF
--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -114,6 +114,10 @@ const options: Options = {
         name: 'Empresas - Vagas',
         description: 'Administração de vagas corporativas vinculadas às empresas',
       },
+      {
+        name: 'Empresas - Admin',
+        description: 'Gestão administrativa das empresas e seus planos ativos',
+      },
       { name: 'MercadoPago - Assinaturas', description: 'Assinaturas e cobranças recorrentes (Mercado Pago)' },
     ],
     'x-tagGroups': [
@@ -151,7 +155,12 @@ const options: Options = {
       },
       {
         name: 'Empresas',
-        tags: ['Empresas - Planos Empresariais', 'Empresas - Clientes', 'Empresas - Vagas'],
+        tags: [
+          'Empresas - Planos Empresariais',
+          'Empresas - Clientes',
+          'Empresas - Vagas',
+          'Empresas - Admin',
+        ],
       },
       { name: 'Pagamentos', tags: ['MercadoPago - Assinaturas'] },
     ],
@@ -3240,6 +3249,136 @@ const options: Options = {
           description: 'Etapas do fluxo de publicação da vaga',
           enum: ['RASCUNHO', 'EM_ANALISE', 'PUBLICADO', 'EXPIRADO'],
           example: 'EM_ANALISE',
+        },
+        PaginationMeta: {
+          type: 'object',
+          properties: {
+            page: { type: 'integer', example: 1 },
+            pageSize: { type: 'integer', example: 20 },
+            total: { type: 'integer', example: 120 },
+            totalPages: { type: 'integer', example: 6 },
+          },
+        },
+        AdminEmpresaPlanoResumo: {
+          type: 'object',
+          description: 'Resumo do plano ativo vinculado à empresa',
+          properties: {
+            id: { type: 'string', format: 'uuid', example: 'plano-uuid' },
+            nome: { type: 'string', nullable: true, example: 'Plano Avançado' },
+            tipo: {
+              type: 'string',
+              enum: ['7_dias', '15_dias', '30_dias', '60_dias', '90dias', '120_dias', 'assinatura_mensal', 'parceiro'],
+              example: 'parceiro',
+            },
+            inicio: { type: 'string', format: 'date-time', nullable: true, example: '2024-01-10T12:00:00Z' },
+            fim: { type: 'string', format: 'date-time', nullable: true, example: '2024-02-10T12:00:00Z' },
+            modeloPagamento: {
+              allOf: [{ $ref: '#/components/schemas/ModeloPagamento' }],
+              nullable: true,
+            },
+            metodoPagamento: {
+              allOf: [{ $ref: '#/components/schemas/MetodoPagamento' }],
+              nullable: true,
+            },
+            statusPagamento: {
+              allOf: [{ $ref: '#/components/schemas/StatusPagamento' }],
+              nullable: true,
+            },
+            quantidadeVagas: { type: 'integer', nullable: true, example: 3 },
+          },
+        },
+        AdminEmpresaListItem: {
+          type: 'object',
+          description: 'Dados resumidos da empresa para listagem administrativa',
+          properties: {
+            id: { type: 'string', format: 'uuid', example: 'empresa-uuid' },
+            codUsuario: { type: 'string', example: 'EMP-123456' },
+            nome: { type: 'string', example: 'Advance Tech Consultoria' },
+            avatarUrl: { type: 'string', nullable: true, example: 'https://cdn.advance.com.br/logo.png' },
+            cidade: { type: 'string', nullable: true, example: 'São Paulo' },
+            estado: { type: 'string', nullable: true, example: 'SP' },
+            criadoEm: { type: 'string', format: 'date-time', example: '2024-01-05T12:00:00Z' },
+            parceira: { type: 'boolean', example: true },
+            diasTesteDisponibilizados: { type: 'integer', nullable: true, example: 30 },
+            plano: {
+              allOf: [{ $ref: '#/components/schemas/AdminEmpresaPlanoResumo' }],
+              nullable: true,
+            },
+          },
+        },
+        AdminEmpresasListResponse: {
+          type: 'object',
+          properties: {
+            data: {
+              type: 'array',
+              items: { $ref: '#/components/schemas/AdminEmpresaListItem' },
+            },
+            pagination: {
+              allOf: [{ $ref: '#/components/schemas/PaginationMeta' }],
+            },
+          },
+        },
+        AdminEmpresaDetail: {
+          type: 'object',
+          description: 'Informações detalhadas da empresa para o painel administrativo',
+          properties: {
+            id: { type: 'string', format: 'uuid', example: 'empresa-uuid' },
+            codUsuario: { type: 'string', example: 'EMP-123456' },
+            nome: { type: 'string', example: 'Advance Tech Consultoria' },
+            avatarUrl: { type: 'string', nullable: true, example: 'https://cdn.advance.com.br/logo.png' },
+            descricao: {
+              type: 'string',
+              nullable: true,
+              example: 'Consultoria especializada em recrutamento e seleção para empresas de tecnologia.',
+            },
+            instagram: { type: 'string', nullable: true, example: 'https://instagram.com/advancemais' },
+            linkedin: { type: 'string', nullable: true, example: 'https://linkedin.com/company/advancemais' },
+            cidade: { type: 'string', nullable: true, example: 'São Paulo' },
+            estado: { type: 'string', nullable: true, example: 'SP' },
+            criadoEm: { type: 'string', format: 'date-time', example: '2023-11-01T08:30:00Z' },
+            parceira: { type: 'boolean', example: true },
+            diasTesteDisponibilizados: { type: 'integer', nullable: true, example: 30 },
+            plano: {
+              allOf: [{ $ref: '#/components/schemas/AdminEmpresaPlanoResumo' }],
+              nullable: true,
+            },
+            vagas: {
+              type: 'object',
+              properties: {
+                publicadas: { type: 'integer', example: 1 },
+                limitePlano: { type: 'integer', nullable: true, example: 3 },
+              },
+            },
+            pagamento: {
+              type: 'object',
+              properties: {
+                modelo: {
+                  allOf: [{ $ref: '#/components/schemas/ModeloPagamento' }],
+                  nullable: true,
+                },
+                metodo: {
+                  allOf: [{ $ref: '#/components/schemas/MetodoPagamento' }],
+                  nullable: true,
+                },
+                status: {
+                  allOf: [{ $ref: '#/components/schemas/StatusPagamento' }],
+                  nullable: true,
+                },
+                ultimoPagamentoEm: {
+                  type: 'string',
+                  format: 'date-time',
+                  nullable: true,
+                  example: '2024-01-15T14:20:00Z',
+                },
+              },
+            },
+          },
+        },
+        AdminEmpresaDetailResponse: {
+          type: 'object',
+          properties: {
+            empresa: { $ref: '#/components/schemas/AdminEmpresaDetail' },
+          },
         },
         EmpresaResumo: {
           type: 'object',

--- a/src/modules/empresas/admin/controllers/admin-empresas.controller.ts
+++ b/src/modules/empresas/admin/controllers/admin-empresas.controller.ts
@@ -1,0 +1,67 @@
+import { Request, Response } from 'express';
+import { ZodError } from 'zod';
+
+import { adminEmpresasService } from '@/modules/empresas/admin/services/admin-empresas.service';
+import {
+  adminEmpresasIdParamSchema,
+  adminEmpresasListQuerySchema,
+} from '@/modules/empresas/admin/validators/admin-empresas.schema';
+
+export class AdminEmpresasController {
+  static list = async (req: Request, res: Response) => {
+    try {
+      const filters = adminEmpresasListQuerySchema.parse(req.query);
+      const result = await adminEmpresasService.list(filters);
+      res.json(result);
+    } catch (error: any) {
+      if (error instanceof ZodError) {
+        return res.status(400).json({
+          success: false,
+          code: 'VALIDATION_ERROR',
+          message: 'Parâmetros de busca inválidos',
+          issues: error.flatten().fieldErrors,
+        });
+      }
+
+      res.status(500).json({
+        success: false,
+        code: 'ADMIN_EMPRESAS_LIST_ERROR',
+        message: 'Erro ao listar empresas',
+        error: error?.message,
+      });
+    }
+  };
+
+  static get = async (req: Request, res: Response) => {
+    try {
+      const params = adminEmpresasIdParamSchema.parse(req.params);
+      const empresa = await adminEmpresasService.get(params.id);
+
+      if (!empresa) {
+        return res.status(404).json({
+          success: false,
+          code: 'EMPRESA_NOT_FOUND',
+          message: 'Empresa não encontrada',
+        });
+      }
+
+      res.json({ empresa });
+    } catch (error: any) {
+      if (error instanceof ZodError) {
+        return res.status(400).json({
+          success: false,
+          code: 'VALIDATION_ERROR',
+          message: 'Parâmetros inválidos',
+          issues: error.flatten().fieldErrors,
+        });
+      }
+
+      res.status(500).json({
+        success: false,
+        code: 'ADMIN_EMPRESAS_GET_ERROR',
+        message: 'Erro ao consultar a empresa',
+        error: error?.message,
+      });
+    }
+  };
+}

--- a/src/modules/empresas/admin/index.ts
+++ b/src/modules/empresas/admin/index.ts
@@ -1,0 +1,1 @@
+export { adminEmpresasRoutes } from './routes';

--- a/src/modules/empresas/admin/routes/index.ts
+++ b/src/modules/empresas/admin/routes/index.ts
@@ -1,0 +1,117 @@
+import { Router } from 'express';
+
+import { supabaseAuthMiddleware } from '@/modules/usuarios/auth';
+import { AdminEmpresasController } from '@/modules/empresas/admin/controllers/admin-empresas.controller';
+
+const router = Router();
+const adminRoles = ['ADMIN', 'MODERADOR'];
+
+/**
+ * @openapi
+ * /api/v1/empresas/admin:
+ *   get:
+ *     summary: (Admin) Listar empresas
+ *     description: "Retorna empresas (Pessoa Jurídica) com dados resumidos do plano ativo. Endpoint restrito aos perfis ADMIN e MODERADOR."
+ *     tags: [Empresas - Admin]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: page
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *           default: 1
+ *         description: Página atual da paginação
+ *       - in: query
+ *         name: pageSize
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *           maximum: 100
+ *           default: 20
+ *         description: Quantidade de registros por página
+ *       - in: query
+ *         name: search
+ *         schema:
+ *           type: string
+ *         description: "Filtro por nome, código da empresa, e-mail ou CNPJ"
+ *     responses:
+ *       200:
+ *         description: Empresas listadas com sucesso
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/AdminEmpresasListResponse'
+ *       400:
+ *         description: Parâmetros inválidos
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ValidationErrorResponse'
+ *       401:
+ *         description: Token inválido ou ausente
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ */
+router.get('/', supabaseAuthMiddleware(adminRoles), AdminEmpresasController.list);
+
+/**
+ * @openapi
+ * /api/v1/empresas/admin/{id}:
+ *   get:
+ *     summary: (Admin) Detalhes completos da empresa
+ *     description: "Retorna informações completas da empresa incluindo plano ativo, pagamentos e métricas. Endpoint restrito aos perfis ADMIN e MODERADOR."
+ *     tags: [Empresas - Admin]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *     responses:
+ *       200:
+ *         description: Empresa encontrada
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/AdminEmpresaDetailResponse'
+ *       400:
+ *         description: Parâmetros inválidos
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ValidationErrorResponse'
+ *       401:
+ *         description: Token inválido ou ausente
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       404:
+ *         description: Empresa não encontrada
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ */
+router.get('/:id', supabaseAuthMiddleware(adminRoles), AdminEmpresasController.get);
+
+export { router as adminEmpresasRoutes };

--- a/src/modules/empresas/admin/services/admin-empresas.service.ts
+++ b/src/modules/empresas/admin/services/admin-empresas.service.ts
@@ -1,0 +1,259 @@
+import {
+  METODO_PAGAMENTO,
+  MODELO_PAGAMENTO,
+  STATUS_PAGAMENTO,
+  Prisma,
+  StatusVaga,
+  TipoUsuario,
+} from '@prisma/client';
+
+import { prisma } from '@/config/prisma';
+import {
+  getPlanoParceiroDuracao,
+  isPlanoParceiroElegivel,
+  mapPlanoParceiroToClienteTipo,
+} from '@/modules/empresas/shared/plano-parceiro';
+import type { AdminEmpresasListQuery } from '@/modules/empresas/admin/validators/admin-empresas.schema';
+
+const planoAtivoSelect = {
+  where: { ativo: true },
+  orderBy: [{ inicio: 'desc' as const }, { criadoEm: 'desc' as const }],
+  take: 1,
+  select: {
+    id: true,
+    tipo: true,
+    inicio: true,
+    fim: true,
+    criadoEm: true,
+    atualizadoEm: true,
+    modeloPagamento: true,
+    metodoPagamento: true,
+    statusPagamento: true,
+    plano: {
+      select: {
+        id: true,
+        nome: true,
+        quantidadeVagas: true,
+      },
+    },
+  },
+} as const;
+
+const usuarioListSelect = {
+  id: true,
+  codUsuario: true,
+  nomeCompleto: true,
+  avatarUrl: true,
+  cidade: true,
+  estado: true,
+  criadoEm: true,
+  planosContratados: planoAtivoSelect,
+} as const;
+
+const usuarioDetailSelect = {
+  id: true,
+  codUsuario: true,
+  nomeCompleto: true,
+  avatarUrl: true,
+  descricao: true,
+  instagram: true,
+  linkedin: true,
+  cidade: true,
+  estado: true,
+  criadoEm: true,
+  tipoUsuario: true,
+  planosContratados: planoAtivoSelect,
+  _count: {
+    select: {
+      vagasCriadas: {
+        where: {
+          status: StatusVaga.PUBLICADO,
+        },
+      },
+    },
+  },
+} as const;
+
+type UsuarioListResult = Prisma.UsuarioGetPayload<{ select: typeof usuarioListSelect }>;
+type PlanoResumoData = UsuarioListResult['planosContratados'][number];
+
+type AdminEmpresaPlanoResumo = {
+  id: string;
+  nome: string | null;
+  tipo: string;
+  inicio: Date | null;
+  fim: Date | null;
+  modeloPagamento: MODELO_PAGAMENTO | null;
+  metodoPagamento: METODO_PAGAMENTO | null;
+  statusPagamento: STATUS_PAGAMENTO | null;
+  quantidadeVagas: number | null;
+};
+
+type AdminEmpresaListItem = {
+  id: string;
+  codUsuario: string;
+  nome: string;
+  avatarUrl: string | null;
+  cidade: string | null;
+  estado: string | null;
+  criadoEm: Date;
+  parceira: boolean;
+  diasTesteDisponibilizados: number | null;
+  plano: AdminEmpresaPlanoResumo | null;
+};
+
+type AdminEmpresaDetail = {
+  id: string;
+  codUsuario: string;
+  nome: string;
+  avatarUrl: string | null;
+  descricao: string | null;
+  instagram: string | null;
+  linkedin: string | null;
+  cidade: string | null;
+  estado: string | null;
+  criadoEm: Date;
+  parceira: boolean;
+  diasTesteDisponibilizados: number | null;
+  plano: AdminEmpresaPlanoResumo | null;
+  vagas: {
+    publicadas: number;
+    limitePlano: number | null;
+  };
+  pagamento: {
+    modelo: MODELO_PAGAMENTO | null;
+    metodo: METODO_PAGAMENTO | null;
+    status: STATUS_PAGAMENTO | null;
+    ultimoPagamentoEm: Date | null;
+  };
+};
+
+const buildSearchFilter = (search?: string): Prisma.UsuarioWhereInput => {
+  if (!search) {
+    return {};
+  }
+
+  return {
+    OR: [
+      { nomeCompleto: { contains: search, mode: 'insensitive' } },
+      { codUsuario: { contains: search, mode: 'insensitive' } },
+      { email: { contains: search, mode: 'insensitive' } },
+      { cnpj: { contains: search, mode: 'insensitive' } },
+    ],
+  };
+};
+
+const mapPlanoResumo = (plano?: PlanoResumoData): AdminEmpresaPlanoResumo | null => {
+  if (!plano) {
+    return null;
+  }
+
+  return {
+    id: plano.id,
+    nome: plano.plano?.nome ?? null,
+    tipo: mapPlanoParceiroToClienteTipo(plano.tipo),
+    inicio: plano.inicio,
+    fim: plano.fim,
+    modeloPagamento: plano.modeloPagamento ?? null,
+    metodoPagamento: plano.metodoPagamento ?? null,
+    statusPagamento: plano.statusPagamento ?? null,
+    quantidadeVagas: plano.plano?.quantidadeVagas ?? null,
+  };
+};
+
+export const adminEmpresasService = {
+  list: async ({ page, pageSize, search }: AdminEmpresasListQuery) => {
+    const where: Prisma.UsuarioWhereInput = {
+      tipoUsuario: TipoUsuario.PESSOA_JURIDICA,
+      ...buildSearchFilter(search),
+    };
+
+    const skip = (page - 1) * pageSize;
+
+    const [total, empresas] = await prisma.$transaction([
+      prisma.usuario.count({ where }),
+      prisma.usuario.findMany({
+        where,
+        orderBy: { criadoEm: 'desc' },
+        skip,
+        take: pageSize,
+        select: usuarioListSelect,
+      }),
+    ]);
+
+    const data: AdminEmpresaListItem[] = empresas.map((empresa) => {
+      const planoAtual = empresa.planosContratados[0];
+      const plano = mapPlanoResumo(planoAtual);
+      const diasTeste = planoAtual ? getPlanoParceiroDuracao(planoAtual.tipo) : null;
+
+      return {
+        id: empresa.id,
+        codUsuario: empresa.codUsuario,
+        nome: empresa.nomeCompleto,
+        avatarUrl: empresa.avatarUrl,
+        cidade: empresa.cidade,
+        estado: empresa.estado,
+        criadoEm: empresa.criadoEm,
+        parceira: planoAtual ? isPlanoParceiroElegivel(planoAtual.tipo) : false,
+        diasTesteDisponibilizados: diasTeste,
+        plano,
+      };
+    });
+
+    return {
+      data,
+      pagination: {
+        page,
+        pageSize,
+        total,
+        totalPages: total === 0 ? 0 : Math.ceil(total / pageSize),
+      },
+    };
+  },
+
+  get: async (id: string): Promise<AdminEmpresaDetail | null> => {
+    const empresa = await prisma.usuario.findUnique({
+      where: { id },
+      select: usuarioDetailSelect,
+    });
+
+    if (!empresa || empresa.tipoUsuario !== TipoUsuario.PESSOA_JURIDICA) {
+      return null;
+    }
+
+    const planoAtual = empresa.planosContratados[0];
+    const plano = mapPlanoResumo(planoAtual);
+    const diasTeste = planoAtual ? getPlanoParceiroDuracao(planoAtual.tipo) : null;
+    const ultimoPagamentoEm =
+      planoAtual?.atualizadoEm ?? planoAtual?.inicio ?? planoAtual?.criadoEm ?? null;
+
+    return {
+      id: empresa.id,
+      codUsuario: empresa.codUsuario,
+      nome: empresa.nomeCompleto,
+      avatarUrl: empresa.avatarUrl,
+      descricao: empresa.descricao,
+      instagram: empresa.instagram,
+      linkedin: empresa.linkedin,
+      cidade: empresa.cidade,
+      estado: empresa.estado,
+      criadoEm: empresa.criadoEm,
+      parceira: planoAtual ? isPlanoParceiroElegivel(planoAtual.tipo) : false,
+      diasTesteDisponibilizados: diasTeste,
+      plano,
+      vagas: {
+        publicadas: empresa._count?.vagasCriadas ?? 0,
+        limitePlano: plano?.quantidadeVagas ?? null,
+      },
+      pagamento: {
+        modelo: planoAtual?.modeloPagamento ?? null,
+        metodo: planoAtual?.metodoPagamento ?? null,
+        status: planoAtual?.statusPagamento ?? null,
+        ultimoPagamentoEm,
+      },
+    };
+  },
+};
+
+export type AdminEmpresasListResult = Awaited<ReturnType<typeof adminEmpresasService.list>>;
+export type AdminEmpresaDetailResult = Awaited<ReturnType<typeof adminEmpresasService.get>>;

--- a/src/modules/empresas/admin/validators/admin-empresas.schema.ts
+++ b/src/modules/empresas/admin/validators/admin-empresas.schema.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod';
+
+export const adminEmpresasListQuerySchema = z
+  .object({
+    page: z.coerce.number().int().min(1).optional(),
+    pageSize: z.coerce.number().int().min(1).max(100).optional(),
+    search: z
+      .string()
+      .trim()
+      .transform((value) => (value.length === 0 ? undefined : value))
+      .refine((value) => value === undefined || value.length >= 3, {
+        message: 'A busca deve conter pelo menos 3 caracteres',
+      })
+      .optional(),
+  })
+  .transform((values) => ({
+    page: values.page ?? 1,
+    pageSize: values.pageSize ?? 20,
+    search: values.search,
+  }));
+
+export type AdminEmpresasListQuery = z.infer<typeof adminEmpresasListQuerySchema>;
+
+export const adminEmpresasIdParamSchema = z.object({
+  id: z.string().uuid(),
+});
+
+export type AdminEmpresasIdParam = z.infer<typeof adminEmpresasIdParamSchema>;

--- a/src/modules/empresas/routes/index.ts
+++ b/src/modules/empresas/routes/index.ts
@@ -3,6 +3,7 @@ import { Router } from 'express';
 import { planosEmpresariaisRoutes } from '@/modules/empresas/planos-empresarial';
 import { clientesRoutes } from '@/modules/empresas/clientes';
 import { vagasRoutes } from '@/modules/empresas/vagas';
+import { adminEmpresasRoutes } from '@/modules/empresas/admin';
 
 const router = Router();
 
@@ -10,5 +11,6 @@ router.use('/planos-empresarial', planosEmpresariaisRoutes);
 // Rota oficial para clientes (empresas vinculadas a planos pagos)
 router.use('/clientes', clientesRoutes);
 router.use('/vagas', vagasRoutes);
+router.use('/admin', adminEmpresasRoutes);
 
 export { router as empresasRoutes };

--- a/src/modules/empresas/shared/plano-parceiro.ts
+++ b/src/modules/empresas/shared/plano-parceiro.ts
@@ -1,0 +1,44 @@
+import { PlanoParceiro } from '@prisma/client';
+
+import type { ClientePlanoTipo } from '@/modules/empresas/clientes/validators/clientes.schema';
+
+const PLANO_INPUT_MAP: Record<ClientePlanoTipo, PlanoParceiro> = {
+  '7_dias': PlanoParceiro.SETE_DIAS,
+  '15_dias': PlanoParceiro.QUINZE_DIAS,
+  '30_dias': PlanoParceiro.TRINTA_DIAS,
+  '60_dias': PlanoParceiro.SESSENTA_DIAS,
+  '90dias': PlanoParceiro.NOVENTA_DIAS,
+  '120_dias': PlanoParceiro.CENTO_VINTE_DIAS,
+  parceiro: PlanoParceiro.PARCEIRO,
+};
+
+const PLANO_OUTPUT_MAP: Record<PlanoParceiro, ClientePlanoTipo | 'assinatura_mensal'> = {
+  [PlanoParceiro.SETE_DIAS]: '7_dias',
+  [PlanoParceiro.QUINZE_DIAS]: '15_dias',
+  [PlanoParceiro.TRINTA_DIAS]: '30_dias',
+  [PlanoParceiro.SESSENTA_DIAS]: '60_dias',
+  [PlanoParceiro.NOVENTA_DIAS]: '90dias',
+  [PlanoParceiro.CENTO_VINTE_DIAS]: '120_dias',
+  [PlanoParceiro.ASSINATURA_MENSAL]: 'assinatura_mensal',
+  [PlanoParceiro.PARCEIRO]: 'parceiro',
+};
+
+const PLANO_DURACAO: Record<PlanoParceiro, number | null> = {
+  [PlanoParceiro.SETE_DIAS]: 7,
+  [PlanoParceiro.QUINZE_DIAS]: 15,
+  [PlanoParceiro.TRINTA_DIAS]: 30,
+  [PlanoParceiro.SESSENTA_DIAS]: 60,
+  [PlanoParceiro.NOVENTA_DIAS]: 90,
+  [PlanoParceiro.CENTO_VINTE_DIAS]: 120,
+  [PlanoParceiro.ASSINATURA_MENSAL]: null,
+  [PlanoParceiro.PARCEIRO]: null,
+};
+
+export const mapClienteTipoToPlanoParceiro = (tipo: ClientePlanoTipo) => PLANO_INPUT_MAP[tipo];
+
+export const mapPlanoParceiroToClienteTipo = (tipo: PlanoParceiro) => PLANO_OUTPUT_MAP[tipo];
+
+export const getPlanoParceiroDuracao = (tipo: PlanoParceiro) => PLANO_DURACAO[tipo];
+
+export const isPlanoParceiroElegivel = (tipo: PlanoParceiro) =>
+  tipo === PlanoParceiro.PARCEIRO || getPlanoParceiroDuracao(tipo) !== null;


### PR DESCRIPTION
## Summary
- add admin companies module with endpoints to list and inspect empresas including plano and parceria info
- reuse plano-parceiro helpers across modules and extend swagger docs for the new admin flows
- document pagination metadata and secure routes for ADMIN/MODERADOR reviewers

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68cad69cc88c8325b5eaa7da355bca3a