### PR TITLE
feat: separar estado de verificação de e-mail dos usuários

### DIFF
--- a/prisma/migrations/20240709120000_split_email_verification_table/migration.sql
+++ b/prisma/migrations/20240709120000_split_email_verification_table/migration.sql
@@ -1,0 +1,44 @@
+-- CreateTable
+CREATE TABLE "UsuariosVerificacaoEmail" (
+    "usuarioId" UUID NOT NULL,
+    "emailVerificado" BOOLEAN NOT NULL DEFAULT false,
+    "emailVerificadoEm" TIMESTAMP(3),
+    "emailVerificationToken" TEXT,
+    "emailVerificationTokenExp" TIMESTAMP(3),
+    "emailVerificationAttempts" INTEGER NOT NULL DEFAULT 0,
+    "ultimaTentativaVerificacao" TIMESTAMP(3),
+    CONSTRAINT "UsuariosVerificacaoEmail_pkey" PRIMARY KEY ("usuarioId"),
+    CONSTRAINT "UsuariosVerificacaoEmail_usuarioId_fkey" FOREIGN KEY ("usuarioId") REFERENCES "Usuarios"("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- Migrate existing verification data
+INSERT INTO "UsuariosVerificacaoEmail" (
+    "usuarioId",
+    "emailVerificado",
+    "emailVerificadoEm",
+    "emailVerificationToken",
+    "emailVerificationTokenExp",
+    "emailVerificationAttempts",
+    "ultimaTentativaVerificacao"
+)
+SELECT
+    "id",
+    COALESCE("emailVerificado", false),
+    "emailVerificadoEm",
+    "emailVerificationToken",
+    "emailVerificationTokenExp",
+    COALESCE("emailVerificationAttempts", 0),
+    "ultimaTentativaVerificacao"
+FROM "Usuarios";
+
+-- Drop legacy columns from Usuarios
+ALTER TABLE "Usuarios" DROP COLUMN "emailVerificado";
+ALTER TABLE "Usuarios" DROP COLUMN "emailVerificadoEm";
+ALTER TABLE "Usuarios" DROP COLUMN "emailVerificationToken";
+ALTER TABLE "Usuarios" DROP COLUMN "emailVerificationTokenExp";
+ALTER TABLE "Usuarios" DROP COLUMN "emailVerificationAttempts";
+ALTER TABLE "Usuarios" DROP COLUMN "ultimaTentativaVerificacao";
+
+-- Indexes for the new table
+CREATE UNIQUE INDEX "UsuariosVerificacaoEmail_emailVerificationToken_key" ON "UsuariosVerificacaoEmail"("emailVerificationToken");
+CREATE INDEX "UsuariosVerificacaoEmail_emailVerificationTokenExp_idx" ON "UsuariosVerificacaoEmail"("emailVerificationTokenExp");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -32,14 +32,6 @@ model Usuarios {
   ultimoLogin   DateTime?
   refreshToken  String?
 
-  // CAMPOS PARA VERIFICAÇÃO DE EMAIL (NOVOS)
-  emailVerificado            Boolean   @default(false)
-  emailVerificadoEm          DateTime?
-  emailVerificationToken     String?   @unique
-  emailVerificationTokenExp  DateTime?
-  emailVerificationAttempts  Int       @default(0)
-  ultimaTentativaVerificacao DateTime?
-
   // RELACIONAMENTOS EXISTENTES
   enderecos            UsuariosEnderecos[]
   vagasCriadas         EmpresasVagas[]    @relation("UsuarioVagas")
@@ -48,12 +40,27 @@ model Usuarios {
   banimentosAplicados  EmpresasEmBanimentos[] @relation("EmpresasEmBanimentosAdmin")
   redesSociais         UsuariosRedesSociais?
   recuperacaoSenha     UsuariosRecuperacaoSenha?
+  emailVerification    UsuariosVerificacaoEmail?
 
-  @@index([emailVerificationToken])
   @@index([status])
   @@index([role])
   @@index([tipoUsuario])
   @@index([criadoEm])
+}
+
+model UsuariosVerificacaoEmail {
+  usuarioId                  String   @id
+  emailVerificado            Boolean  @default(false)
+  emailVerificadoEm          DateTime?
+  emailVerificationToken     String?  @unique
+  emailVerificationTokenExp  DateTime?
+  emailVerificationAttempts  Int      @default(0)
+  ultimaTentativaVerificacao DateTime?
+
+  usuario Usuarios @relation(fields: [usuarioId], references: [id], onDelete: Cascade)
+
+  @@index([emailVerificationToken])
+  @@index([emailVerificationTokenExp])
 }
 
 model UsuariosRecuperacaoSenha {

--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -536,6 +536,38 @@ const options: Options = {
             },
             supabaseId: { type: 'string', example: 'uuid-supabase' },
             emailVerificado: { type: 'boolean', example: true },
+            emailVerificadoEm: {
+              type: 'string',
+              format: 'date-time',
+              nullable: true,
+              example: '2024-01-01T12:00:00Z',
+            },
+            emailVerification: {
+              type: 'object',
+              description: 'Detalhes completos da verificação de email',
+              properties: {
+                verified: { type: 'boolean', example: true },
+                verifiedAt: {
+                  type: 'string',
+                  format: 'date-time',
+                  nullable: true,
+                  example: '2024-01-01T12:00:00Z',
+                },
+                tokenExpiration: {
+                  type: 'string',
+                  format: 'date-time',
+                  nullable: true,
+                  example: '2024-01-02T12:00:00Z',
+                },
+                attempts: { type: 'integer', example: 2 },
+                lastAttemptAt: {
+                  type: 'string',
+                  format: 'date-time',
+                  nullable: true,
+                  example: '2024-01-01T13:00:00Z',
+                },
+              },
+            },
             ultimoLogin: {
               type: 'string',
               format: 'date-time',
@@ -743,6 +775,32 @@ const options: Options = {
                   type: 'string',
                   format: 'date-time',
                   example: '2024-01-01T12:00:00Z',
+                },
+                emailVerification: {
+                  type: 'object',
+                  description: 'Informações detalhadas de verificação',
+                  properties: {
+                    verified: { type: 'boolean', example: false },
+                    verifiedAt: {
+                      type: 'string',
+                      format: 'date-time',
+                      nullable: true,
+                      example: null,
+                    },
+                    tokenExpiration: {
+                      type: 'string',
+                      format: 'date-time',
+                      nullable: true,
+                      example: '2024-01-01T12:00:00Z',
+                    },
+                    attempts: { type: 'integer', example: 1 },
+                    lastAttemptAt: {
+                      type: 'string',
+                      format: 'date-time',
+                      nullable: true,
+                      example: '2024-01-01T10:00:00Z',
+                    },
+                  },
                 },
               },
             },

--- a/src/modules/usuarios/routes/usuario-routes.ts
+++ b/src/modules/usuarios/routes/usuario-routes.ts
@@ -598,6 +598,13 @@ router.post(
  *               tipoUsuario: "PESSOA_FISICA"
  *               supabaseId: "uuid-supabase"
  *               emailVerificado: true
+  *               emailVerificadoEm: "2024-01-01T12:00:00Z"
+  *               emailVerification:
+  *                 verified: true
+  *                 verifiedAt: "2024-01-01T12:00:00Z"
+  *                 tokenExpiration: "2024-01-02T12:00:00Z"
+  *                 attempts: 1
+  *                 lastAttemptAt: "2024-01-01T12:30:00Z"
  *               ultimoLogin: "2024-01-01T12:00:00Z"
  *       401:
  *         description: Não autenticado

--- a/src/modules/usuarios/services/user-cleanup-service.ts
+++ b/src/modules/usuarios/services/user-cleanup-service.ts
@@ -10,9 +10,13 @@ const cleanupLogger = logger.child({ module: 'UserCleanupService' });
 export async function deleteExpiredUnverifiedUsers(): Promise<number> {
   const result = await prisma.usuarios.deleteMany({
     where: {
-      emailVerificado: false,
-      emailVerificationTokenExp: {
-        lt: new Date(),
+      emailVerification: {
+        is: {
+          emailVerificado: false,
+          emailVerificationTokenExp: {
+            lt: new Date(),
+          },
+        },
       },
     },
   });

--- a/src/modules/usuarios/utils/email-verification.ts
+++ b/src/modules/usuarios/utils/email-verification.ts
@@ -1,0 +1,54 @@
+import type { UsuariosVerificacaoEmail } from '@prisma/client';
+
+export const emailVerificationSelect = {
+  emailVerificado: true,
+  emailVerificadoEm: true,
+  emailVerificationToken: true,
+  emailVerificationTokenExp: true,
+  emailVerificationAttempts: true,
+  ultimaTentativaVerificacao: true,
+} as const;
+
+export type EmailVerificationSelection = Pick<
+  UsuariosVerificacaoEmail,
+  | 'emailVerificado'
+  | 'emailVerificadoEm'
+  | 'emailVerificationToken'
+  | 'emailVerificationTokenExp'
+  | 'emailVerificationAttempts'
+  | 'ultimaTentativaVerificacao'
+>;
+
+export type NormalizedEmailVerification = {
+  emailVerificado: boolean;
+  emailVerificadoEm: Date | null;
+  emailVerificationToken: string | null;
+  emailVerificationTokenExp: Date | null;
+  emailVerificationAttempts: number;
+  ultimaTentativaVerificacao: Date | null;
+};
+
+export const normalizeEmailVerification = (
+  verification?: Partial<EmailVerificationSelection> | null,
+): NormalizedEmailVerification => ({
+  emailVerificado: verification?.emailVerificado ?? false,
+  emailVerificadoEm: verification?.emailVerificadoEm ?? null,
+  emailVerificationToken: verification?.emailVerificationToken ?? null,
+  emailVerificationTokenExp: verification?.emailVerificationTokenExp ?? null,
+  emailVerificationAttempts: verification?.emailVerificationAttempts ?? 0,
+  ultimaTentativaVerificacao: verification?.ultimaTentativaVerificacao ?? null,
+});
+
+export const buildEmailVerificationSummary = (
+  verification?: Partial<EmailVerificationSelection> | null,
+) => {
+  const normalized = normalizeEmailVerification(verification);
+  return {
+    verified: normalized.emailVerificado,
+    verifiedAt: normalized.emailVerificadoEm,
+    token: normalized.emailVerificationToken,
+    tokenExpiration: normalized.emailVerificationTokenExp,
+    attempts: normalized.emailVerificationAttempts,
+    lastAttemptAt: normalized.ultimaTentativaVerificacao,
+  };
+};


### PR DESCRIPTION
## Summary
- extrai os campos de verificação de e-mail para a nova tabela `UsuariosVerificacaoEmail` e adiciona a migration correspondente
- adiciona utilitário para normalizar dados de verificação e atualiza serviços/controllers do Brevo e de usuários para usar a nova relação
- documenta o novo bloco `emailVerification` no Swagger/Redoc e ajusta as respostas das rotas de usuários e Brevo

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68cf0e6f61b88332970e28890fbaf796