### PR TITLE
feat: rename enderecos table to usuarios enderecos

### DIFF
--- a/prisma/migrations/20250305000000_rename_enderecos_to_usuarios_enderecos/migration.sql
+++ b/prisma/migrations/20250305000000_rename_enderecos_to_usuarios_enderecos/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Enderecos" RENAME TO "UsuariosEnderecos";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -49,7 +49,7 @@ model Usuarios {
   ultimaTentativaVerificacao DateTime?
 
   // RELACIONAMENTOS EXISTENTES
-  enderecos            Enderecos[]
+  enderecos            UsuariosEnderecos[]
   vagasCriadas         Vagas[]            @relation("UsuarioVagas")
   planosContratados    EmpresaPlano[]     @relation("UsuarioPlanos")
   banimentosRecebidos  EmpresaBanimento[] @relation("EmpresaBanimentosUsuario")
@@ -204,7 +204,7 @@ model PlanoEmpresarial {
   mpPreapprovalPlanId String? @unique
 }
 
-model Enderecos {
+model UsuariosEnderecos {
   id           String   @id @default(uuid())
   usuarioId    String
   logradouro   String?

--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -3387,7 +3387,8 @@ const options: Options = {
         },
         UsuarioEndereco: {
           type: 'object',
-          description: 'Endereço cadastrado para o usuário. Campos podem ser preenchidos parcialmente conforme o fluxo do microserviço de endereços.',
+          description:
+            'Endereço cadastrado para o usuário, persistido na tabela UsuariosEnderecos (anteriormente Enderecos). Campos podem ser preenchidos parcialmente conforme o fluxo do microserviço de endereços.',
           required: ['id'],
           properties: {
             id: { type: 'string', format: 'uuid', example: 'end-uuid' },

--- a/src/modules/empresas/admin/services/admin-empresas.service.ts
+++ b/src/modules/empresas/admin/services/admin-empresas.service.ts
@@ -301,8 +301,8 @@ const upsertEnderecoPrincipal = async (
   usuarioId: string,
   endereco: { cidade?: string | null; estado?: string | null },
 ) => {
-  const dataToUpdate: Prisma.EnderecosUpdateInput = {};
-  const dataToCreate: Prisma.EnderecosUncheckedCreateInput = { usuarioId };
+  const dataToUpdate: Prisma.UsuariosEnderecosUpdateInput = {};
+  const dataToCreate: Prisma.UsuariosEnderecosUncheckedCreateInput = { usuarioId };
 
   let hasDefinedField = false;
   let hasCreateValue = false;
@@ -329,13 +329,13 @@ const upsertEnderecoPrincipal = async (
     return;
   }
 
-  const principalEndereco = await tx.enderecos.findFirst({
+  const principalEndereco = await tx.usuariosEnderecos.findFirst({
     where: { usuarioId },
     orderBy: { criadoEm: 'asc' },
   });
 
   if (principalEndereco) {
-    await tx.enderecos.update({
+    await tx.usuariosEnderecos.update({
       where: { id: principalEndereco.id },
       data: dataToUpdate,
     });
@@ -346,7 +346,7 @@ const upsertEnderecoPrincipal = async (
     return;
   }
 
-  await tx.enderecos.create({
+  await tx.usuariosEnderecos.create({
     data: dataToCreate,
   });
 };

--- a/src/modules/usuarios/utils/address.ts
+++ b/src/modules/usuarios/utils/address.ts
@@ -1,4 +1,4 @@
-import type { Enderecos } from '@prisma/client';
+import type { UsuariosEnderecos } from '@prisma/client';
 
 export interface UsuarioEnderecoDto {
   id: string;
@@ -10,7 +10,7 @@ export interface UsuarioEnderecoDto {
   cep: string | null;
 }
 
-type MaybeEndereco = Partial<UsuarioEnderecoDto> | Enderecos;
+type MaybeEndereco = Partial<UsuarioEnderecoDto> | UsuariosEnderecos;
 
 export const normalizeUsuarioEnderecos = (
   enderecos?: MaybeEndereco[] | null,


### PR DESCRIPTION
## Summary
- rename the Prisma Enderecos model to UsuariosEnderecos and keep user relations aligned
- update services and utilities to consume the new usuariosEnderecos delegate and types
- refresh the migration and API documentation to reflect the UsuariosEnderecos table

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68ced53a79dc8332a492be594e04fe9d