### PR TITLE
feat: rename vacancy enums to plural naming

### DIFF
--- a/prisma/migrations/20250307000000_rename_vagas_enums/migration.sql
+++ b/prisma/migrations/20250307000000_rename_vagas_enums/migration.sql
@@ -1,0 +1,3 @@
+-- AlterEnum
+ALTER TYPE "RegimeTrabalho" RENAME TO "RegimesDeTrabalhos";
+ALTER TYPE "ModalidadeVaga" RENAME TO "ModalidadesDeVagas";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -63,7 +63,7 @@ model Usuarios {
   @@index([criadoEm])
 }
 
-enum RegimeTrabalho {
+enum RegimesDeTrabalhos {
   CLT
   TEMPORARIO
   ESTAGIO
@@ -72,7 +72,7 @@ enum RegimeTrabalho {
   JOVEM_APRENDIZ
 }
 
-enum ModalidadeVaga {
+enum ModalidadesDeVagas {
   PRESENCIAL
   REMOTO
   HIBRIDO
@@ -101,8 +101,8 @@ model EmpresasVagas {
   codigo           String         @unique @db.VarChar(6)
   usuarioId        String
   modoAnonimo      Boolean        @default(false)
-  regimeDeTrabalho RegimeTrabalho
-  modalidade       ModalidadeVaga
+  regimeDeTrabalho RegimesDeTrabalhos
+  modalidade       ModalidadesDeVagas
   titulo           String         @db.VarChar(255)
   paraPcd          Boolean        @default(false)
   requisitos       String         @db.Text

--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -3315,6 +3315,18 @@ const options: Options = {
           enum: ['RASCUNHO', 'EM_ANALISE', 'PUBLICADO', 'EXPIRADO'],
           example: 'EM_ANALISE',
         },
+        RegimesDeTrabalhos: {
+          type: 'string',
+          description: 'Formatos de contratação oferecidos pelas empresas nas vagas.',
+          enum: ['CLT', 'TEMPORARIO', 'ESTAGIO', 'PJ', 'HOME_OFFICE', 'JOVEM_APRENDIZ'],
+          example: 'CLT',
+        },
+        ModalidadesDeVagas: {
+          type: 'string',
+          description: 'Modalidades de atuação disponíveis para a vaga.',
+          enum: ['PRESENCIAL', 'REMOTO', 'HIBRIDO'],
+          example: 'REMOTO',
+        },
         PaginationMeta: {
           type: 'object',
           properties: {
@@ -4249,16 +4261,8 @@ const options: Options = {
             atualizadoEm: { type: 'string', format: 'date-time', example: '2024-05-12T11:30:00Z' },
             inscricoesAte: { type: 'string', format: 'date-time', nullable: true, example: '2024-06-01T23:59:59Z' },
             modoAnonimo: { type: 'boolean', example: false },
-            modalidade: {
-              type: 'string',
-              enum: ['PRESENCIAL', 'REMOTO', 'HIBRIDO'],
-              example: 'REMOTO',
-            },
-            regimeDeTrabalho: {
-              type: 'string',
-              enum: ['CLT', 'TEMPORARIO', 'ESTAGIO', 'PJ', 'HOME_OFFICE', 'JOVEM_APRENDIZ'],
-              example: 'CLT',
-            },
+            modalidade: { allOf: [{ $ref: '#/components/schemas/ModalidadesDeVagas' }] },
+            regimeDeTrabalho: { allOf: [{ $ref: '#/components/schemas/RegimesDeTrabalhos' }] },
             paraPcd: { type: 'boolean', example: false },
           },
           example: {
@@ -4372,16 +4376,8 @@ const options: Options = {
               nullable: true,
             },
             modoAnonimo: { type: 'boolean', example: true },
-            regimeDeTrabalho: {
-              type: 'string',
-              enum: ['CLT', 'TEMPORARIO', 'ESTAGIO', 'PJ', 'HOME_OFFICE', 'JOVEM_APRENDIZ'],
-              example: 'CLT',
-            },
-            modalidade: {
-              type: 'string',
-              enum: ['PRESENCIAL', 'REMOTO', 'HIBRIDO'],
-              example: 'PRESENCIAL',
-            },
+            regimeDeTrabalho: { allOf: [{ $ref: '#/components/schemas/RegimesDeTrabalhos' }] },
+            modalidade: { allOf: [{ $ref: '#/components/schemas/ModalidadesDeVagas' }] },
             titulo: {
               type: 'string',
               maxLength: 255,
@@ -4477,16 +4473,8 @@ const options: Options = {
               example: true,
               description: 'Quando verdadeiro, oculta o nome e a logo da empresa nas listagens públicas',
             },
-            regimeDeTrabalho: {
-              type: 'string',
-              enum: ['CLT', 'TEMPORARIO', 'ESTAGIO', 'PJ', 'HOME_OFFICE', 'JOVEM_APRENDIZ'],
-              example: 'CLT',
-            },
-            modalidade: {
-              type: 'string',
-              enum: ['PRESENCIAL', 'REMOTO', 'HIBRIDO'],
-              example: 'PRESENCIAL',
-            },
+            regimeDeTrabalho: { allOf: [{ $ref: '#/components/schemas/RegimesDeTrabalhos' }] },
+            modalidade: { allOf: [{ $ref: '#/components/schemas/ModalidadesDeVagas' }] },
             titulo: {
               type: 'string',
               maxLength: 255,
@@ -4536,16 +4524,8 @@ const options: Options = {
               example: 'f1d7a9c2-4e0b-4f6d-90ad-8c6b84a0f1a1',
             },
             modoAnonimo: { type: 'boolean', example: false },
-            regimeDeTrabalho: {
-              type: 'string',
-              enum: ['CLT', 'TEMPORARIO', 'ESTAGIO', 'PJ', 'HOME_OFFICE', 'JOVEM_APRENDIZ'],
-              example: 'PJ',
-            },
-            modalidade: {
-              type: 'string',
-              enum: ['PRESENCIAL', 'REMOTO', 'HIBRIDO'],
-              example: 'HIBRIDO',
-            },
+            regimeDeTrabalho: { allOf: [{ $ref: '#/components/schemas/RegimesDeTrabalhos' }] },
+            modalidade: { allOf: [{ $ref: '#/components/schemas/ModalidadesDeVagas' }] },
             titulo: {
               type: 'string',
               maxLength: 255,

--- a/src/modules/empresas/admin/services/admin-empresas.service.ts
+++ b/src/modules/empresas/admin/services/admin-empresas.service.ts
@@ -4,10 +4,12 @@ import {
   METODO_PAGAMENTO,
   MODELO_PAGAMENTO,
   STATUS_PAGAMENTO,
+  ModalidadesDeVagas,
   Prisma,
   Role,
   Status,
   StatusVaga,
+  RegimesDeTrabalhos,
   TipoUsuario,
 } from '@prisma/client';
 
@@ -221,8 +223,8 @@ type AdminEmpresaJobResumo = {
   atualizadoEm: Date;
   inscricoesAte: Date | null;
   modoAnonimo: boolean;
-  modalidade: string;
-  regimeDeTrabalho: string;
+  modalidade: ModalidadesDeVagas;
+  regimeDeTrabalho: RegimesDeTrabalhos;
   paraPcd: boolean;
 };
 

--- a/src/modules/empresas/vagas/services/vagas.service.ts
+++ b/src/modules/empresas/vagas/services/vagas.service.ts
@@ -1,6 +1,12 @@
 import { randomUUID } from 'crypto';
 
-import { ModalidadeVaga, Prisma, RegimeTrabalho, StatusVaga, TipoUsuario } from '@prisma/client';
+import {
+  ModalidadesDeVagas,
+  Prisma,
+  RegimesDeTrabalhos,
+  StatusVaga,
+  TipoUsuario,
+} from '@prisma/client';
 
 import { prisma } from '@/config/prisma';
 import { attachEnderecoResumo } from '@/modules/usuarios/utils/address';
@@ -14,8 +20,8 @@ import {
 export type CreateVagaData = {
   usuarioId: string;
   modoAnonimo?: boolean;
-  regimeDeTrabalho: RegimeTrabalho;
-  modalidade: ModalidadeVaga;
+  regimeDeTrabalho: RegimesDeTrabalhos;
+  modalidade: ModalidadesDeVagas;
   titulo: string;
   paraPcd?: boolean;
   requisitos: string;

--- a/src/modules/empresas/vagas/validators/vagas.schema.ts
+++ b/src/modules/empresas/vagas/validators/vagas.schema.ts
@@ -1,4 +1,4 @@
-import { ModalidadeVaga, RegimeTrabalho, StatusVaga } from '@prisma/client';
+import { ModalidadesDeVagas, RegimesDeTrabalhos, StatusVaga } from '@prisma/client';
 import { z } from 'zod';
 
 const longTextField = (field: string) =>
@@ -23,11 +23,11 @@ const baseVagaSchema = z.object({
     .string({ required_error: 'O ID do usuário é obrigatório', invalid_type_error: 'O ID do usuário deve ser uma string' })
     .uuid('O ID do usuário deve ser um UUID válido'),
   modoAnonimo: z.boolean({ invalid_type_error: 'modoAnonimo deve ser verdadeiro ou falso' }).optional(),
-  regimeDeTrabalho: z.nativeEnum(RegimeTrabalho, {
+  regimeDeTrabalho: z.nativeEnum(RegimesDeTrabalhos, {
     required_error: 'O regime de trabalho é obrigatório',
     invalid_type_error: 'regimeDeTrabalho inválido',
   }),
-  modalidade: z.nativeEnum(ModalidadeVaga, {
+  modalidade: z.nativeEnum(ModalidadesDeVagas, {
     required_error: 'A modalidade da vaga é obrigatória',
     invalid_type_error: 'modalidade inválida',
   }),


### PR DESCRIPTION
## Summary
- rename the Prisma enums for vacancy regime and modality to their new plural names
- update the job services, validators, and admin types to rely on the regenerated enum names
- refresh the OpenAPI documentation with shared enum components and reference the new names for Swagger/Redoc

## Testing
- pnpm prisma generate
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68cedcd1759c833282e49212819a10f6