### PR TITLE
feat: adicionar listagem administrativa de candidatos

### DIFF
--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -3837,6 +3837,49 @@ const options: Options = {
             },
           },
         },
+        AdminCandidateSummary: {
+          type: 'object',
+          properties: {
+            id: { type: 'string', example: 'candidate-uuid' },
+            email: { type: 'string', example: 'candidato@example.com' },
+            nomeCompleto: { type: 'string', example: 'João da Silva' },
+            role: { type: 'string', example: 'ALUNO_CANDIDATO' },
+            status: { type: 'string', example: 'ATIVO' },
+            tipoUsuario: { type: 'string', example: 'PESSOA_FISICA' },
+            cidade: { type: 'string', nullable: true, example: 'Maceió' },
+            estado: { type: 'string', nullable: true, example: 'AL' },
+            criadoEm: {
+              type: 'string',
+              format: 'date-time',
+              example: '2024-01-01T12:00:00Z',
+            },
+            ultimoLogin: {
+              type: 'string',
+              format: 'date-time',
+              nullable: true,
+              example: '2024-01-10T12:00:00Z',
+            },
+          },
+        },
+        AdminCandidateListResponse: {
+          type: 'object',
+          properties: {
+            message: { type: 'string', example: 'Lista de candidatos' },
+            candidatos: {
+              type: 'array',
+              items: { $ref: '#/components/schemas/AdminCandidateSummary' },
+            },
+            pagination: {
+              type: 'object',
+              properties: {
+                page: { type: 'integer', example: 1 },
+                limit: { type: 'integer', example: 50 },
+                total: { type: 'integer', example: 100 },
+                pages: { type: 'integer', example: 2 },
+              },
+            },
+          },
+        },
         AdminUserListResponse: {
           type: 'object',
           properties: {
@@ -3920,6 +3963,70 @@ const options: Options = {
           properties: {
             message: { type: 'string', example: 'Usuário encontrado' },
             usuario: { $ref: '#/components/schemas/AdminUserDetail' },
+          },
+        },
+        AdminCandidateDetail: {
+          allOf: [
+            { $ref: '#/components/schemas/AdminCandidateSummary' },
+            {
+              type: 'object',
+              properties: {
+                cpf: { type: 'string', nullable: true, example: '12345678900' },
+                telefone: { type: 'string', example: '+55 11 99999-0000' },
+                dataNasc: {
+                  type: 'string',
+                  format: 'date',
+                  nullable: true,
+                  example: '1990-01-01',
+                },
+                genero: { type: 'string', nullable: true, example: 'MASCULINO' },
+                matricula: { type: 'string', nullable: true, example: 'MAT123' },
+                supabaseId: { type: 'string', example: 'uuid-supabase' },
+                avatarUrl: {
+                  type: 'string',
+                  nullable: true,
+                  example: 'https://cdn.advance.com.br/avatar.png',
+                },
+                descricao: {
+                  type: 'string',
+                  nullable: true,
+                  example: 'Profissional com experiência em atendimento.',
+                },
+                instagram: {
+                  type: 'string',
+                  nullable: true,
+                  example: 'https://instagram.com/candidato',
+                },
+                linkedin: {
+                  type: 'string',
+                  nullable: true,
+                  example: 'https://linkedin.com/in/candidato',
+                },
+                codUsuario: { type: 'string', example: 'CAN1234' },
+                enderecos: {
+                  type: 'array',
+                  items: {
+                    type: 'object',
+                    properties: {
+                      id: { type: 'string', example: 'end-1' },
+                      logradouro: { type: 'string', example: 'Rua A' },
+                      numero: { type: 'string', example: '100' },
+                      bairro: { type: 'string', example: 'Centro' },
+                      cidade: { type: 'string', example: 'São Paulo' },
+                      estado: { type: 'string', example: 'SP' },
+                      cep: { type: 'string', example: '01000-000' },
+                    },
+                  },
+                },
+              },
+            },
+          ],
+        },
+        AdminCandidateDetailResponse: {
+          type: 'object',
+          properties: {
+            message: { type: 'string', example: 'Candidato encontrado' },
+            candidato: { $ref: '#/components/schemas/AdminCandidateDetail' },
           },
         },
         AdminStatusUpdateRequest: {

--- a/src/modules/usuarios/controllers/admin-controller.ts
+++ b/src/modules/usuarios/controllers/admin-controller.ts
@@ -52,6 +52,21 @@ export class AdminController {
   };
 
   /**
+   * Lista candidatos com paginação e filtros
+   */
+  public listarCandidatos = async (req: Request, res: Response, next: NextFunction) => {
+    const log = this.getLogger(req);
+    try {
+      const result = await this.adminService.listarCandidatos(req.query);
+      res.json(result);
+    } catch (error) {
+      const err = error instanceof Error ? error : new Error(String(error));
+      log.error({ err }, 'Erro ao listar candidatos');
+      return next(err);
+    }
+  };
+
+  /**
    * Busca usuário específico
    */
   public buscarUsuario = async (req: Request, res: Response, next: NextFunction) => {
@@ -73,6 +88,32 @@ export class AdminController {
     } catch (error) {
       const err = error instanceof Error ? error : new Error(String(error));
       log.error({ err }, 'Erro ao buscar usuário');
+      return next(err);
+    }
+  };
+
+  /**
+   * Busca candidato específico
+   */
+  public buscarCandidato = async (req: Request, res: Response, next: NextFunction) => {
+    const log = this.getLogger(req);
+    try {
+      const { userId } = req.params;
+      const result = await this.adminService.buscarCandidato(userId);
+
+      if (!result) {
+        return res.status(404).json({
+          message: 'Candidato não encontrado',
+        });
+      }
+
+      res.json({
+        message: 'Candidato encontrado',
+        candidato: result,
+      });
+    } catch (error) {
+      const err = error instanceof Error ? error : new Error(String(error));
+      log.error({ err }, 'Erro ao buscar candidato');
       return next(err);
     }
   };

--- a/src/modules/usuarios/routes/admin-routes.ts
+++ b/src/modules/usuarios/routes/admin-routes.ts
@@ -121,6 +121,66 @@ router.get('/', asyncHandler(adminController.getAdminInfo));
 router.get('/usuarios', asyncHandler(adminController.listarUsuarios));
 
 /**
+ * Listar candidatos com filtros
+ * GET /admin/candidatos
+ */
+/**
+ * @openapi
+ * /api/v1/usuarios/admin/candidatos:
+ *   get:
+ *     summary: Listar candidatos
+ *     tags: [Usuários - Admin]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: page
+ *         schema:
+ *           type: integer
+ *           example: 1
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *           example: 50
+ *       - in: query
+ *         name: status
+ *         schema:
+ *           type: string
+ *           example: ATIVO
+ *       - in: query
+ *         name: tipoUsuario
+ *         schema:
+ *           type: string
+ *           example: PESSOA_FISICA
+ *       - in: query
+ *         name: search
+ *         schema:
+ *           type: string
+ *           example: Joao da Silva
+ *     responses:
+ *       200:
+ *         description: Lista de candidatos
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/AdminCandidateListResponse'
+ *       500:
+ *         description: Erro ao listar candidatos
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X GET "http://localhost:3000/api/v1/usuarios/admin/candidatos" \\
+ *            -H "Authorization: Bearer <TOKEN>"
+ */
+router.get('/candidatos', asyncHandler(adminController.listarCandidatos));
+
+/**
  * Buscar usuário específico por ID
  * GET /admin/usuarios/:userId
  */
@@ -165,6 +225,52 @@ router.get('/usuarios', asyncHandler(adminController.listarUsuarios));
  *            -H "Authorization: Bearer <TOKEN>"
  */
 router.get('/usuarios/:userId', asyncHandler(adminController.buscarUsuario));
+
+/**
+ * Buscar candidato específico por ID
+ * GET /admin/candidatos/:userId
+ */
+/**
+ * @openapi
+ * /api/v1/usuarios/admin/candidatos/{userId}:
+ *   get:
+ *     summary: Buscar candidato por ID
+ *     tags: [Usuários - Admin]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: userId
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Candidato encontrado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/AdminCandidateDetailResponse'
+ *       404:
+ *         description: Candidato não encontrado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X GET "http://localhost:3000/api/v1/usuarios/admin/candidatos/{userId}" \\
+ *            -H "Authorization: Bearer <TOKEN>"
+ */
+router.get('/candidatos/:userId', asyncHandler(adminController.buscarCandidato));
 
 // =============================================
 // ROTAS DE MODIFICAÇÃO (APENAS ADMIN)

--- a/src/modules/usuarios/services/admin-service.ts
+++ b/src/modules/usuarios/services/admin-service.ts
@@ -5,6 +5,7 @@
  * @author Sistema Advance+
  * @version 3.0.0
  */
+import { Prisma, Role, Status, TipoUsuario } from '@prisma/client';
 import { z } from 'zod';
 
 import { prisma } from '@/config/prisma';
@@ -14,6 +15,39 @@ export class AdminService {
   private readonly log = logger.child({ module: 'AdminService' });
 
   constructor() {}
+
+  private getStatusFilter(status?: string) {
+    if (!status) return undefined;
+
+    const normalized = status.trim().toUpperCase();
+    if (normalized in Status) {
+      return Status[normalized as keyof typeof Status];
+    }
+
+    return undefined;
+  }
+
+  private getRoleFilter(role?: string) {
+    if (!role) return undefined;
+
+    const normalized = role.trim().toUpperCase();
+    if (normalized in Role) {
+      return Role[normalized as keyof typeof Role];
+    }
+
+    return undefined;
+  }
+
+  private getTipoUsuarioFilter(tipoUsuario?: string) {
+    if (!tipoUsuario) return undefined;
+
+    const normalized = tipoUsuario.trim().toUpperCase();
+    if (normalized in TipoUsuario) {
+      return TipoUsuario[normalized as keyof typeof TipoUsuario];
+    }
+
+    return undefined;
+  }
 
   /**
    * Lista usuários com filtros e paginação
@@ -32,10 +66,15 @@ export class AdminService {
     const skip = (page - 1) * pageSize;
 
     // Construir filtros dinamicamente
-    const where: any = {};
-    if (status) where.status = status as string;
-    if (role) where.role = role as string;
-    if (tipoUsuario) where.tipoUsuario = tipoUsuario;
+    const where: Prisma.UsuarioWhereInput = {};
+    const statusFilter = this.getStatusFilter(status);
+    const tipoUsuarioFilter = this.getTipoUsuarioFilter(tipoUsuario);
+
+    const roleFilter = this.getRoleFilter(role);
+
+    if (statusFilter) where.status = statusFilter;
+    if (roleFilter) where.role = roleFilter;
+    if (tipoUsuarioFilter) where.tipoUsuario = tipoUsuarioFilter;
 
     const [usuarios, total] = await Promise.all([
       prisma.usuario.findMany({
@@ -60,6 +99,80 @@ export class AdminService {
     return {
       message: 'Lista de usuários',
       usuarios,
+      pagination: {
+        page,
+        limit: pageSize,
+        total,
+        pages: Math.ceil(total / pageSize),
+      },
+    };
+  }
+
+  /**
+   * Lista candidatos (role ALUNO_CANDIDATO) com filtros e paginação
+   */
+  async listarCandidatos(query: unknown) {
+    const querySchema = z.object({
+      page: z.coerce.number().int().min(1).default(1),
+      limit: z.coerce.number().int().min(1).default(50),
+      status: z.string().optional(),
+      tipoUsuario: z.string().optional(),
+      search: z.string().optional(),
+    });
+
+    const { page, limit, status, tipoUsuario, search } = querySchema.parse(query);
+    const pageSize = Math.min(Number(limit) || 50, 100);
+    const skip = (page - 1) * pageSize;
+
+    const where: Prisma.UsuarioWhereInput = {
+      role: Role.ALUNO_CANDIDATO,
+    };
+
+    const statusFilter = this.getStatusFilter(status);
+    if (statusFilter) {
+      where.status = statusFilter;
+    }
+
+    const tipoUsuarioFilter = this.getTipoUsuarioFilter(tipoUsuario);
+    if (tipoUsuarioFilter) {
+      where.tipoUsuario = tipoUsuarioFilter;
+    }
+
+    if (search && search.trim() !== '') {
+      const term = search.trim();
+      where.OR = [
+        { nomeCompleto: { contains: term, mode: 'insensitive' } },
+        { email: { contains: term, mode: 'insensitive' } },
+        { cpf: { contains: term, mode: 'insensitive' } },
+        { codUsuario: { contains: term, mode: 'insensitive' } },
+      ];
+    }
+
+    const [candidatos, total] = await Promise.all([
+      prisma.usuario.findMany({
+        where,
+        select: {
+          id: true,
+          nomeCompleto: true,
+          email: true,
+          role: true,
+          status: true,
+          tipoUsuario: true,
+          criadoEm: true,
+          ultimoLogin: true,
+          cidade: true,
+          estado: true,
+        },
+        orderBy: { criadoEm: 'desc' },
+        skip,
+        take: pageSize,
+      }),
+      prisma.usuario.count({ where }),
+    ]);
+
+    return {
+      message: 'Lista de candidatos',
+      candidatos,
       pagination: {
         page,
         limit: pageSize,
@@ -121,6 +234,63 @@ export class AdminService {
       return null;
     }
     return usuario;
+  }
+
+  /**
+   * Busca candidato específico com detalhes
+   */
+  async buscarCandidato(userId: string) {
+    if (!userId || userId.trim() === '') {
+      throw new Error('ID do candidato é obrigatório');
+    }
+
+    const candidato = await prisma.usuario.findFirst({
+      where: {
+        id: userId,
+        role: Role.ALUNO_CANDIDATO,
+      },
+      select: {
+        id: true,
+        email: true,
+        nomeCompleto: true,
+        cpf: true,
+        telefone: true,
+        dataNasc: true,
+        genero: true,
+        matricula: true,
+        role: true,
+        status: true,
+        tipoUsuario: true,
+        supabaseId: true,
+        ultimoLogin: true,
+        criadoEm: true,
+        atualizadoEm: true,
+        cidade: true,
+        estado: true,
+        avatarUrl: true,
+        descricao: true,
+        instagram: true,
+        linkedin: true,
+        codUsuario: true,
+        enderecos: {
+          select: {
+            id: true,
+            logradouro: true,
+            numero: true,
+            bairro: true,
+            cidade: true,
+            estado: true,
+            cep: true,
+          },
+        },
+      },
+    });
+
+    if (!candidato) {
+      return null;
+    }
+
+    return candidato;
   }
 
   /**


### PR DESCRIPTION
## Summary
- adiciona métodos e rotas administrativas para listar e consultar candidatos do tipo ALUNO_CANDIDATO
- filtra e normaliza parâmetros de busca usando enums do Prisma
- documenta os novos contratos na especificação OpenAPI

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68cae4552d1883259f15eab049a01f06