### PR TITLE
feat: expand admin enterprise management endpoints

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -51,9 +51,11 @@ model Usuario {
   ultimaTentativaVerificacao DateTime?
 
   // RELACIONAMENTOS EXISTENTES
-  enderecos         Endereco[]
-  vagasCriadas      Vaga[]         @relation("UsuarioVagas")
-  planosContratados EmpresaPlano[] @relation("UsuarioPlanos")
+  enderecos            Endereco[]
+  vagasCriadas         Vaga[]             @relation("UsuarioVagas")
+  planosContratados    EmpresaPlano[]     @relation("UsuarioPlanos")
+  banimentosRecebidos  EmpresaBanimento[] @relation("EmpresaBanimentosUsuario")
+  banimentosAplicados  EmpresaBanimento[] @relation("EmpresaBanimentosAdmin")
 
   @@index([tokenRecuperacao])
   @@index([emailVerificationToken])
@@ -164,6 +166,23 @@ model LogPagamento {
   @@index([empresaPlanoId])
   @@index([tipo])
   @@index([criadoEm])
+}
+
+model EmpresaBanimento {
+  id          String   @id @default(uuid())
+  usuarioId   String
+  criadoPorId String
+  dias        Int
+  motivo      String?  @db.VarChar(500)
+  inicio      DateTime @default(now())
+  fim         DateTime
+  criadoEm    DateTime @default(now())
+
+  usuario   Usuario @relation("EmpresaBanimentosUsuario", fields: [usuarioId], references: [id], onDelete: Cascade)
+  criadoPor Usuario @relation("EmpresaBanimentosAdmin", fields: [criadoPorId], references: [id])
+
+  @@index([usuarioId])
+  @@index([fim])
 }
 
 model PlanoEmpresarial {

--- a/src/modules/empresas/admin/routes/index.ts
+++ b/src/modules/empresas/admin/routes/index.ts
@@ -245,4 +245,418 @@ router.get('/', supabaseAuthMiddleware(adminRoles), AdminEmpresasController.list
 router.put('/:id', supabaseAuthMiddleware(adminRoles), AdminEmpresasController.update);
 router.get('/:id', supabaseAuthMiddleware(adminRoles), AdminEmpresasController.get);
 
+/**
+ * @openapi
+ * /api/v1/empresas/admin/{id}/pagamentos:
+ *   get:
+ *     summary: (Admin) Histórico de pagamentos da empresa
+ *     description: "Lista eventos de pagamento relacionados à empresa sem expor dados sensíveis de cartão. Apenas perfis ADMIN e MODERADOR podem acessar."
+ *     tags: [Empresas - Admin]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *       - in: query
+ *         name: page
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *           default: 1
+ *         description: Página atual da paginação
+ *       - in: query
+ *         name: pageSize
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *           maximum: 100
+ *           default: 20
+ *         description: Quantidade de registros por página
+ *     responses:
+ *       200:
+ *         description: Histórico de pagamentos retornado com sucesso
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/AdminEmpresasPagamentosResponse'
+ *       400:
+ *         description: Parâmetros inválidos
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ValidationErrorResponse'
+ *       401:
+ *         description: Token inválido ou ausente
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/UnauthorizedResponse'
+ *       403:
+ *         description: Acesso negado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ForbiddenResponse'
+ *       404:
+ *         description: Empresa não encontrada
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ */
+router.get(
+  '/:id/pagamentos',
+  supabaseAuthMiddleware(adminRoles),
+  AdminEmpresasController.listPagamentos,
+);
+
+/**
+ * @openapi
+ * /api/v1/empresas/admin/{id}/banimentos:
+ *   get:
+ *     summary: (Admin) Listar banimentos aplicados
+ *     description: "Retorna histórico de banimentos aplicados a uma empresa, incluindo motivo e vigência."
+ *     tags: [Empresas - Admin]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *       - in: query
+ *         name: page
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *           default: 1
+ *       - in: query
+ *         name: pageSize
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *           maximum: 100
+ *           default: 20
+ *     responses:
+ *       200:
+ *         description: Histórico de banimentos retornado com sucesso
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/AdminEmpresasBanimentosResponse'
+ *       400:
+ *         description: Parâmetros inválidos
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ValidationErrorResponse'
+ *       401:
+ *         description: Token inválido ou ausente
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/UnauthorizedResponse'
+ *       403:
+ *         description: Acesso negado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ForbiddenResponse'
+ *       404:
+ *         description: Empresa não encontrada
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *   post:
+ *     summary: (Admin) Aplicar banimento à empresa
+ *     description: "Aplica banimento temporário a uma empresa por quantidade de dias definida pelo administrador."
+ *     tags: [Empresas - Admin]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/AdminEmpresaBanimentoCreate'
+ *     responses:
+ *       201:
+ *         description: Banimento aplicado com sucesso
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/AdminEmpresaBanimentoResponse'
+ *       400:
+ *         description: Dados inválidos
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ValidationErrorResponse'
+ *       401:
+ *         description: Token inválido ou ausente
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/UnauthorizedResponse'
+ *       403:
+ *         description: Acesso negado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ForbiddenResponse'
+ *       404:
+ *         description: Empresa não encontrada
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ */
+router.get('/:id/banimentos', supabaseAuthMiddleware(adminRoles), AdminEmpresasController.listBanimentos);
+router.post('/:id/banimentos', supabaseAuthMiddleware(adminRoles), AdminEmpresasController.ban);
+
+/**
+ * @openapi
+ * /api/v1/empresas/admin/{id}/vagas:
+ *   get:
+ *     summary: (Admin) Histórico de vagas da empresa
+ *     description: "Lista vagas criadas pela empresa com opção de filtrar por status."
+ *     tags: [Empresas - Admin]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *       - in: query
+ *         name: status
+ *         schema:
+ *           type: string
+ *         description: "Lista de status separados por vírgula (RASCUNHO, EM_ANALISE, PUBLICADO, EXPIRADO)"
+ *       - in: query
+ *         name: page
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *           default: 1
+ *       - in: query
+ *         name: pageSize
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *           maximum: 100
+ *           default: 20
+ *     responses:
+ *       200:
+ *         description: Histórico de vagas retornado com sucesso
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/AdminEmpresasVagasResponse'
+ *       400:
+ *         description: Parâmetros inválidos
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ValidationErrorResponse'
+ *       401:
+ *         description: Token inválido ou ausente
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/UnauthorizedResponse'
+ *       403:
+ *         description: Acesso negado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ForbiddenResponse'
+ *       404:
+ *         description: Empresa não encontrada
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ */
+router.get('/:id/vagas', supabaseAuthMiddleware(adminRoles), AdminEmpresasController.listVagas);
+
+/**
+ * @openapi
+ * /api/v1/empresas/admin/{id}/vagas/em-analise:
+ *   get:
+ *     summary: (Admin) Vagas em análise da empresa
+ *     description: "Retorna vagas da empresa com status EM_ANALISE aguardando aprovação."
+ *     tags: [Empresas - Admin]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *       - in: query
+ *         name: page
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *           default: 1
+ *       - in: query
+ *         name: pageSize
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *           maximum: 100
+ *           default: 20
+ *     responses:
+ *       200:
+ *         description: Vagas em análise retornadas com sucesso
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/AdminEmpresasVagasResponse'
+ *       400:
+ *         description: Parâmetros inválidos
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ValidationErrorResponse'
+ *       401:
+ *         description: Token inválido ou ausente
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/UnauthorizedResponse'
+ *       403:
+ *         description: Acesso negado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ForbiddenResponse'
+ *       404:
+ *         description: Empresa não encontrada
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ */
+router.get(
+  '/:id/vagas/em-analise',
+  supabaseAuthMiddleware(adminRoles),
+  AdminEmpresasController.listVagasEmAnalise,
+);
+
+/**
+ * @openapi
+ * /api/v1/empresas/admin/{id}/vagas/{vagaId}/aprovar:
+ *   post:
+ *     summary: (Admin) Aprovar vaga em análise
+ *     description: "Altera o status da vaga para PUBLICADO caso esteja em análise."
+ *     tags: [Empresas - Admin]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *       - in: path
+ *         name: vagaId
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *     responses:
+ *       200:
+ *         description: Vaga aprovada com sucesso
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/AdminEmpresaVagaAprovacaoResponse'
+ *       400:
+ *         description: Dados inválidos ou vaga em status incorreto
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       401:
+ *         description: Token inválido ou ausente
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/UnauthorizedResponse'
+ *       403:
+ *         description: Acesso negado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ForbiddenResponse'
+ *       404:
+ *         description: Empresa ou vaga não encontrada
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ */
+router.post(
+  '/:id/vagas/:vagaId/aprovar',
+  supabaseAuthMiddleware(adminRoles),
+  AdminEmpresasController.approveVaga,
+);
+
 export { router as adminEmpresasRoutes };


### PR DESCRIPTION
## Resumo
- adicionar modelo de banimento de empresas e relacionamentos no Prisma
- ampliar serviço/admin controller com histórico de pagamentos, vagas, banimentos e aprovação
- documentar novas rotas e esquemas no Swagger para suporte a banimento e auditoria

## Testes
- pnpm prisma:generate
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68cc8054b1588332a07fb17f8f45ecbd