### PR TITLE
feat: rename empresas tables and update api references

### DIFF
--- a/prisma/migrations/20250306000000_rename_empresas_entities/migration.sql
+++ b/prisma/migrations/20250306000000_rename_empresas_entities/migration.sql
@@ -1,0 +1,8 @@
+BEGIN;
+
+ALTER TABLE "Vagas" RENAME TO "EmpresasVagas";
+ALTER TABLE "EmpresaPlano" RENAME TO "EmpresasPlano";
+ALTER TABLE "LogPagamento" RENAME COLUMN "empresaPlanoId" TO "empresasPlanoId";
+ALTER INDEX "LogPagamento_empresaPlanoId_idx" RENAME TO "LogPagamento_empresasPlanoId_idx";
+
+COMMIT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -50,8 +50,8 @@ model Usuarios {
 
   // RELACIONAMENTOS EXISTENTES
   enderecos            UsuariosEnderecos[]
-  vagasCriadas         Vagas[]            @relation("UsuarioVagas")
-  planosContratados    EmpresaPlano[]     @relation("UsuarioPlanos")
+  vagasCriadas         EmpresasVagas[]    @relation("UsuarioVagas")
+  planosContratados    EmpresasPlano[]    @relation("UsuarioPlanos")
   banimentosRecebidos  EmpresaBanimento[] @relation("EmpresaBanimentosUsuario")
   banimentosAplicados  EmpresaBanimento[] @relation("EmpresaBanimentosAdmin")
 
@@ -96,7 +96,7 @@ enum PlanoParceiro {
   PARCEIRO          @map("parceiro")
 }
 
-model Vagas {
+model EmpresasVagas {
   id               String         @id @default(uuid())
   codigo           String         @unique @db.VarChar(6)
   usuarioId        String
@@ -120,7 +120,7 @@ model Vagas {
   @@index([usuarioId])
 }
 
-model EmpresaPlano {
+model EmpresasPlano {
   id                 String        @id @default(uuid())
   usuarioId          String
   planoEmpresarialId String
@@ -151,9 +151,9 @@ model EmpresaPlano {
 }
 
 model LogPagamento {
-  id             String   @id @default(uuid())
-  usuarioId      String?
-  empresaPlanoId String?
+  id              String   @id @default(uuid())
+  usuarioId       String?
+  empresasPlanoId String?
   tipo           String
   status         String?
   externalRef    String?
@@ -163,7 +163,7 @@ model LogPagamento {
   criadoEm       DateTime @default(now())
 
   @@index([usuarioId])
-  @@index([empresaPlanoId])
+  @@index([empresasPlanoId])
   @@index([tipo])
   @@index([criadoEm])
 }
@@ -198,7 +198,7 @@ model PlanoEmpresarial {
   criadoEm                DateTime @default(now())
   atualizadoEm            DateTime @updatedAt
 
-  empresas EmpresaPlano[]
+  empresas EmpresasPlano[]
 
   // Integração Mercado Pago - plano recorrente reutilizável
   mpPreapprovalPlanId String? @unique

--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -111,7 +111,7 @@ const options: Options = {
         description: 'Clientes (empresas) vinculados a planos pagos',
       },
       {
-        name: 'Empresas - Vagas',
+        name: 'Empresas - EmpresasVagas',
         description: 'Administração de vagas corporativas vinculadas às empresas',
       },
       {
@@ -159,7 +159,7 @@ const options: Options = {
         tags: [
           'Empresas - Planos Empresariais',
           'Empresas - Clientes',
-          'Empresas - Vagas',
+          'Empresas - EmpresasVagas',
           'Empresas - Admin',
         ],
       },
@@ -791,7 +791,7 @@ const options: Options = {
             },
           },
         },
-        EmpresaPlan: {
+        EmpresasPlano: {
           type: 'object',
           properties: {
             id: { type: 'string', example: 'plan-uuid' },
@@ -846,7 +846,7 @@ const options: Options = {
             },
           },
         },
-        EmpresaPlanCreateRequest: {
+        EmpresasPlanoCreateRequest: {
           type: 'object',
           required: [
             'nome',
@@ -897,7 +897,7 @@ const options: Options = {
             },
           },
         },
-        EmpresaPlanUpdateRequest: {
+        EmpresasPlanoUpdateRequest: {
           type: 'object',
           properties: {
             nome: { type: 'string', example: 'Plano Atualizado' },
@@ -939,30 +939,30 @@ const options: Options = {
             },
           },
         },
-        EmpresaPlanCreateResponse: {
+        EmpresasPlanoCreateResponse: {
           type: 'object',
           properties: {
             message: { type: 'string', example: 'Plano criado' },
-            plan: { $ref: '#/components/schemas/EmpresaPlan' },
+            plan: { $ref: '#/components/schemas/EmpresasPlano' },
           },
         },
-        EmpresaPlanUpdateResponse: {
+        EmpresasPlanoUpdateResponse: {
           type: 'object',
           properties: {
             message: { type: 'string', example: 'Plano atualizado' },
-            plan: { $ref: '#/components/schemas/EmpresaPlan' },
+            plan: { $ref: '#/components/schemas/EmpresasPlano' },
           },
         },
-        EmpresaPlansResponse: {
+        EmpresasPlanosResponse: {
           type: 'object',
           properties: {
             plans: {
               type: 'array',
-              items: { $ref: '#/components/schemas/EmpresaPlan' },
+              items: { $ref: '#/components/schemas/EmpresasPlano' },
             },
           },
         },
-        EmpresaPlanAssignRequest: {
+        EmpresasPlanoAssignRequest: {
           type: 'object',
           required: ['usuarioId', 'metodoPagamento'],
           properties: {
@@ -993,7 +993,7 @@ const options: Options = {
             },
           },
         },
-        EmpresaPlanAssignment: {
+        EmpresasPlanoAssignment: {
           type: 'object',
           properties: {
             id: { type: 'string', example: 'assignment-uuid' },
@@ -1046,19 +1046,19 @@ const options: Options = {
             },
           },
         },
-        EmpresaPlanAssignResponse: {
+        EmpresasPlanoAssignResponse: {
           type: 'object',
           properties: {
             message: {
               type: 'string',
               example: 'Plano vinculado à empresa',
             },
-            empresaPlano: {
-              $ref: '#/components/schemas/EmpresaPlanAssignment',
+            empresasPlano: {
+              $ref: '#/components/schemas/EmpresasPlanoAssignment',
             },
           },
         },
-        EmpresaPlanUnassignResponse: {
+        EmpresasPlanoUnassignResponse: {
           type: 'object',
           properties: {
             message: {
@@ -3324,7 +3324,7 @@ const options: Options = {
             totalPages: { type: 'integer', example: 6 },
           },
         },
-        AdminEmpresaPlanoResumo: {
+        AdminEmpresasPlanoResumo: {
           type: 'object',
           description: 'Resumo do plano ativo vinculado à empresa',
           required: ['id', 'tipo'],
@@ -3456,7 +3456,7 @@ const options: Options = {
             parceira: { type: 'boolean', example: true },
             diasTesteDisponibilizados: { type: 'integer', nullable: true, example: 30 },
             plano: {
-              allOf: [{ $ref: '#/components/schemas/AdminEmpresaPlanoResumo' }],
+              allOf: [{ $ref: '#/components/schemas/AdminEmpresasPlanoResumo' }],
               nullable: true,
             },
             vagasPublicadas: {
@@ -3536,7 +3536,7 @@ const options: Options = {
             banimentoAtivo: null,
           },
         },
-        AdminEmpresaPlanoInput: {
+        AdminEmpresasPlanoInput: {
           type: 'object',
           required: ['planoEmpresarialId', 'tipo'],
           properties: {
@@ -3571,9 +3571,9 @@ const options: Options = {
             observacao: 'Plano cortesia liberado pelo time comercial',
           },
         },
-        AdminEmpresaPlanoUpdateInput: {
+        AdminEmpresasPlanoUpdateInput: {
           allOf: [
-            { $ref: '#/components/schemas/AdminEmpresaPlanoInput' },
+            { $ref: '#/components/schemas/AdminEmpresasPlanoInput' },
             {
               type: 'object',
               properties: {
@@ -3671,7 +3671,7 @@ const options: Options = {
               description: 'Status inicial da conta da empresa. Padrão: ATIVO',
             },
             plano: {
-              allOf: [{ $ref: '#/components/schemas/AdminEmpresaPlanoInput' }],
+              allOf: [{ $ref: '#/components/schemas/AdminEmpresasPlanoInput' }],
               nullable: true,
               description: 'Dados opcionais para já vincular um plano empresarial ativo',
             },
@@ -3755,7 +3755,7 @@ const options: Options = {
               example: 'ATIVO',
             },
             plano: {
-              allOf: [{ $ref: '#/components/schemas/AdminEmpresaPlanoUpdateInput' }],
+              allOf: [{ $ref: '#/components/schemas/AdminEmpresasPlanoUpdateInput' }],
               nullable: true,
               description: 'Envie null para encerrar o plano atual da empresa',
             },
@@ -3900,7 +3900,7 @@ const options: Options = {
             parceira: { type: 'boolean', example: true },
             diasTesteDisponibilizados: { type: 'integer', nullable: true, example: 30 },
             plano: {
-              allOf: [{ $ref: '#/components/schemas/AdminEmpresaPlanoResumo' }],
+              allOf: [{ $ref: '#/components/schemas/AdminEmpresasPlanoResumo' }],
               nullable: true,
             },
             banimentoAtivo: {
@@ -5154,7 +5154,7 @@ export function setupSwagger(app: Application): void {
               // Empresas - após Website - Header Pages
               'Empresas - Planos Empresariais',
               'Empresas - Clientes',
-              'Empresas - Vagas',
+              'Empresas - EmpresasVagas',
             ];
             const ai = order.indexOf(a);
             const bi = order.indexOf(b);

--- a/src/modules/empresas/clientes/controllers/clientes.controller.ts
+++ b/src/modules/empresas/clientes/controllers/clientes.controller.ts
@@ -8,7 +8,7 @@ import {
   updateClientePlanoSchema,
 } from '@/modules/empresas/clientes/validators/clientes.schema';
 
-const PRISMA_NOT_FOUND_CODE = 'EMPRESA_PLANO_NOT_FOUND';
+const PRISMA_NOT_FOUND_CODE = 'EMPRESAS_PLANO_NOT_FOUND';
 
 export class ClientesController {
   static list = async (req: Request, res: Response) => {

--- a/src/modules/empresas/vagas/routes/index.ts
+++ b/src/modules/empresas/vagas/routes/index.ts
@@ -15,7 +15,7 @@ const updateRoles = [Role.ADMIN, Role.MODERADOR, Role.RECRUTADOR];
  *   get:
  *     summary: Listar vagas publicadas
  *     description: "Retorna as vagas disponíveis para visualização. Por padrão, apenas vagas PUBLICADAS são retornadas. É possível filtrar por status via query string. Consultas envolvendo os status RASCUNHO ou EM_ANALISE exigem autenticação com roles válidas (ADMIN, MODERADOR, EMPRESA, RECRUTADOR ou ALUNO_CANDIDATO)."
- *     tags: [Empresas - Vagas]
+ *     tags: [Empresas - EmpresasVagas]
  *     parameters:
  *       - in: query
  *         name: status
@@ -94,7 +94,7 @@ router.get('/', optionalSupabaseAuth(), publicCache, VagasController.list);
  *   get:
  *     summary: Obter vaga por ID
  *     description: Recupera os detalhes de uma vaga PUBLICADA. O conteúdo é público e preserva o anonimato das empresas quando configurado.
- *     tags: [Empresas - Vagas]
+ *     tags: [Empresas - EmpresasVagas]
  *     parameters:
  *       - in: path
  *         name: id
@@ -134,7 +134,7 @@ router.get('/:id', publicCache, VagasController.get);
  *   post:
  *     summary: Criar uma nova vaga
  *     description: "Disponível para administradores, moderadores, empresas e recrutadores autenticados (roles: ADMIN, MODERADOR, EMPRESA, RECRUTADOR). Permite cadastrar vagas vinculadas a uma empresa, gera um código alfanumérico curto para facilitar a identificação e envia automaticamente o registro para a fila de revisão com status EM_ANALISE."
- *     tags: [Empresas - Vagas]
+ *     tags: [Empresas - EmpresasVagas]
  *     security:
  *       - bearerAuth: []
  *     requestBody:
@@ -218,7 +218,7 @@ router.post('/', supabaseAuthMiddleware(protectedRoles), VagasController.create)
  *   put:
  *     summary: Atualizar vaga
  *     description: "Permite editar os dados de uma vaga existente, incluindo o status do fluxo (RASCUNHO, EM_ANALISE, PUBLICADO ou EXPIRADO). Requer autenticação com perfil autorizado (roles: ADMIN, MODERADOR ou RECRUTADOR)."
- *     tags: [Empresas - Vagas]
+ *     tags: [Empresas - EmpresasVagas]
  *     security:
  *       - bearerAuth: []
  *     parameters:
@@ -292,7 +292,7 @@ router.put('/:id', supabaseAuthMiddleware(updateRoles), VagasController.update);
  *   delete:
  *     summary: Remover vaga
  *     description: "Exclui uma vaga cadastrada. Requer autenticação com perfil autorizado (roles: ADMIN, MODERADOR, EMPRESA ou RECRUTADOR)."
- *     tags: [Empresas - Vagas]
+ *     tags: [Empresas - EmpresasVagas]
  *     security:
  *       - bearerAuth: []
  *     parameters:

--- a/src/modules/mercadopago/assinaturas/cron/boleto-watcher.ts
+++ b/src/modules/mercadopago/assinaturas/cron/boleto-watcher.ts
@@ -17,7 +17,7 @@ async function processPendingBoletos() {
   const maxDays = mercadopagoConfig.settings.boletoWatcherMaxDays || 5;
   const cutoff = new Date(Date.now() - maxDays * 24 * 60 * 60 * 1000);
 
-  const boletos = await prisma.empresaPlano.findMany({
+  const boletos = await prisma.empresasPlano.findMany({
     where: {
       metodoPagamento: METODO_PAGAMENTO.BOLETO,
       statusPagamento: { in: [STATUS_PAGAMENTO.PENDENTE, STATUS_PAGAMENTO.EM_PROCESSAMENTO] },
@@ -62,7 +62,7 @@ async function processPendingBoletos() {
           });
           await assinaturasService.logEvent({
             usuarioId: boleto.usuarioId,
-            empresaPlanoId: boleto.id,
+            empresasPlanoId: boleto.id,
             tipo: 'BOLETO_TIMEOUT_CANCEL',
             status: STATUS_PAGAMENTO.CANCELADO,
             externalRef: boleto.id,

--- a/src/modules/mercadopago/logs/routes/index.ts
+++ b/src/modules/mercadopago/logs/routes/index.ts
@@ -18,7 +18,7 @@ const empresaRoles = ['ADMIN', 'MODERADOR', 'EMPRESA', 'RECRUTADOR'];
  *         name: usuarioId
  *         schema: { type: string, format: uuid }
  *       - in: query
- *         name: empresaPlanoId
+ *         name: empresasPlanoId
  *         schema: { type: string, format: uuid }
  *       - in: query
  *         name: tipo

--- a/src/modules/mercadopago/logs/services/logs.controller.ts
+++ b/src/modules/mercadopago/logs/services/logs.controller.ts
@@ -5,11 +5,11 @@ export const logsController = {
   list: async (req: Request, res: Response) => {
     try {
       const isAdmin = ['ADMIN', 'MODERADOR'].includes((req.user as any)?.role);
-      const { usuarioId, empresaPlanoId, tipo, page, pageSize, startDate, endDate } = req.query as any;
+      const { usuarioId, empresasPlanoId, tipo, page, pageSize, startDate, endDate } = req.query as any;
       const where: any = {};
       if (usuarioId && isAdmin) where.usuarioId = usuarioId;
       if (!isAdmin) where.usuarioId = (req.user as any)?.id;
-      if (empresaPlanoId) where.empresaPlanoId = empresaPlanoId;
+      if (empresasPlanoId) where.empresasPlanoId = empresasPlanoId;
       if (tipo) where.tipo = tipo;
       const range: any = {};
       if (startDate) {


### PR DESCRIPTION
## Summary
- rename the Prisma models and database objects for company job postings and plans, updating the corresponding migration
- propagate the new EmpresasVagas and EmpresasPlano naming across services, controllers, and Mercado Pago integrations
- refresh Swagger/OpenAPI documentation and routes to expose the new resource names throughout the public API

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68ced8701f2483329de29588f1a82e05