### PR TITLE
feat: rename payment and banishment entities

### DIFF
--- a/prisma/migrations/20250314000000_rename_log_pagamento_banimentos_planos/migration.sql
+++ b/prisma/migrations/20250314000000_rename_log_pagamento_banimentos_planos/migration.sql
@@ -1,0 +1,18 @@
+-- Alterações de renomeação de tabelas e índices para acompanhar os novos nomes de entidades
+ALTER TABLE "LogPagamento" RENAME TO "LogsPagamentosDeAssinaturas";
+ALTER INDEX "LogPagamento_pkey" RENAME TO "LogsPagamentosDeAssinaturas_pkey";
+ALTER INDEX "LogPagamento_usuarioId_idx" RENAME TO "LogsPagamentosDeAssinaturas_usuarioId_idx";
+ALTER INDEX "LogPagamento_empresasPlanoId_idx" RENAME TO "LogsPagamentosDeAssinaturas_empresasPlanoId_idx";
+ALTER INDEX "LogPagamento_tipo_idx" RENAME TO "LogsPagamentosDeAssinaturas_tipo_idx";
+ALTER INDEX "LogPagamento_criadoEm_idx" RENAME TO "LogsPagamentosDeAssinaturas_criadoEm_idx";
+
+ALTER TABLE "EmpresaBanimento" RENAME TO "EmpresasEmBanimentos";
+ALTER INDEX "EmpresaBanimento_pkey" RENAME TO "EmpresasEmBanimentos_pkey";
+ALTER INDEX "EmpresaBanimento_usuarioId_idx" RENAME TO "EmpresasEmBanimentos_usuarioId_idx";
+ALTER INDEX "EmpresaBanimento_fim_idx" RENAME TO "EmpresasEmBanimentos_fim_idx";
+ALTER TABLE "EmpresasEmBanimentos" RENAME CONSTRAINT "EmpresaBanimento_usuarioId_fkey" TO "EmpresasEmBanimentos_usuarioId_fkey";
+ALTER TABLE "EmpresasEmBanimentos" RENAME CONSTRAINT "EmpresaBanimento_criadoPorId_fkey" TO "EmpresasEmBanimentos_criadoPorId_fkey";
+
+ALTER TABLE "PlanoEmpresarial" RENAME TO "PlanosEmpresariais";
+ALTER INDEX "PlanoEmpresarial_pkey" RENAME TO "PlanosEmpresariais_pkey";
+ALTER INDEX "PlanoEmpresarial_mpPreapprovalPlanId_key" RENAME TO "PlanosEmpresariais_mpPreapprovalPlanId_key";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -52,8 +52,8 @@ model Usuarios {
   enderecos            UsuariosEnderecos[]
   vagasCriadas         EmpresasVagas[]    @relation("UsuarioVagas")
   planosContratados    EmpresasPlano[]    @relation("UsuarioPlanos")
-  banimentosRecebidos  EmpresaBanimento[] @relation("EmpresaBanimentosUsuario")
-  banimentosAplicados  EmpresaBanimento[] @relation("EmpresaBanimentosAdmin")
+  banimentosRecebidos  EmpresasEmBanimentos[] @relation("EmpresaBanimentosUsuario")
+  banimentosAplicados  EmpresasEmBanimentos[] @relation("EmpresaBanimentosAdmin")
 
   @@index([tokenRecuperacao])
   @@index([emailVerificationToken])
@@ -144,13 +144,13 @@ model EmpresasPlano {
   graceUntil       DateTime?
 
   empresa Usuarios         @relation("UsuarioPlanos", fields: [usuarioId], references: [id], onDelete: Cascade)
-  plano   PlanoEmpresarial @relation(fields: [planoEmpresarialId], references: [id])
+  plano   PlanosEmpresariais @relation(fields: [planoEmpresarialId], references: [id])
 
   @@index([usuarioId, ativo])
   @@index([planoEmpresarialId])
 }
 
-model LogPagamento {
+model LogsPagamentosDeAssinaturas {
   id              String   @id @default(uuid())
   usuarioId       String?
   empresasPlanoId String?
@@ -168,7 +168,7 @@ model LogPagamento {
   @@index([criadoEm])
 }
 
-model EmpresaBanimento {
+model EmpresasEmBanimentos {
   id          String   @id @default(uuid())
   usuarioId   String
   criadoPorId String
@@ -185,7 +185,7 @@ model EmpresaBanimento {
   @@index([fim])
 }
 
-model PlanoEmpresarial {
+model PlanosEmpresariais {
   id                      String   @id @default(uuid())
   icon                    String
   nome                    String

--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -3009,7 +3009,7 @@ const options: Options = {
             },
           },
         },
-        PlanoEmpresarial: {
+        PlanosEmpresariais: {
           type: 'object',
           properties: {
             id: { type: 'string', example: 'plano-uuid' },
@@ -3054,7 +3054,7 @@ const options: Options = {
             },
           },
         },
-        PlanoEmpresarialCreateInput: {
+        PlanosEmpresariaisCreateInput: {
           type: 'object',
           required: ['icon', 'nome', 'descricao', 'valor', 'quantidadeVagas', 'vagaEmDestaque'],
           properties: {
@@ -3101,7 +3101,7 @@ const options: Options = {
             },
           },
         },
-        PlanoEmpresarialUpdateInput: {
+        PlanosEmpresariaisUpdateInput: {
           type: 'object',
           properties: {
             icon: { type: 'string', example: 'ph-shield-check' },
@@ -3139,7 +3139,7 @@ const options: Options = {
             },
           },
         },
-        PlanoEmpresarialLimitResponse: {
+        PlanosEmpresariaisLimitResponse: {
           type: 'object',
           properties: {
             success: { type: 'boolean', example: false },
@@ -3239,7 +3239,7 @@ const options: Options = {
               allOf: [{ $ref: '#/components/schemas/ClientePlanoEmpresa' }],
               nullable: true,
             },
-            plano: { $ref: '#/components/schemas/PlanoEmpresarial' },
+            plano: { $ref: '#/components/schemas/PlanosEmpresariais' },
           },
         },
         EmpresaClientePlanoCreateInput: {
@@ -3488,7 +3488,7 @@ const options: Options = {
               description: 'Indica se a empresa possui um banimento ativo no momento da consulta',
             },
             banimentoAtivo: {
-              allOf: [{ $ref: '#/components/schemas/AdminEmpresaBanimentoResumo' }],
+              allOf: [{ $ref: '#/components/schemas/AdminEmpresasEmBanimentosResumo' }],
               nullable: true,
             },
           },
@@ -3502,17 +3502,6 @@ const options: Options = {
             cnpj: '12345678000190',
             cidade: 'São Paulo',
             estado: 'SP',
-            enderecos: [
-              {
-                id: 'end-uuid',
-                logradouro: 'Av. Paulista',
-                numero: '1578',
-                bairro: 'Bela Vista',
-                cidade: 'São Paulo',
-                estado: 'SP',
-                cep: '01310-200',
-              },
-            ],
             enderecos: [
               {
                 id: 'end-uuid',
@@ -3916,7 +3905,7 @@ const options: Options = {
               nullable: true,
             },
             banimentoAtivo: {
-              allOf: [{ $ref: '#/components/schemas/AdminEmpresaBanimentoResumo' }],
+              allOf: [{ $ref: '#/components/schemas/AdminEmpresasEmBanimentosResumo' }],
               nullable: true,
             },
             vagas: {
@@ -4057,7 +4046,7 @@ const options: Options = {
             },
           },
         },
-        AdminEmpresaBanimentoResumo: {
+        AdminEmpresasEmBanimentosResumo: {
           type: 'object',
           description: 'Informações resumidas sobre um banimento aplicado à empresa',
           required: ['id', 'dias', 'inicio', 'fim', 'criadoEm'],
@@ -4169,7 +4158,7 @@ const options: Options = {
           properties: {
             data: {
               type: 'array',
-              items: { $ref: '#/components/schemas/AdminEmpresaBanimentoResumo' },
+              items: { $ref: '#/components/schemas/AdminEmpresasEmBanimentosResumo' },
             },
             pagination: { allOf: [{ $ref: '#/components/schemas/PaginationMeta' }] },
           },
@@ -4192,7 +4181,7 @@ const options: Options = {
             },
           },
         },
-        AdminEmpresaBanimentoCreate: {
+        AdminEmpresasEmBanimentosCreate: {
           type: 'object',
           required: ['dias'],
           properties: {
@@ -4210,11 +4199,11 @@ const options: Options = {
             },
           },
         },
-        AdminEmpresaBanimentoResponse: {
+        AdminEmpresasEmBanimentosResponse: {
           type: 'object',
           required: ['banimento'],
           properties: {
-            banimento: { $ref: '#/components/schemas/AdminEmpresaBanimentoResumo' },
+            banimento: { $ref: '#/components/schemas/AdminEmpresasEmBanimentosResumo' },
           },
           example: {
             banimento: {

--- a/src/modules/empresas/admin/routes/index.ts
+++ b/src/modules/empresas/admin/routes/index.ts
@@ -525,7 +525,7 @@ router.get(
  *       content:
  *         application/json:
  *           schema:
- *             $ref: '#/components/schemas/AdminEmpresaBanimentoCreate'
+ *             $ref: '#/components/schemas/AdminEmpresasEmBanimentosCreate'
  *           examples:
  *             default:
  *               summary: Banimento de 30 dias com motivo
@@ -538,7 +538,7 @@ router.get(
  *         content:
  *           application/json:
  *             schema:
- *               $ref: '#/components/schemas/AdminEmpresaBanimentoResponse'
+ *               $ref: '#/components/schemas/AdminEmpresasEmBanimentosResponse'
  *             examples:
  *               created:
  *                 summary: Banimento registrado

--- a/src/modules/empresas/planos-empresarial/controllers/planos-empresariais.controller.ts
+++ b/src/modules/empresas/planos-empresarial/controllers/planos-empresariais.controller.ts
@@ -3,12 +3,12 @@ import { ZodError } from 'zod';
 
 import {
   MAX_PLANOS_EMPRESARIAIS,
-  PlanoEmpresarialLimitError,
+  PlanosEmpresariaisLimitError,
   planosEmpresariaisService,
 } from '@/modules/empresas/planos-empresarial/services/planos-empresariais.service';
 import {
-  createPlanoEmpresarialSchema,
-  updatePlanoEmpresarialSchema,
+  createPlanosEmpresariaisSchema,
+  updatePlanosEmpresariaisSchema,
 } from '@/modules/empresas/planos-empresarial/validators/planos-empresariais.schema';
 
 export class PlanosEmpresariaisController {
@@ -52,7 +52,7 @@ export class PlanosEmpresariaisController {
 
   static create = async (req: Request, res: Response) => {
     try {
-      const data = createPlanoEmpresarialSchema.parse(req.body);
+      const data = createPlanosEmpresariaisSchema.parse(req.body);
       const plano = await planosEmpresariaisService.create(data);
       res.status(201).json(plano);
     } catch (error: any) {
@@ -65,7 +65,7 @@ export class PlanosEmpresariaisController {
         });
       }
 
-      if (error instanceof PlanoEmpresarialLimitError) {
+      if (error instanceof PlanosEmpresariaisLimitError) {
         return res.status(409).json({
           success: false,
           code: 'PLANOS_EMPRESARIAIS_LIMIT_REACHED',
@@ -86,7 +86,7 @@ export class PlanosEmpresariaisController {
   static update = async (req: Request, res: Response) => {
     try {
       const { id } = req.params;
-      const data = updatePlanoEmpresarialSchema.parse(req.body);
+      const data = updatePlanosEmpresariaisSchema.parse(req.body);
 
       if (Object.keys(data).length === 0) {
         return res.status(400).json({

--- a/src/modules/empresas/planos-empresarial/routes/index.ts
+++ b/src/modules/empresas/planos-empresarial/routes/index.ts
@@ -8,7 +8,7 @@ const router = Router();
 
 /**
  * @openapi
- * /api/v1/empresas/planos-empresarial:
+ * /api/v1/empresas/planos-empresariais:
  *   get:
  *     summary: Listar planos empresariais disponíveis
  *     description: "Retorna todos os planos empresariais configurados, incluindo regras de publicação de vagas. A tabela está limitada a no máximo 4 registros. Endpoint público, não requer autenticação."
@@ -21,7 +21,7 @@ const router = Router();
  *             schema:
  *               type: array
  *               items:
- *                 $ref: '#/components/schemas/PlanoEmpresarial'
+ *                 $ref: '#/components/schemas/PlanosEmpresariais'
  *       500:
  *         description: Erro interno do servidor
  *         content:
@@ -32,13 +32,13 @@ const router = Router();
  *       - lang: cURL
  *         label: Exemplo
  *         source: |
- *           curl -X GET "http://localhost:3000/api/v1/empresas/planos-empresarial"
+ *           curl -X GET "http://localhost:3000/api/v1/empresas/planos-empresariais"
  */
 router.get('/', publicCache, PlanosEmpresariaisController.list);
 
 /**
  * @openapi
- * /api/v1/empresas/planos-empresarial/{id}:
+ * /api/v1/empresas/planos-empresariais/{id}:
  *   get:
  *     summary: Obter plano empresarial por ID
  *     tags: [Empresas - Planos Empresariais]
@@ -54,7 +54,7 @@ router.get('/', publicCache, PlanosEmpresariaisController.list);
  *         content:
  *           application/json:
  *             schema:
- *               $ref: '#/components/schemas/PlanoEmpresarial'
+ *               $ref: '#/components/schemas/PlanosEmpresariais'
  *       404:
  *         description: Plano não encontrado
  *         content:
@@ -71,13 +71,13 @@ router.get('/', publicCache, PlanosEmpresariaisController.list);
  *       - lang: cURL
  *         label: Exemplo
  *         source: |
- *           curl -X GET "http://localhost:3000/api/v1/empresas/planos-empresarial/{id}"
+ *           curl -X GET "http://localhost:3000/api/v1/empresas/planos-empresariais/{id}"
  */
 router.get('/:id', publicCache, PlanosEmpresariaisController.get);
 
 /**
  * @openapi
- * /api/v1/empresas/planos-empresarial:
+ * /api/v1/empresas/planos-empresariais:
  *   post:
  *     summary: Criar um novo plano empresarial
  *     description: "Disponível apenas para administradores e moderadores (roles: ADMIN, MODERADOR). A criação respeita o limite máximo de 4 planos ativos e permite definir descontos percentuais e regras de publicação de vagas."
@@ -89,14 +89,14 @@ router.get('/:id', publicCache, PlanosEmpresariaisController.get);
  *       content:
  *         application/json:
  *           schema:
- *             $ref: '#/components/schemas/PlanoEmpresarialCreateInput'
+ *             $ref: '#/components/schemas/PlanosEmpresariaisCreateInput'
  *     responses:
  *       201:
  *         description: Plano empresarial criado com sucesso
  *         content:
  *           application/json:
  *             schema:
- *               $ref: '#/components/schemas/PlanoEmpresarial'
+ *               $ref: '#/components/schemas/PlanosEmpresariais'
  *       400:
  *         description: Dados inválidos
  *         content:
@@ -120,7 +120,7 @@ router.get('/:id', publicCache, PlanosEmpresariaisController.get);
  *         content:
  *           application/json:
  *             schema:
- *               $ref: '#/components/schemas/PlanoEmpresarialLimitResponse'
+ *               $ref: '#/components/schemas/PlanosEmpresariaisLimitResponse'
  *       500:
  *         description: Erro interno do servidor
  *         content:
@@ -131,7 +131,7 @@ router.get('/:id', publicCache, PlanosEmpresariaisController.get);
  *       - lang: cURL
  *         label: Exemplo
  *         source: |
- *           curl -X POST "http://localhost:3000/api/v1/empresas/planos-empresarial" \
+ *           curl -X POST "http://localhost:3000/api/v1/empresas/planos-empresariais" \
  *            -H "Authorization: Bearer <TOKEN>" \
  *            -H "Content-Type: application/json" \
  *            -d '{
@@ -149,7 +149,7 @@ router.post('/', supabaseAuthMiddleware(['ADMIN', 'MODERADOR']), PlanosEmpresari
 
 /**
  * @openapi
- * /api/v1/empresas/planos-empresarial/{id}:
+ * /api/v1/empresas/planos-empresariais/{id}:
  *   put:
  *     summary: Atualizar plano empresarial
  *     description: "Disponível apenas para administradores e moderadores (roles: ADMIN, MODERADOR)."
@@ -167,14 +167,14 @@ router.post('/', supabaseAuthMiddleware(['ADMIN', 'MODERADOR']), PlanosEmpresari
  *       content:
  *         application/json:
  *           schema:
- *             $ref: '#/components/schemas/PlanoEmpresarialUpdateInput'
+ *             $ref: '#/components/schemas/PlanosEmpresariaisUpdateInput'
  *     responses:
  *       200:
  *         description: Plano empresarial atualizado
  *         content:
  *           application/json:
  *             schema:
- *               $ref: '#/components/schemas/PlanoEmpresarial'
+ *               $ref: '#/components/schemas/PlanosEmpresariais'
  *       400:
  *         description: Dados inválidos
  *         content:
@@ -209,7 +209,7 @@ router.post('/', supabaseAuthMiddleware(['ADMIN', 'MODERADOR']), PlanosEmpresari
  *       - lang: cURL
  *         label: Exemplo
  *         source: |
- *           curl -X PUT "http://localhost:3000/api/v1/empresas/planos-empresarial/{id}" \
+ *           curl -X PUT "http://localhost:3000/api/v1/empresas/planos-empresariais/{id}" \
  *            -H "Authorization: Bearer <TOKEN>" \
  *            -H "Content-Type: application/json" \
  *            -d '{
@@ -223,7 +223,7 @@ router.put('/:id', supabaseAuthMiddleware(['ADMIN', 'MODERADOR']), PlanosEmpresa
 
 /**
  * @openapi
- * /api/v1/empresas/planos-empresarial/{id}:
+ * /api/v1/empresas/planos-empresariais/{id}:
  *   delete:
  *     summary: Remover plano empresarial
  *     description: "Disponível apenas para administradores e moderadores (roles: ADMIN, MODERADOR)."
@@ -267,7 +267,7 @@ router.put('/:id', supabaseAuthMiddleware(['ADMIN', 'MODERADOR']), PlanosEmpresa
  *       - lang: cURL
  *         label: Exemplo
  *         source: |
- *           curl -X DELETE "http://localhost:3000/api/v1/empresas/planos-empresarial/{id}" \
+ *           curl -X DELETE "http://localhost:3000/api/v1/empresas/planos-empresariais/{id}" \
  *            -H "Authorization: Bearer <TOKEN>"
  */
 router.delete('/:id', supabaseAuthMiddleware(['ADMIN', 'MODERADOR']), PlanosEmpresariaisController.remove);

--- a/src/modules/empresas/planos-empresarial/services/planos-empresariais.service.ts
+++ b/src/modules/empresas/planos-empresarial/services/planos-empresariais.service.ts
@@ -4,14 +4,14 @@ import { prisma } from '@/config/prisma';
 
 export const MAX_PLANOS_EMPRESARIAIS = 4;
 
-export class PlanoEmpresarialLimitError extends Error {
+export class PlanosEmpresariaisLimitError extends Error {
   constructor() {
     super(`Limite máximo de ${MAX_PLANOS_EMPRESARIAIS} planos empresariais atingido`);
-    this.name = 'PlanoEmpresarialLimitError';
+    this.name = 'PlanosEmpresariaisLimitError';
   }
 }
 
-type CreatePlanoEmpresarialData = {
+type CreatePlanosEmpresariaisData = {
   icon: string;
   nome: string;
   descricao: string;
@@ -22,9 +22,11 @@ type CreatePlanoEmpresarialData = {
   quantidadeVagasDestaque?: number | null;
 };
 
-type UpdatePlanoEmpresarialData = Partial<CreatePlanoEmpresarialData>;
+type UpdatePlanosEmpresariaisData = Partial<CreatePlanosEmpresariaisData>;
 
-const sanitizeCreateData = (data: CreatePlanoEmpresarialData): Prisma.PlanoEmpresarialUncheckedCreateInput => ({
+const sanitizeCreateData = (
+  data: CreatePlanosEmpresariaisData,
+): Prisma.PlanosEmpresariaisUncheckedCreateInput => ({
   icon: data.icon.trim(),
   nome: data.nome.trim(),
   descricao: data.descricao.trim(),
@@ -36,9 +38,9 @@ const sanitizeCreateData = (data: CreatePlanoEmpresarialData): Prisma.PlanoEmpre
 });
 
 const sanitizeUpdateData = (
-  data: UpdatePlanoEmpresarialData,
-): Prisma.PlanoEmpresarialUncheckedUpdateInput => {
-  const update: Prisma.PlanoEmpresarialUncheckedUpdateInput = {};
+  data: UpdatePlanosEmpresariaisData,
+): Prisma.PlanosEmpresariaisUncheckedUpdateInput => {
+  const update: Prisma.PlanosEmpresariaisUncheckedUpdateInput = {};
 
   if (data.icon !== undefined) {
     update.icon = data.icon.trim();
@@ -74,23 +76,23 @@ const sanitizeUpdateData = (
 
 export const planosEmpresariaisService = {
   list: () =>
-    prisma.planoEmpresarial.findMany({
+    prisma.planosEmpresariais.findMany({
       orderBy: { criadoEm: 'asc' },
     }),
 
-  get: (id: string) => prisma.planoEmpresarial.findUnique({ where: { id } }),
+  get: (id: string) => prisma.planosEmpresariais.findUnique({ where: { id } }),
 
-  create: async (data: CreatePlanoEmpresarialData) => {
-    const totalPlanos = await prisma.planoEmpresarial.count();
+  create: async (data: CreatePlanosEmpresariaisData) => {
+    const totalPlanos = await prisma.planosEmpresariais.count();
     if (totalPlanos >= MAX_PLANOS_EMPRESARIAIS) {
-      throw new PlanoEmpresarialLimitError();
+      throw new PlanosEmpresariaisLimitError();
     }
 
-    return prisma.planoEmpresarial.create({ data: sanitizeCreateData(data) });
+    return prisma.planosEmpresariais.create({ data: sanitizeCreateData(data) });
   },
 
-  update: (id: string, data: UpdatePlanoEmpresarialData) =>
-    prisma.planoEmpresarial.update({ where: { id }, data: sanitizeUpdateData(data) }),
+  update: (id: string, data: UpdatePlanosEmpresariaisData) =>
+    prisma.planosEmpresariais.update({ where: { id }, data: sanitizeUpdateData(data) }),
 
-  remove: (id: string) => prisma.planoEmpresarial.delete({ where: { id } }),
+  remove: (id: string) => prisma.planosEmpresariais.delete({ where: { id } }),
 };

--- a/src/modules/empresas/planos-empresarial/validators/planos-empresariais.schema.ts
+++ b/src/modules/empresas/planos-empresarial/validators/planos-empresariais.schema.ts
@@ -126,7 +126,7 @@ const quantidadeVagasDestaqueSchema = z.preprocess(
   ]),
 );
 
-const planoEmpresarialSchema = z
+const planosEmpresariaisSchema = z
   .object({
     icon: z.string().trim().min(1, 'O ícone do plano é obrigatório'),
     nome: z.string().trim().min(1, 'O nome do plano é obrigatório'),
@@ -139,7 +139,7 @@ const planoEmpresarialSchema = z
   })
   .strict();
 
-const validatePlanoRegras = (data: z.infer<typeof planoEmpresarialSchema>, ctx: RefinementCtx) => {
+const validatePlanoRegras = (data: z.infer<typeof planosEmpresariaisSchema>, ctx: RefinementCtx) => {
   if (data.vagaEmDestaque) {
     if (data.quantidadeVagasDestaque === undefined || data.quantidadeVagasDestaque === null) {
       ctx.addIssue({
@@ -163,9 +163,9 @@ const validatePlanoRegras = (data: z.infer<typeof planoEmpresarialSchema>, ctx: 
   }
 };
 
-export const createPlanoEmpresarialSchema = planoEmpresarialSchema.superRefine(validatePlanoRegras);
+export const createPlanosEmpresariaisSchema = planosEmpresariaisSchema.superRefine(validatePlanoRegras);
 
-export const updatePlanoEmpresarialSchema = planoEmpresarialSchema
+export const updatePlanosEmpresariaisSchema = planosEmpresariaisSchema
   .partial()
   .superRefine((data, ctx) => {
     if (data.vagaEmDestaque === true) {
@@ -200,5 +200,5 @@ export const updatePlanoEmpresarialSchema = planoEmpresarialSchema
     }
   });
 
-export type CreatePlanoEmpresarialInput = z.infer<typeof createPlanoEmpresarialSchema>;
-export type UpdatePlanoEmpresarialInput = z.infer<typeof updatePlanoEmpresarialSchema>;
+export type CreatePlanosEmpresariaisInput = z.infer<typeof createPlanosEmpresariaisSchema>;
+export type UpdatePlanosEmpresariaisInput = z.infer<typeof updatePlanosEmpresariaisSchema>;

--- a/src/modules/empresas/routes/index.ts
+++ b/src/modules/empresas/routes/index.ts
@@ -7,7 +7,7 @@ import { adminEmpresasRoutes } from '@/modules/empresas/admin';
 
 const router = Router();
 
-router.use('/planos-empresarial', planosEmpresariaisRoutes);
+router.use('/planos-empresariais', planosEmpresariaisRoutes);
 // Rota oficial para clientes (empresas vinculadas a planos pagos)
 router.use('/clientes', clientesRoutes);
 router.use('/vagas', vagasRoutes);

--- a/src/modules/mercadopago/assinaturas/controllers/assinaturas.controller.ts
+++ b/src/modules/mercadopago/assinaturas/controllers/assinaturas.controller.ts
@@ -120,7 +120,7 @@ export class AssinaturasController {
     try {
       // Busca todos os planos e cria/garante preapprovalPlan
       const { prisma } = await import('../../../../config/prisma.js');
-      const planos = await prisma.planoEmpresarial.findMany({ select: { id: true, mpPreapprovalPlanId: true } });
+      const planos = await prisma.planosEmpresariais.findMany({ select: { id: true, mpPreapprovalPlanId: true } });
       const results: Record<string, string> = {};
       for (const p of planos) {
         try {

--- a/src/modules/mercadopago/assinaturas/routes/index.ts
+++ b/src/modules/mercadopago/assinaturas/routes/index.ts
@@ -194,7 +194,7 @@ router.post('/admin/remind-payment', supabaseAuthMiddleware(adminRoles), Assinat
  * /api/v1/mercadopago/assinaturas/admin/sync-plans:
  *   post:
  *     summary: (Admin) Sincronizar Planos Empresariais com PreApprovalPlan
- *     description: "Cria/garante um PreApprovalPlan no Mercado Pago para cada PlanoEmpresarial e salva o id (mpPreapprovalPlanId)."
+ *     description: "Cria/garante um PreApprovalPlan no Mercado Pago para cada PlanosEmpresariais e salva o id (mpPreapprovalPlanId)."
  *     tags: [MercadoPago - Assinaturas]
  *     security:
  *       - bearerAuth: []
@@ -209,7 +209,7 @@ router.post('/admin/sync-plans', supabaseAuthMiddleware(adminRoles), Assinaturas
  * /api/v1/mercadopago/assinaturas/admin/sync-plan:
  *   post:
  *     summary: (Admin) Sincronizar um plano empresarial com PreApprovalPlan
- *     description: "Cria/garante um PreApprovalPlan no Mercado Pago para o PlanoEmpresarial informado."
+ *     description: "Cria/garante um PreApprovalPlan no Mercado Pago para o PlanosEmpresariais informado."
  *     tags: [MercadoPago - Assinaturas]
  *     security:
  *       - bearerAuth: []

--- a/src/modules/mercadopago/logs/services/logs.controller.ts
+++ b/src/modules/mercadopago/logs/services/logs.controller.ts
@@ -30,8 +30,8 @@ export const logsController = {
       const take = pageSize ? Math.min(100, Math.max(1, parseInt(pageSize))) : 20;
       const skip = page ? (Math.max(1, parseInt(page)) - 1) * take : 0;
       const [items, total] = await Promise.all([
-        prisma.logPagamento.findMany({ where, orderBy: { criadoEm: 'desc' }, take, skip }),
-        prisma.logPagamento.count({ where }),
+        prisma.logsPagamentosDeAssinaturas.findMany({ where, orderBy: { criadoEm: 'desc' }, take, skip }),
+        prisma.logsPagamentosDeAssinaturas.count({ where }),
       ]);
       res.json({ items, total, page: page ? parseInt(page) : 1, pageSize: take });
     } catch (error: any) {
@@ -41,7 +41,7 @@ export const logsController = {
   get: async (req: Request, res: Response) => {
     try {
       const isAdmin = ['ADMIN', 'MODERADOR'].includes((req.user as any)?.role);
-      const item = await prisma.logPagamento.findUnique({ where: { id: req.params.id } });
+      const item = await prisma.logsPagamentosDeAssinaturas.findUnique({ where: { id: req.params.id } });
       if (!item) return res.status(404).json({ success: false, code: 'LOG_NOT_FOUND' });
       if (!isAdmin && item.usuarioId !== (req.user as any)?.id) {
         return res.status(403).json({ success: false, code: 'FORBIDDEN' });

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -76,7 +76,7 @@ router.get('/', publicCache, (req, res) => {
       brevo: '/api/v1/brevo',
       website: '/api/v1/website',
       empresas: '/api/v1/empresas',
-      planosEmpresariais: '/api/v1/empresas/planos-empresarial',
+      planosEmpresariais: '/api/v1/empresas/planos-empresariais',
       clientesEmpresas: '/api/v1/empresas/clientes',
       vagasEmpresariais: '/api/v1/empresas/vagas',
       mercadopagoAssinaturas: '/api/v1/mercadopago/assinaturas',


### PR DESCRIPTION
## Summary
- rename Prisma models to LogsPagamentosDeAssinaturas, EmpresasEmBanimentos and PlanosEmpresariais and add a migration to rename the existing tables and indexes
- align admin services, Mercado Pago flows and plan management modules with the new model names and helpers
- refresh Express routes and Swagger/OpenAPI documentation to expose the new entity naming across the API

## Testing
- pnpm build
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68cef1fe96388332b00e1446ff3e1568