### PR TITLE
Allow candidate role to view vacancies and tighten update permissions

### DIFF
--- a/src/modules/empresas/vagas/controllers/vagas.controller.ts
+++ b/src/modules/empresas/vagas/controllers/vagas.controller.ts
@@ -2,6 +2,7 @@ import { Request, Response } from 'express';
 import { ZodError } from 'zod';
 import type { StatusVaga } from '@prisma/client';
 import { setCacheHeaders, DEFAULT_TTL } from '@/utils/cache';
+import { Role } from '@/modules/usuarios/enums/Role';
 
 import { vagasService } from '@/modules/empresas/vagas/services/vagas.service';
 import {
@@ -22,7 +23,13 @@ export class VagasController {
 
       const validStatuses = new Set<StatusVaga>(['RASCUNHO', 'EM_ANALISE', 'PUBLICADO', 'EXPIRADO'] as const);
       const restrictedStatuses = new Set<StatusVaga>(['RASCUNHO', 'EM_ANALISE']);
-      const allowedRoles = ['ADMIN', 'MODERADOR', 'EMPRESA', 'RECRUTADOR'] as const;
+      const allowedRoles: Role[] = [
+        Role.ADMIN,
+        Role.MODERADOR,
+        Role.EMPRESA,
+        Role.RECRUTADOR,
+        Role.ALUNO_CANDIDATO,
+      ];
       let statusesFilter: StatusVaga[] | undefined = undefined;
 
       if (typeof status === 'string' && status.trim() !== '') {
@@ -52,7 +59,7 @@ export class VagasController {
             message: 'Token de autorização necessário para consultar vagas não públicas',
           });
         }
-        if (!allowedRoles.includes(user.role as (typeof allowedRoles)[number])) {
+        if (!allowedRoles.includes(user.role as Role)) {
           return res.status(403).json({
             success: false,
             code: 'FORBIDDEN',

--- a/src/modules/empresas/vagas/routes/index.ts
+++ b/src/modules/empresas/vagas/routes/index.ts
@@ -2,10 +2,12 @@ import { Router } from 'express';
 
 import { publicCache } from '@/middlewares/cache-control';
 import { supabaseAuthMiddleware, optionalSupabaseAuth } from '@/modules/usuarios/auth';
+import { Role } from '@/modules/usuarios/enums/Role';
 import { VagasController } from '@/modules/empresas/vagas/controllers/vagas.controller';
 
 const router = Router();
-const protectedRoles = ['ADMIN', 'MODERADOR', 'EMPRESA', 'RECRUTADOR'];
+const protectedRoles = [Role.ADMIN, Role.MODERADOR, Role.EMPRESA, Role.RECRUTADOR];
+const updateRoles = [Role.ADMIN, Role.MODERADOR, Role.RECRUTADOR];
 
 /**
  * @openapi
@@ -248,7 +250,7 @@ router.post('/', supabaseAuthMiddleware(protectedRoles), VagasController.create)
  *                  "status": "PUBLICADO"
  *                }'
  */
-router.put('/:id', supabaseAuthMiddleware(protectedRoles), VagasController.update);
+router.put('/:id', supabaseAuthMiddleware(updateRoles), VagasController.update);
 
 /**
  * @openapi


### PR DESCRIPTION
## Summary
- allow the ALUNO_CANDIDATO role to access restricted vacancy listings
- limit vacancy updates to ADMIN, MODERADOR, and RECRUTADOR roles

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68cae29ad4fc8325bfccaeb675127cb7