### PR TITLE
feat: allow admin companies management

### DIFF
--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -3308,6 +3308,184 @@ const options: Options = {
             },
           },
         },
+        AdminEmpresaPlanoInput: {
+          type: 'object',
+          required: ['planoEmpresarialId', 'tipo'],
+          properties: {
+            planoEmpresarialId: {
+              type: 'string',
+              format: 'uuid',
+              example: 'plano-uuid',
+              description: 'Identificador do plano empresarial que será vinculado à empresa',
+            },
+            tipo: {
+              allOf: [{ $ref: '#/components/schemas/ClientePlanoTipo' }],
+              description: 'Tipo de duração/liberação do plano parceiro',
+            },
+            iniciarEm: {
+              type: 'string',
+              format: 'date-time',
+              nullable: true,
+              example: '2024-01-01T12:00:00Z',
+              description: 'Data de início do plano. Quando omitido, utiliza a data atual',
+            },
+            observacao: {
+              type: 'string',
+              nullable: true,
+              example: 'Plano cortesia liberado pelo time comercial',
+              description: 'Observação interna sobre a concessão do plano',
+            },
+          },
+        },
+        AdminEmpresaCreateInput: {
+          type: 'object',
+          required: ['nome', 'email', 'telefone', 'senha', 'supabaseId', 'cnpj'],
+          properties: {
+            nome: {
+              type: 'string',
+              example: 'Advance Tech Consultoria',
+              description: 'Nome fantasia da empresa',
+            },
+            email: {
+              type: 'string',
+              format: 'email',
+              example: 'contato@advancetech.com.br',
+              description: 'E-mail principal utilizado pela empresa',
+            },
+            telefone: {
+              type: 'string',
+              example: '11987654321',
+              description: 'Telefone de contato direto com a empresa',
+            },
+            senha: {
+              type: 'string',
+              example: 'SenhaForte123!',
+              description: 'Senha inicial que será criptografada antes de salvar',
+            },
+            supabaseId: {
+              type: 'string',
+              example: 'supabase-user-id',
+              description: 'Identificador do usuário correspondente no Supabase',
+            },
+            cnpj: {
+              type: 'string',
+              example: '12345678000190',
+              description: 'CNPJ da empresa, apenas números',
+            },
+            cidade: {
+              type: 'string',
+              nullable: true,
+              example: 'São Paulo',
+            },
+            estado: {
+              type: 'string',
+              nullable: true,
+              example: 'SP',
+            },
+            descricao: {
+              type: 'string',
+              nullable: true,
+              example: 'Consultoria especializada em recrutamento e seleção.',
+            },
+            instagram: {
+              type: 'string',
+              nullable: true,
+              example: 'https://instagram.com/advancemais',
+            },
+            linkedin: {
+              type: 'string',
+              nullable: true,
+              example: 'https://linkedin.com/company/advancemais',
+            },
+            avatarUrl: {
+              type: 'string',
+              nullable: true,
+              example: 'https://cdn.advance.com.br/logo.png',
+            },
+            aceitarTermos: {
+              type: 'boolean',
+              example: true,
+              description: 'Indica se os termos de uso já foram aceitos em nome da empresa',
+            },
+            status: {
+              type: 'string',
+              nullable: true,
+              enum: ['ATIVO', 'INATIVO', 'BANIDO', 'PENDENTE', 'SUSPENSO'],
+              example: 'ATIVO',
+              description: 'Status inicial da conta da empresa. Padrão: ATIVO',
+            },
+            plano: {
+              allOf: [{ $ref: '#/components/schemas/AdminEmpresaPlanoInput' }],
+              nullable: true,
+              description: 'Dados opcionais para já vincular um plano empresarial ativo',
+            },
+          },
+        },
+        AdminEmpresaUpdateInput: {
+          type: 'object',
+          description: 'Informe ao menos um campo para atualização',
+          properties: {
+            nome: {
+              type: 'string',
+              example: 'Advance Tech Consultoria LTDA',
+            },
+            email: {
+              type: 'string',
+              format: 'email',
+              example: 'contato@advancetech.com.br',
+            },
+            telefone: {
+              type: 'string',
+              example: '11912345678',
+            },
+            cnpj: {
+              type: 'string',
+              nullable: true,
+              example: '12345678000190',
+            },
+            cidade: {
+              type: 'string',
+              nullable: true,
+              example: 'São Paulo',
+            },
+            estado: {
+              type: 'string',
+              nullable: true,
+              example: 'SP',
+            },
+            descricao: {
+              type: 'string',
+              nullable: true,
+              example: 'Consultoria especializada em recrutamento e seleção com foco em tecnologia.',
+            },
+            instagram: {
+              type: 'string',
+              nullable: true,
+              example: 'https://instagram.com/advancemais',
+            },
+            linkedin: {
+              type: 'string',
+              nullable: true,
+              example: 'https://linkedin.com/company/advancemais',
+            },
+            avatarUrl: {
+              type: 'string',
+              nullable: true,
+              example: 'https://cdn.advance.com.br/logo.png',
+            },
+            status: {
+              type: 'string',
+              nullable: true,
+              enum: ['ATIVO', 'INATIVO', 'BANIDO', 'PENDENTE', 'SUSPENSO'],
+              example: 'ATIVO',
+            },
+            plano: {
+              allOf: [{ $ref: '#/components/schemas/AdminEmpresaPlanoInput' }],
+              nullable: true,
+              description: 'Envie null para encerrar o plano atual da empresa',
+            },
+          },
+        },
         AdminEmpresasListResponse: {
           type: 'object',
           properties: {

--- a/src/modules/empresas/admin/controllers/admin-empresas.controller.ts
+++ b/src/modules/empresas/admin/controllers/admin-empresas.controller.ts
@@ -3,11 +3,120 @@ import { ZodError } from 'zod';
 
 import { adminEmpresasService } from '@/modules/empresas/admin/services/admin-empresas.service';
 import {
+  adminEmpresasCreateSchema,
   adminEmpresasIdParamSchema,
   adminEmpresasListQuerySchema,
+  adminEmpresasUpdateSchema,
 } from '@/modules/empresas/admin/validators/admin-empresas.schema';
 
 export class AdminEmpresasController {
+  static create = async (req: Request, res: Response) => {
+    try {
+      const payload = adminEmpresasCreateSchema.parse(req.body);
+      const empresa = await adminEmpresasService.create(payload);
+
+      if (!empresa) {
+        return res.status(500).json({
+          success: false,
+          code: 'ADMIN_EMPRESAS_CREATE_ERROR',
+          message: 'Empresa criada, mas não foi possível carregar os dados atualizados',
+        });
+      }
+
+      res.status(201).json({ empresa });
+    } catch (error: any) {
+      if (error instanceof ZodError) {
+        return res.status(400).json({
+          success: false,
+          code: 'VALIDATION_ERROR',
+          message: 'Dados inválidos para criação da empresa',
+          issues: error.flatten().fieldErrors,
+        });
+      }
+
+      if (error?.code === 'P2002') {
+        return res.status(409).json({
+          success: false,
+          code: 'EMPRESA_DUPLICATED',
+          message: 'Já existe uma empresa com os dados informados (e-mail, CNPJ ou Supabase ID)',
+        });
+      }
+
+      if (error?.code === 'P2003') {
+        return res.status(404).json({
+          success: false,
+          code: 'PLANO_EMPRESARIAL_NOT_FOUND',
+          message: 'Plano empresarial informado não foi encontrado',
+        });
+      }
+
+      res.status(500).json({
+        success: false,
+        code: 'ADMIN_EMPRESAS_CREATE_ERROR',
+        message: 'Erro ao criar empresa',
+        error: error?.message,
+      });
+    }
+  };
+
+  static update = async (req: Request, res: Response) => {
+    try {
+      const params = adminEmpresasIdParamSchema.parse(req.params);
+      const payload = adminEmpresasUpdateSchema.parse(req.body);
+      const empresa = await adminEmpresasService.update(params.id, payload);
+
+      if (!empresa) {
+        return res.status(404).json({
+          success: false,
+          code: 'EMPRESA_NOT_FOUND',
+          message: 'Empresa não encontrada',
+        });
+      }
+
+      res.json({ empresa });
+    } catch (error: any) {
+      if (error instanceof ZodError) {
+        return res.status(400).json({
+          success: false,
+          code: 'VALIDATION_ERROR',
+          message: 'Dados inválidos para atualização da empresa',
+          issues: error.flatten().fieldErrors,
+        });
+      }
+
+      if (error?.code === 'EMPRESA_NOT_FOUND' || error?.code === 'P2025') {
+        return res.status(404).json({
+          success: false,
+          code: 'EMPRESA_NOT_FOUND',
+          message: 'Empresa não encontrada',
+        });
+      }
+
+      if (error?.code === 'P2002') {
+        return res.status(409).json({
+          success: false,
+          code: 'EMPRESA_DUPLICATED',
+          message: 'Já existe uma empresa com os dados informados (e-mail, CNPJ ou Supabase ID)',
+        });
+      }
+
+      if (error?.code === 'P2003') {
+        return res.status(404).json({
+          success: false,
+          code: 'PLANO_EMPRESARIAL_NOT_FOUND',
+          message: 'Plano empresarial informado não foi encontrado',
+        });
+      }
+
+      res.status(500).json({
+        success: false,
+        code: 'ADMIN_EMPRESAS_UPDATE_ERROR',
+        message: 'Erro ao atualizar empresa',
+        error: error?.message,
+      });
+    }
+  };
+
   static list = async (req: Request, res: Response) => {
     try {
       const filters = adminEmpresasListQuerySchema.parse(req.query);

--- a/src/modules/empresas/admin/routes/index.ts
+++ b/src/modules/empresas/admin/routes/index.ts
@@ -9,6 +9,55 @@ const adminRoles = ['ADMIN', 'MODERADOR'];
 /**
  * @openapi
  * /api/v1/empresas/admin:
+ *   post:
+ *     summary: (Admin) Criar empresa
+ *     description: "Cria uma nova empresa (Pessoa Jurídica) e permite opcionalmente vincular um plano ativo no momento da criação. Endpoint restrito aos perfis ADMIN e MODERADOR."
+ *     tags: [Empresas - Admin]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/AdminEmpresaCreateInput'
+ *     responses:
+ *       201:
+ *         description: Empresa criada com sucesso
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/AdminEmpresaDetailResponse'
+ *       400:
+ *         description: Dados inválidos
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ValidationErrorResponse'
+ *       401:
+ *         description: Token inválido ou ausente
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       404:
+ *         description: Plano empresarial informado não encontrado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       409:
+ *         description: Dados duplicados
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
  *   get:
  *     summary: (Admin) Listar empresas
  *     description: "Retorna empresas (Pessoa Jurídica) com dados resumidos do plano ativo. Endpoint restrito aos perfis ADMIN e MODERADOR."
@@ -62,11 +111,68 @@ const adminRoles = ['ADMIN', 'MODERADOR'];
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  */
+router.post('/', supabaseAuthMiddleware(adminRoles), AdminEmpresasController.create);
 router.get('/', supabaseAuthMiddleware(adminRoles), AdminEmpresasController.list);
 
 /**
  * @openapi
  * /api/v1/empresas/admin/{id}:
+ *   put:
+ *     summary: (Admin) Atualizar empresa
+ *     description: "Atualiza dados cadastrais da empresa e permite gerenciar o plano vinculado. Endpoint restrito aos perfis ADMIN e MODERADOR."
+ *     tags: [Empresas - Admin]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/AdminEmpresaUpdateInput'
+ *     responses:
+ *       200:
+ *         description: Empresa atualizada com sucesso
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/AdminEmpresaDetailResponse'
+ *       400:
+ *         description: Dados inválidos
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ValidationErrorResponse'
+ *       401:
+ *         description: Token inválido ou ausente
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       404:
+ *         description: Empresa ou plano não encontrados
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       409:
+ *         description: Dados duplicados
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
  *   get:
  *     summary: (Admin) Detalhes completos da empresa
  *     description: "Retorna informações completas da empresa incluindo plano ativo, pagamentos e métricas. Endpoint restrito aos perfis ADMIN e MODERADOR."
@@ -112,6 +218,7 @@ router.get('/', supabaseAuthMiddleware(adminRoles), AdminEmpresasController.list
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  */
+router.put('/:id', supabaseAuthMiddleware(adminRoles), AdminEmpresasController.update);
 router.get('/:id', supabaseAuthMiddleware(adminRoles), AdminEmpresasController.get);
 
 export { router as adminEmpresasRoutes };

--- a/src/modules/empresas/admin/validators/admin-empresas.schema.ts
+++ b/src/modules/empresas/admin/validators/admin-empresas.schema.ts
@@ -1,4 +1,110 @@
+import { Status } from '@prisma/client';
 import { z } from 'zod';
+
+import { clientePlanoTipoSchema } from '@/modules/empresas/clientes/validators/clientes.schema';
+
+const uuidSchema = z.string().uuid('Informe um identificador válido');
+
+const nullableString = z
+  .string()
+  .trim()
+  .min(1, 'Informe um valor válido')
+  .max(255, 'Valor muito longo');
+
+const nullableUrl = z
+  .string()
+  .trim()
+  .url('Informe uma URL válida')
+  .max(500, 'URL muito longa');
+
+const observacaoSchema = z
+  .string()
+  .trim()
+  .min(1, 'A observação não pode estar vazia')
+  .max(500, 'A observação deve ter no máximo 500 caracteres');
+
+export const adminEmpresasPlanoSchema = z.object({
+  planoEmpresarialId: uuidSchema,
+  tipo: clientePlanoTipoSchema,
+  iniciarEm: z.coerce.date({ invalid_type_error: 'Informe uma data válida' }).optional(),
+  observacao: observacaoSchema.optional().nullable(),
+});
+
+export type AdminEmpresasPlanoInput = z.infer<typeof adminEmpresasPlanoSchema>;
+
+export const adminEmpresasCreateSchema = z.object({
+  nome: z
+    .string({ required_error: 'Nome é obrigatório' })
+    .trim()
+    .min(1, 'Nome é obrigatório')
+    .max(255, 'Nome muito longo'),
+  email: z
+    .string({ required_error: 'E-mail é obrigatório' })
+    .trim()
+    .toLowerCase()
+    .email('Informe um e-mail válido'),
+  telefone: z
+    .string({ required_error: 'Telefone é obrigatório' })
+    .trim()
+    .min(10, 'Informe um telefone válido')
+    .max(20, 'Telefone muito longo'),
+  senha: z
+    .string({ required_error: 'Senha é obrigatória' })
+    .min(8, 'Senha deve ter pelo menos 8 caracteres')
+    .max(255, 'Senha muito longa'),
+  supabaseId: z
+    .string({ required_error: 'Supabase ID é obrigatório' })
+    .trim()
+    .min(1, 'Supabase ID é obrigatório')
+    .max(255, 'Supabase ID muito longo'),
+  cnpj: z
+    .string({ required_error: 'CNPJ é obrigatório' })
+    .trim()
+    .min(14, 'CNPJ deve ter 14 dígitos')
+    .max(18, 'CNPJ muito longo'),
+  cidade: nullableString.optional(),
+  estado: nullableString.optional(),
+  descricao: z
+    .string()
+    .trim()
+    .max(500, 'Descrição muito longa')
+    .optional(),
+  instagram: nullableString.optional(),
+  linkedin: nullableString.optional(),
+  avatarUrl: nullableUrl.optional(),
+  aceitarTermos: z.boolean().optional(),
+  status: z.nativeEnum(Status).optional(),
+  plano: adminEmpresasPlanoSchema.optional(),
+});
+
+export type AdminEmpresasCreateInput = z.infer<typeof adminEmpresasCreateSchema>;
+
+export const adminEmpresasUpdateSchema = z
+  .object({
+    nome: nullableString.optional(),
+    email: z.string().trim().toLowerCase().email('Informe um e-mail válido').optional(),
+    telefone: z.string().trim().min(10, 'Informe um telefone válido').max(20).optional(),
+    cnpj: z.string().trim().min(14, 'CNPJ deve ter 14 dígitos').max(18).optional().nullable(),
+    cidade: nullableString.optional().nullable(),
+    estado: nullableString.optional().nullable(),
+    descricao: z.string().trim().max(500, 'Descrição muito longa').optional().nullable(),
+    instagram: nullableString.optional().nullable(),
+    linkedin: nullableString.optional().nullable(),
+    avatarUrl: nullableUrl.optional().nullable(),
+    status: z.nativeEnum(Status).optional(),
+    plano: adminEmpresasPlanoSchema.optional().nullable(),
+  })
+  .refine(
+    (values) =>
+      Object.values({ ...values, plano: undefined }).some((value) => value !== undefined) ||
+      values.plano !== undefined,
+    {
+      message: 'Informe ao menos um campo para atualização',
+      path: [],
+    },
+  );
+
+export type AdminEmpresasUpdateInput = z.infer<typeof adminEmpresasUpdateSchema>;
 
 export const adminEmpresasListQuerySchema = z
   .object({


### PR DESCRIPTION
## Summary
- add POST and PUT endpoints for Empresas - Admin including validation and error handling
- implement service layer helpers to create companies and manage plan assignments
- document the new operations and payload schemas in Swagger

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68cae1aafaf083258f98059658425cde