### PR TITLE
feat: adicionar título obrigatório nas vagas empresariais

### DIFF
--- a/prisma/migrations/20250215000000_add_titulo_to_vaga/migration.sql
+++ b/prisma/migrations/20250215000000_add_titulo_to_vaga/migration.sql
@@ -1,0 +1,7 @@
+ALTER TABLE "Vaga" ADD COLUMN "titulo" VARCHAR(255);
+
+UPDATE "Vaga"
+SET "titulo" = 'Título pendente'
+WHERE "titulo" IS NULL;
+
+ALTER TABLE "Vaga" ALTER COLUMN "titulo" SET NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -105,6 +105,7 @@ model Vaga {
   modoAnonimo      Boolean        @default(false)
   regimeDeTrabalho RegimeTrabalho
   modalidade       ModalidadeVaga
+  titulo           String         @db.VarChar(255)
   paraPcd          Boolean        @default(false)
   requisitos       String         @db.Text
   atividades       String         @db.Text

--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -3811,6 +3811,12 @@ const options: Options = {
               example: 'B24N56',
               description: 'Identificador curto utilizado pelos administradores para localizar a vaga com rapidez.',
             },
+            titulo: {
+              type: 'string',
+              maxLength: 255,
+              example: 'Analista de Dados Pleno',
+              description: 'Nome público da vaga informado pela empresa no momento do cadastro.',
+            },
             status: { allOf: [{ $ref: '#/components/schemas/StatusVaga' }] },
             inseridaEm: { type: 'string', format: 'date-time', example: '2024-05-10T09:00:00Z' },
             atualizadoEm: { type: 'string', format: 'date-time', example: '2024-05-12T11:30:00Z' },
@@ -3896,6 +3902,11 @@ const options: Options = {
               enum: ['PRESENCIAL', 'REMOTO', 'HIBRIDO'],
               example: 'PRESENCIAL',
             },
+            titulo: {
+              type: 'string',
+              maxLength: 255,
+              example: 'Coordenador de Projetos TI',
+            },
             paraPcd: { type: 'boolean', example: false },
             requisitos: {
               type: 'string',
@@ -3969,6 +3980,7 @@ const options: Options = {
             'usuarioId',
             'regimeDeTrabalho',
             'modalidade',
+            'titulo',
             'requisitos',
             'atividades',
             'beneficios',
@@ -3994,6 +4006,12 @@ const options: Options = {
               type: 'string',
               enum: ['PRESENCIAL', 'REMOTO', 'HIBRIDO'],
               example: 'PRESENCIAL',
+            },
+            titulo: {
+              type: 'string',
+              maxLength: 255,
+              example: 'Analista de Marketing Digital',
+              description: 'Nome da vaga que será exibido nos portais e dashboards administrativos.',
             },
             paraPcd: { type: 'boolean', example: false },
             requisitos: {
@@ -4047,6 +4065,11 @@ const options: Options = {
               type: 'string',
               enum: ['PRESENCIAL', 'REMOTO', 'HIBRIDO'],
               example: 'HIBRIDO',
+            },
+            titulo: {
+              type: 'string',
+              maxLength: 255,
+              example: 'Gerente de Operações',
             },
             paraPcd: { type: 'boolean', example: true },
             requisitos: {

--- a/src/modules/empresas/admin/services/admin-empresas.service.ts
+++ b/src/modules/empresas/admin/services/admin-empresas.service.ts
@@ -192,6 +192,7 @@ type AdminEmpresaPaymentLog = {
 type AdminEmpresaJobResumo = {
   id: string;
   codigo: string;
+  titulo: string;
   status: StatusVaga;
   inseridaEm: Date;
   atualizadoEm: Date;
@@ -804,6 +805,7 @@ export const adminEmpresasService = {
         select: {
           id: true,
           codigo: true,
+          titulo: true,
           status: true,
           inseridaEm: true,
           atualizadoEm: true,
@@ -819,6 +821,7 @@ export const adminEmpresasService = {
     const data: AdminEmpresaJobResumo[] = vagas.map((vaga) => ({
       id: vaga.id,
       codigo: vaga.codigo,
+      titulo: vaga.titulo,
       status: vaga.status,
       inseridaEm: vaga.inseridaEm,
       atualizadoEm: vaga.atualizadoEm,
@@ -870,6 +873,7 @@ export const adminEmpresasService = {
         select: {
           id: true,
           codigo: true,
+          titulo: true,
           status: true,
           inseridaEm: true,
           atualizadoEm: true,
@@ -885,6 +889,7 @@ export const adminEmpresasService = {
     return {
       id: vaga.id,
       codigo: vaga.codigo,
+      titulo: vaga.titulo,
       status: vaga.status,
       inseridaEm: vaga.inseridaEm,
       atualizadoEm: vaga.atualizadoEm,

--- a/src/modules/empresas/vagas/routes/index.ts
+++ b/src/modules/empresas/vagas/routes/index.ts
@@ -200,6 +200,7 @@ router.get('/:id', publicCache, VagasController.get);
  *                  "modoAnonimo": true,
  *                  "regimeDeTrabalho": "CLT",
  *                  "modalidade": "PRESENCIAL",
+ *                  "titulo": "Analista de Sistemas",
  *                  "paraPcd": true,
  *                  "requisitos": "Experiência prévia com atendimento ao cliente e pacote Office.",
  *                  "atividades": "Atendimento ao público, abertura de chamados e acompanhamento de demandas.",

--- a/src/modules/empresas/vagas/services/vagas.service.ts
+++ b/src/modules/empresas/vagas/services/vagas.service.ts
@@ -15,6 +15,7 @@ export type CreateVagaData = {
   modoAnonimo?: boolean;
   regimeDeTrabalho: RegimeTrabalho;
   modalidade: ModalidadeVaga;
+  titulo: string;
   paraPcd?: boolean;
   requisitos: string;
   atividades: string;
@@ -109,6 +110,7 @@ const sanitizeCreateData = (data: CreateVagaData, codigo: string): Prisma.VagaUn
   modoAnonimo: data.modoAnonimo ?? false,
   regimeDeTrabalho: data.regimeDeTrabalho,
   modalidade: data.modalidade,
+  titulo: data.titulo.trim(),
   paraPcd: data.paraPcd ?? false,
   requisitos: data.requisitos.trim(),
   atividades: data.atividades.trim(),
@@ -134,6 +136,9 @@ const sanitizeUpdateData = (data: UpdateVagaData): Prisma.VagaUncheckedUpdateInp
   }
   if (data.modalidade !== undefined) {
     update.modalidade = data.modalidade;
+  }
+  if (data.titulo !== undefined) {
+    update.titulo = data.titulo.trim();
   }
   if (data.paraPcd !== undefined) {
     update.paraPcd = data.paraPcd;

--- a/src/modules/empresas/vagas/validators/vagas.schema.ts
+++ b/src/modules/empresas/vagas/validators/vagas.schema.ts
@@ -31,6 +31,11 @@ const baseVagaSchema = z.object({
     required_error: 'A modalidade da vaga é obrigatória',
     invalid_type_error: 'modalidade inválida',
   }),
+  titulo: z
+    .string({ required_error: 'O título da vaga é obrigatório', invalid_type_error: 'O título da vaga deve ser um texto' })
+    .trim()
+    .min(3, 'O título da vaga deve ter pelo menos 3 caracteres')
+    .max(255, 'O título da vaga deve ter no máximo 255 caracteres'),
   paraPcd: z.boolean({ invalid_type_error: 'paraPcd deve ser verdadeiro ou falso' }).optional(),
   requisitos: longTextField('Os requisitos da vaga'),
   atividades: longTextField('As atividades da vaga'),


### PR DESCRIPTION
## Summary
- adiciona o campo `titulo` como obrigatório no modelo Prisma de vagas e cria a migração correspondente
- atualiza validações, serviços e respostas administrativas para contemplar o nome da vaga
- documenta o novo campo nas definições OpenAPI e nos exemplos de criação de vaga

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68cd9cca9f788332b24ed1c51651a3cb