### PR TITLE
feat: incluir contato nas respostas de empresas admin

### DIFF
--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -3361,6 +3361,17 @@ const options: Options = {
             id: { type: 'string', format: 'uuid', example: 'empresa-uuid' },
             codUsuario: { type: 'string', example: 'EMP-123456' },
             nome: { type: 'string', example: 'Advance Tech Consultoria' },
+            email: {
+              type: 'string',
+              format: 'email',
+              example: 'contato@advance.com.br',
+              description: 'E-mail principal cadastrado pela empresa',
+            },
+            telefone: {
+              type: 'string',
+              example: '+55 11 99999-0000',
+              description: 'Telefone de contato informado no cadastro',
+            },
             avatarUrl: { type: 'string', nullable: true, example: 'https://cdn.advance.com.br/logo.png' },
             cnpj: { type: 'string', nullable: true, example: '12345678000190' },
             cidade: { type: 'string', nullable: true, example: 'São Paulo' },
@@ -3608,6 +3619,17 @@ const options: Options = {
             id: { type: 'string', format: 'uuid', example: 'empresa-uuid' },
             codUsuario: { type: 'string', example: 'EMP-123456' },
             nome: { type: 'string', example: 'Advance Tech Consultoria' },
+            email: {
+              type: 'string',
+              format: 'email',
+              example: 'contato@advance.com.br',
+              description: 'E-mail principal cadastrado pela empresa',
+            },
+            telefone: {
+              type: 'string',
+              example: '+55 11 99999-0000',
+              description: 'Telefone de contato informado no cadastro',
+            },
             avatarUrl: { type: 'string', nullable: true, example: 'https://cdn.advance.com.br/logo.png' },
             cnpj: { type: 'string', nullable: true, example: '12345678000190' },
             descricao: {

--- a/src/modules/empresas/admin/services/admin-empresas.service.ts
+++ b/src/modules/empresas/admin/services/admin-empresas.service.ts
@@ -70,6 +70,8 @@ const createUsuarioListSelect = () =>
     id: true,
     codUsuario: true,
     nomeCompleto: true,
+    email: true,
+    telefone: true,
     avatarUrl: true,
     cnpj: true,
     cidade: true,
@@ -98,6 +100,8 @@ const usuarioDetailSelect = {
   id: true,
   codUsuario: true,
   nomeCompleto: true,
+  email: true,
+  telefone: true,
   avatarUrl: true,
   cnpj: true,
   descricao: true,
@@ -145,6 +149,8 @@ type AdminEmpresaListItem = {
   id: string;
   codUsuario: string;
   nome: string;
+  email: string;
+  telefone: string;
   avatarUrl: string | null;
   cnpj: string | null;
   cidade: string | null;
@@ -199,6 +205,8 @@ type AdminEmpresaDetail = {
   id: string;
   codUsuario: string;
   nome: string;
+  email: string;
+  telefone: string;
   avatarUrl: string | null;
   cnpj: string | null;
   descricao: string | null;
@@ -619,6 +627,8 @@ export const adminEmpresasService = {
         id: empresa.id,
         codUsuario: empresa.codUsuario,
         nome: empresa.nomeCompleto,
+        email: empresa.email,
+        telefone: empresa.telefone,
         avatarUrl: empresa.avatarUrl,
         cnpj: empresa.cnpj ?? null,
         cidade: empresa.cidade,
@@ -670,6 +680,8 @@ export const adminEmpresasService = {
       id: empresa.id,
       codUsuario: empresa.codUsuario,
       nome: empresa.nomeCompleto,
+      email: empresa.email,
+      telefone: empresa.telefone,
       avatarUrl: empresa.avatarUrl,
       cnpj: empresa.cnpj ?? null,
       descricao: empresa.descricao,


### PR DESCRIPTION
## Summary
- incluir e-mail e telefone nas respostas de listagem e detalhe da API de Empresas Admin
- documentar os novos campos de contato no Swagger/Redoc para manter os devs alinhados

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68cd5ab3858c8332b583312608bd40e0