### PR TITLE
refactor: rename user type and slider enums

### DIFF
--- a/prisma/migrations/20250310000000_rename_user_type_and_slider_enums/migration.sql
+++ b/prisma/migrations/20250310000000_rename_user_type_and_slider_enums/migration.sql
@@ -1,0 +1,3 @@
+-- AlterEnum
+ALTER TYPE "TipoUsuario" RENAME TO "TiposDeUsuarios";
+ALTER TYPE "SliderOrientation" RENAME TO "WebsiteSlidersOrientations";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -25,7 +25,7 @@ model Usuarios {
   instagram     String?
   linkedin      String?
   codUsuario    String      @unique
-  tipoUsuario   TipoUsuario
+  tipoUsuario   TiposDeUsuarios
   role          Role
   status        Status      @default(ATIVO)
   aceitarTermos Boolean     @default(false)
@@ -387,7 +387,7 @@ model WebsiteSliderOrdem {
   id              String            @id @default(uuid())
   websiteSliderId String            @unique
   ordem           Int
-  orientacao      SliderOrientation
+  orientacao      WebsiteSlidersOrientations
   status          WebsiteStatus     @default(RASCUNHO)
   criadoEm        DateTime          @default(now())
 
@@ -614,7 +614,7 @@ model WebsiteHeaderPage {
 // ENUMS EXISTENTES
 // =============================================
 
-enum TipoUsuario {
+enum TiposDeUsuarios {
   PESSOA_FISICA
   PESSOA_JURIDICA
 }
@@ -666,7 +666,7 @@ enum StatusSMS {
 
 // Métodos de pagamento aceitos para planos
 
-enum SliderOrientation {
+enum WebsiteSlidersOrientations {
   DESKTOP
   TABLET_MOBILE
 }

--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -186,6 +186,19 @@ const options: Options = {
           example: 'PIX',
           description: 'Meios de pagamento aceitos',
         },
+        TiposDeUsuarios: {
+          type: 'string',
+          enum: ['PESSOA_FISICA', 'PESSOA_JURIDICA'],
+          example: 'PESSOA_FISICA',
+          description: 'Enum TiposDeUsuarios utilizado para classificar pessoas físicas e jurídicas.',
+        },
+        WebsiteSlidersOrientations: {
+          type: 'string',
+          enum: ['DESKTOP', 'TABLET_MOBILE'],
+          example: 'DESKTOP',
+          description:
+            'Enum WebsiteSlidersOrientations que determina em quais orientações os sliders são exibidos.',
+        },
         CheckoutMetodo: {
           type: 'string',
           enum: ['pagamento', 'assinatura'],
@@ -445,10 +458,8 @@ const options: Options = {
               example: 'uuid-supabase',
             },
             tipoUsuario: {
-              type: 'string',
-              description: 'Tipo do usuário',
-              enum: ['PESSOA_FISICA', 'PESSOA_JURIDICA'],
-              example: 'PESSOA_FISICA',
+              allOf: [{ $ref: '#/components/schemas/TiposDeUsuarios' }],
+              description: 'Tipo do usuário representado pelo enum TiposDeUsuarios.',
             },
           },
         },
@@ -499,8 +510,7 @@ const options: Options = {
               example: 'ADMIN',
             },
             tipoUsuario: {
-              type: 'string',
-              example: 'PESSOA_FISICA',
+              allOf: [{ $ref: '#/components/schemas/TiposDeUsuarios' }],
             },
             supabaseId: { type: 'string', example: 'uuid-supabase' },
             emailVerificado: { type: 'boolean', example: true },
@@ -1431,9 +1441,8 @@ const options: Options = {
               example: 'https://example.com',
             },
             orientacao: {
-              type: 'string',
-              enum: ['DESKTOP', 'TABLET_MOBILE'],
-              description: 'Orientação em que o slider será exibido',
+              allOf: [{ $ref: '#/components/schemas/WebsiteSlidersOrientations' }],
+              description: 'Orientação em que o slider será exibido.',
               example: 'DESKTOP',
             },
             status: {
@@ -1491,9 +1500,8 @@ const options: Options = {
               example: 'https://example.com',
             },
             orientacao: {
-              type: 'string',
-              enum: ['DESKTOP', 'TABLET_MOBILE'],
-              description: 'Orientação em que o slider será exibido',
+              allOf: [{ $ref: '#/components/schemas/WebsiteSlidersOrientations' }],
+              description: 'Orientação em que o slider será exibido.',
               example: 'DESKTOP',
             },
             status: {
@@ -1530,9 +1538,8 @@ const options: Options = {
               example: 'https://example.com',
             },
             orientacao: {
-              type: 'string',
-              enum: ['DESKTOP', 'TABLET_MOBILE'],
-              description: 'Orientação em que o slider será exibido',
+              allOf: [{ $ref: '#/components/schemas/WebsiteSlidersOrientations' }],
+              description: 'Orientação em que o slider será exibido.',
               example: 'TABLET_MOBILE',
             },
             status: {
@@ -4594,7 +4601,10 @@ const options: Options = {
             nomeCompleto: { type: 'string', example: 'João da Silva' },
             role: { type: 'string', example: 'ALUNO' },
             status: { type: 'string', example: 'ATIVO' },
-            tipoUsuario: { type: 'string', example: 'ALUNO' },
+            tipoUsuario: {
+              allOf: [{ $ref: '#/components/schemas/TiposDeUsuarios' }],
+              example: 'PESSOA_FISICA',
+            },
             criadoEm: {
               type: 'string',
               format: 'date-time',
@@ -4629,8 +4639,7 @@ const options: Options = {
               example: 'ATIVO',
             },
             tipoUsuario: {
-              type: 'string',
-              enum: ['PESSOA_FISICA', 'PESSOA_JURIDICA'],
+              allOf: [{ $ref: '#/components/schemas/TiposDeUsuarios' }],
               example: 'PESSOA_FISICA',
             },
             cidade: { type: 'string', nullable: true, example: 'Maceió' },

--- a/src/modules/empresas/admin/services/admin-empresas.service.ts
+++ b/src/modules/empresas/admin/services/admin-empresas.service.ts
@@ -10,7 +10,7 @@ import {
   Status,
   StatusDeVagas,
   RegimesDeTrabalhos,
-  TipoUsuario,
+  TiposDeUsuarios,
 } from '@prisma/client';
 
 import { prisma } from '@/config/prisma';
@@ -453,7 +453,7 @@ const ensureEmpresaExiste = async (db: PrismaUsuarioClient, id: string) => {
     select: { id: true, tipoUsuario: true },
   });
 
-  if (!empresa || empresa.tipoUsuario !== TipoUsuario.PESSOA_JURIDICA) {
+  if (!empresa || empresa.tipoUsuario !== TiposDeUsuarios.PESSOA_JURIDICA) {
     throw Object.assign(new Error('Empresa não encontrada'), { code: 'EMPRESA_NOT_FOUND' });
   }
 };
@@ -574,7 +574,7 @@ export const adminEmpresasService = {
           senha: senhaHash,
           aceitarTermos,
           supabaseId: sanitizeSupabaseId(input.supabaseId),
-          tipoUsuario: TipoUsuario.PESSOA_JURIDICA,
+          tipoUsuario: TiposDeUsuarios.PESSOA_JURIDICA,
           role: Role.EMPRESA,
           status,
           codUsuario,
@@ -677,7 +677,7 @@ export const adminEmpresasService = {
 
   list: async ({ page, pageSize, search }: AdminEmpresasListQuery) => {
     const where: Prisma.UsuariosWhereInput = {
-      tipoUsuario: TipoUsuario.PESSOA_JURIDICA,
+      tipoUsuario: TiposDeUsuarios.PESSOA_JURIDICA,
       ...buildSearchFilter(search),
     };
 
@@ -738,7 +738,7 @@ export const adminEmpresasService = {
       select: usuarioDetailSelect,
     });
 
-    if (!empresaRecord || empresaRecord.tipoUsuario !== TipoUsuario.PESSOA_JURIDICA) {
+    if (!empresaRecord || empresaRecord.tipoUsuario !== TiposDeUsuarios.PESSOA_JURIDICA) {
       return null;
     }
 

--- a/src/modules/empresas/clientes/services/clientes.service.ts
+++ b/src/modules/empresas/clientes/services/clientes.service.ts
@@ -1,4 +1,4 @@
-import { TiposDePlanos, Prisma, TipoUsuario } from '@prisma/client';
+import { TiposDePlanos, Prisma, TiposDeUsuarios } from '@prisma/client';
 
 import { prisma } from '@/config/prisma';
 import { attachEnderecoResumo } from '@/modules/usuarios/utils/address';
@@ -69,7 +69,7 @@ const ensureUsuarioEmpresa = async (usuarioId: string) => {
     select: { tipoUsuario: true },
   });
 
-  if (!usuario || usuario.tipoUsuario !== TipoUsuario.PESSOA_JURIDICA) {
+  if (!usuario || usuario.tipoUsuario !== TiposDeUsuarios.PESSOA_JURIDICA) {
     throw Object.assign(new Error('Usuário informado não é uma empresa válida'), {
       code: 'USUARIO_NAO_EMPRESA',
     });
@@ -83,7 +83,9 @@ const transformarPlano = (plano: EmpresasPlanoWithRelations) => {
     plano.fim && plano.fim > now ? Math.ceil((plano.fim.getTime() - now.getTime()) / 86400000) : null;
 
   const empresaUsuarioRaw =
-    plano.empresa && plano.empresa.tipoUsuario === TipoUsuario.PESSOA_JURIDICA ? plano.empresa : null;
+    plano.empresa && plano.empresa.tipoUsuario === TiposDeUsuarios.PESSOA_JURIDICA
+      ? plano.empresa
+      : null;
   const empresaUsuario = empresaUsuarioRaw ? attachEnderecoResumo(empresaUsuarioRaw)! : null;
 
   const empresa = empresaUsuario

--- a/src/modules/empresas/vagas/services/vagas.service.ts
+++ b/src/modules/empresas/vagas/services/vagas.service.ts
@@ -5,7 +5,7 @@ import {
   Prisma,
   RegimesDeTrabalhos,
   StatusDeVagas,
-  TipoUsuario,
+  TiposDeUsuarios,
 } from '@prisma/client';
 
 import { prisma } from '@/config/prisma';
@@ -195,7 +195,9 @@ const transformVaga = (vaga: VagaWithEmpresa) => {
   if (!vaga) return null;
 
   const empresaUsuarioRaw =
-    vaga.empresa && vaga.empresa.tipoUsuario === TipoUsuario.PESSOA_JURIDICA ? vaga.empresa : null;
+    vaga.empresa && vaga.empresa.tipoUsuario === TiposDeUsuarios.PESSOA_JURIDICA
+      ? vaga.empresa
+      : null;
   const empresaUsuario = empresaUsuarioRaw ? attachEnderecoResumo(empresaUsuarioRaw)! : null;
 
   const displayName = vaga.modoAnonimo
@@ -240,7 +242,7 @@ const ensurePlanoAtivoParaUsuario = async (usuarioId: string) => {
     select: { tipoUsuario: true },
   });
 
-  if (!usuarioEmpresa || usuarioEmpresa.tipoUsuario !== TipoUsuario.PESSOA_JURIDICA) {
+  if (!usuarioEmpresa || usuarioEmpresa.tipoUsuario !== TiposDeUsuarios.PESSOA_JURIDICA) {
     throw new UsuarioNaoEmpresaError();
   }
 

--- a/src/modules/usuarios/enums/TiposDeUsuarios.ts
+++ b/src/modules/usuarios/enums/TiposDeUsuarios.ts
@@ -3,7 +3,7 @@
  * PESSOA_FISICA: Usuários individuais (CPF)
  * PESSOA_JURIDICA: Empresas/organizações (CNPJ)
  */
-export enum TipoUsuario {
+export enum TiposDeUsuarios {
   PESSOA_FISICA = 'PESSOA_FISICA',
   PESSOA_JURIDICA = 'PESSOA_JURIDICA',
 }

--- a/src/modules/usuarios/enums/index.ts
+++ b/src/modules/usuarios/enums/index.ts
@@ -1,4 +1,4 @@
-export { TipoUsuario } from './TipoUsuario';
+export { TiposDeUsuarios } from './TiposDeUsuarios';
 export { Role } from './Role';
 export { Status } from './Status';
 export { Genero } from './Genero';

--- a/src/modules/usuarios/register/register-controller.ts
+++ b/src/modules/usuarios/register/register-controller.ts
@@ -4,7 +4,7 @@ import { prisma } from '../../../config/prisma';
 import { invalidateCacheByPrefix } from '../../../utils/cache';
 import { invalidateUserCache } from '../utils/cache';
 import { Prisma } from '@prisma/client';
-import { TipoUsuario, Role } from '../enums';
+import { TiposDeUsuarios, Role } from '../enums';
 import {
   validarCPF,
   validarCNPJ,
@@ -124,7 +124,7 @@ export const criarUsuario = async (req: Request, res: Response, next: NextFuncti
     const normalizedRole =
       role && Object.values(Role).includes(role)
         ? role
-        : tipoUsuario === TipoUsuario.PESSOA_JURIDICA
+        : tipoUsuario === TiposDeUsuarios.PESSOA_JURIDICA
           ? Role.EMPRESA
           : Role.ALUNO_CANDIDATO;
 
@@ -227,7 +227,7 @@ export const criarUsuario = async (req: Request, res: Response, next: NextFuncti
     );
 
     // Resposta de sucesso
-    const userTypeLabel = tipoUsuario === TipoUsuario.PESSOA_FISICA ? 'Pessoa física' : 'Empresa';
+    const userTypeLabel = tipoUsuario === TiposDeUsuarios.PESSOA_FISICA ? 'Pessoa física' : 'Empresa';
 
     res.status(201).json({
       success: true,
@@ -283,7 +283,7 @@ async function processUserTypeSpecificData(
   try {
     const { tipoUsuario } = dadosUsuario;
 
-    if (tipoUsuario === TipoUsuario.PESSOA_FISICA) {
+    if (tipoUsuario === TiposDeUsuarios.PESSOA_FISICA) {
       const dadosPF = dadosUsuario as CriarPessoaFisicaData;
 
       // Validações específicas para Pessoa Física
@@ -336,7 +336,7 @@ async function processUserTypeSpecificData(
         dataNascimento,
         generoValidado,
       };
-    } else if (tipoUsuario === TipoUsuario.PESSOA_JURIDICA) {
+    } else if (tipoUsuario === TiposDeUsuarios.PESSOA_JURIDICA) {
       const dadosPJ = dadosUsuario as CriarPessoaJuridicaData;
 
       // Validações específicas para Pessoa Jurídica
@@ -475,7 +475,7 @@ function buildUserDataForDatabase(params: {
   email: string;
   senha: string;
   telefone: string;
-  tipoUsuario: TipoUsuario;
+  tipoUsuario: TiposDeUsuarios;
   role: Role;
   aceitarTermos: boolean;
   supabaseId: string;
@@ -548,7 +548,7 @@ async function createUserWithTransaction(userData: any, correlationId: string) {
         select: userSelect,
       });
 
-      if (userData.tipoUsuario === TipoUsuario.PESSOA_JURIDICA) {
+      if (userData.tipoUsuario === TiposDeUsuarios.PESSOA_JURIDICA) {
         log.info({ userId: usuario.id }, '🏢 Usuário registrado como pessoa jurídica');
       }
 

--- a/src/modules/usuarios/services/admin-service.ts
+++ b/src/modules/usuarios/services/admin-service.ts
@@ -5,7 +5,7 @@
  * @author Sistema Advance+
  * @version 3.0.0
  */
-import { Prisma, Role, Status, TipoUsuario } from '@prisma/client';
+import { Prisma, Role, Status, TiposDeUsuarios } from '@prisma/client';
 import { z } from 'zod';
 
 import { prisma } from '@/config/prisma';
@@ -43,8 +43,8 @@ export class AdminService {
     if (!tipoUsuario) return undefined;
 
     const normalized = tipoUsuario.trim().toUpperCase();
-    if (normalized in TipoUsuario) {
-      return TipoUsuario[normalized as keyof typeof TipoUsuario];
+    if (normalized in TiposDeUsuarios) {
+      return TiposDeUsuarios[normalized as keyof typeof TiposDeUsuarios];
     }
 
     return undefined;

--- a/src/modules/usuarios/validators/auth.schema.ts
+++ b/src/modules/usuarios/validators/auth.schema.ts
@@ -1,5 +1,5 @@
 import { z, type ZodError } from 'zod';
-import { Role, Status, TipoUsuario } from '../enums';
+import { Role, Status, TiposDeUsuarios } from '../enums';
 
 export const loginSchema = z.object({
   documento: z
@@ -31,14 +31,14 @@ const baseRegisterSchema = z.object({
 });
 
 const pessoaFisicaRegisterSchema = baseRegisterSchema.extend({
-  tipoUsuario: z.literal(TipoUsuario.PESSOA_FISICA),
+  tipoUsuario: z.literal(TiposDeUsuarios.PESSOA_FISICA),
   cpf: z.string({ required_error: 'CPF é obrigatório' }).min(1, 'CPF é obrigatório'),
   dataNasc: z.string().optional(),
   genero: z.string().optional(),
 });
 
 const pessoaJuridicaRegisterSchema = baseRegisterSchema.extend({
-  tipoUsuario: z.literal(TipoUsuario.PESSOA_JURIDICA),
+  tipoUsuario: z.literal(TiposDeUsuarios.PESSOA_JURIDICA),
   cnpj: z.string({ required_error: 'CNPJ é obrigatório' }).min(1, 'CNPJ é obrigatório'),
 });
 

--- a/src/modules/website/services/slider.service.ts
+++ b/src/modules/website/services/slider.service.ts
@@ -1,4 +1,4 @@
-import { SliderOrientation, WebsiteStatus } from '@prisma/client';
+import { WebsiteSlidersOrientations, WebsiteStatus } from '@prisma/client';
 import { prisma } from '@/config/prisma';
 import { getCache, setCache, invalidateCache } from '@/utils/cache';
 import { WEBSITE_CACHE_TTL } from '@/modules/website/config';
@@ -55,7 +55,7 @@ export const sliderService = {
     sliderName: string;
     imagemUrl: string;
     link?: string;
-    orientacao: SliderOrientation;
+    orientacao: WebsiteSlidersOrientations;
     status?: WebsiteStatus;
   }) => {
     const max = await prisma.websiteSliderOrdem.aggregate({
@@ -102,7 +102,7 @@ export const sliderService = {
       sliderName?: string;
       imagemUrl?: string;
       link?: string;
-      orientacao?: SliderOrientation;
+      orientacao?: WebsiteSlidersOrientations;
       status?: WebsiteStatus;
       ordem?: number;
     },


### PR DESCRIPTION
## Summary
- rename the Prisma enums for user type and slider orientation to TiposDeUsuarios and WebsiteSlidersOrientations
- update application services, validators and website slider logic to consume the new enum names
- refresh Swagger/Redoc documentation to reuse the renamed enums and describe them via dedicated schemas
- add a database migration to rename the underlying PostgreSQL enum types

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68cefba44b988332a905273ae0bd2e41