### PR TITLE
feat: isolate usuario information in dedicated table

### DIFF
--- a/prisma/migrations/20250314000000_create_usuarios_information/migration.sql
+++ b/prisma/migrations/20250314000000_create_usuarios_information/migration.sql
@@ -1,0 +1,59 @@
+BEGIN;
+
+-- Create auxiliary table for user profile information
+CREATE TABLE IF NOT EXISTS "UsuariosInformation" (
+  "usuarioId" TEXT NOT NULL,
+  "telefone" TEXT NOT NULL,
+  "genero" TEXT,
+  "dataNasc" TIMESTAMP(3),
+  "matricula" TEXT,
+  "avatarUrl" TEXT,
+  "descricao" VARCHAR(500),
+  "aceitarTermos" BOOLEAN NOT NULL DEFAULT FALSE,
+  CONSTRAINT "UsuariosInformation_pkey" PRIMARY KEY ("usuarioId"),
+  CONSTRAINT "UsuariosInformation_usuarioId_fkey"
+    FOREIGN KEY ("usuarioId") REFERENCES "Usuarios"("id")
+    ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- Copy existing profile data into the new table
+INSERT INTO "UsuariosInformation" (
+  "usuarioId",
+  "telefone",
+  "genero",
+  "dataNasc",
+  "matricula",
+  "avatarUrl",
+  "descricao",
+  "aceitarTermos"
+)
+SELECT
+  "id" AS "usuarioId",
+  COALESCE(NULLIF(TRIM("telefone"), ''), '+55 00 0000-0000') AS "telefone",
+  "genero",
+  "dataNasc",
+  "matricula",
+  "avatarUrl",
+  "descricao",
+  COALESCE("aceitarTermos", FALSE)
+FROM "Usuarios"
+ON CONFLICT ("usuarioId") DO UPDATE
+SET
+  "telefone" = EXCLUDED."telefone",
+  "genero" = EXCLUDED."genero",
+  "dataNasc" = EXCLUDED."dataNasc",
+  "matricula" = EXCLUDED."matricula",
+  "avatarUrl" = EXCLUDED."avatarUrl",
+  "descricao" = EXCLUDED."descricao",
+  "aceitarTermos" = EXCLUDED."aceitarTermos";
+
+-- Remove legacy columns from Usuarios
+ALTER TABLE "Usuarios" DROP COLUMN IF EXISTS "telefone";
+ALTER TABLE "Usuarios" DROP COLUMN IF EXISTS "genero";
+ALTER TABLE "Usuarios" DROP COLUMN IF EXISTS "dataNasc";
+ALTER TABLE "Usuarios" DROP COLUMN IF EXISTS "matricula";
+ALTER TABLE "Usuarios" DROP COLUMN IF EXISTS "avatarUrl";
+ALTER TABLE "Usuarios" DROP COLUMN IF EXISTS "descricao";
+ALTER TABLE "Usuarios" DROP COLUMN IF EXISTS "aceitarTermos";
+
+COMMIT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -9,28 +9,21 @@ datasource db {
 }
 
 model Usuarios {
-  id            String      @id @default(uuid())
-  nomeCompleto  String
-  supabaseId    String      @unique
-  cpf           String?     @unique
-  cnpj          String?     @unique
-  dataNasc      DateTime?
-  telefone      String
-  genero        String?
-  email         String      @unique
-  senha         String
-  matricula     String?
-  avatarUrl     String?
-  descricao     String?     @db.VarChar(500)
-  codUsuario    String      @unique
-  tipoUsuario   TiposDeUsuarios
-  role          Roles
-  status        Status      @default(ATIVO)
-  aceitarTermos Boolean     @default(false)
-  criadoEm      DateTime    @default(now())
-  atualizadoEm  DateTime    @updatedAt
-  ultimoLogin   DateTime?
-  refreshToken  String?
+  id           String      @id @default(uuid())
+  nomeCompleto String
+  supabaseId   String      @unique
+  cpf          String?     @unique
+  cnpj         String?     @unique
+  email        String      @unique
+  senha        String
+  codUsuario   String      @unique
+  tipoUsuario  TiposDeUsuarios
+  role         Roles
+  status       Status      @default(ATIVO)
+  criadoEm     DateTime    @default(now())
+  atualizadoEm DateTime    @updatedAt
+  ultimoLogin  DateTime?
+  refreshToken String?
 
   // RELACIONAMENTOS EXISTENTES
   enderecos            UsuariosEnderecos[]
@@ -41,11 +34,25 @@ model Usuarios {
   redesSociais         UsuariosRedesSociais?
   recuperacaoSenha     UsuariosRecuperacaoSenha?
   emailVerification    UsuariosVerificacaoEmail?
+  informacoes          UsuariosInformation?
 
   @@index([status])
   @@index([role])
   @@index([tipoUsuario])
   @@index([criadoEm])
+}
+
+model UsuariosInformation {
+  usuarioId     String   @id
+  telefone      String
+  genero        String?
+  dataNasc      DateTime?
+  matricula     String?
+  avatarUrl     String?
+  descricao     String?  @db.VarChar(500)
+  aceitarTermos Boolean  @default(false)
+
+  usuario Usuarios @relation(fields: [usuarioId], references: [id], onDelete: Cascade)
 }
 
 model UsuariosVerificacaoEmail {

--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -436,6 +436,10 @@ const options: Options = {
               description: 'Token para renovação de sessão',
               example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...',
             },
+            usuario: {
+              allOf: [{ $ref: '#/components/schemas/UserProfile' }],
+              description: 'Perfil básico retornado no momento da autenticação.',
+            },
           },
         },
         UserRegisterRequest: {
@@ -526,6 +530,15 @@ const options: Options = {
             id: { type: 'string', example: 'b9e1d9b0-7c9f-4d1a-8f2a-1234567890ab' },
             email: { type: 'string', example: 'joao@example.com' },
             nomeCompleto: { type: 'string', example: 'João da Silva' },
+            telefone: { type: 'string', example: '+55 11 99999-0000' },
+            genero: { type: 'string', nullable: true, example: 'MASCULINO' },
+            dataNasc: {
+              type: 'string',
+              format: 'date',
+              nullable: true,
+              example: '1990-01-01',
+            },
+            matricula: { type: 'string', nullable: true, example: 'MAT123' },
             role: {
               allOf: [{ $ref: '#/components/schemas/Roles' }],
               description: 'Role do usuário',
@@ -541,6 +554,32 @@ const options: Options = {
               format: 'date-time',
               nullable: true,
               example: '2024-01-01T12:00:00Z',
+            },
+            cidade: { type: 'string', nullable: true, example: 'São Paulo' },
+            estado: { type: 'string', nullable: true, example: 'SP' },
+            codUsuario: { type: 'string', example: 'ABC1234' },
+            avatarUrl: {
+              type: 'string',
+              nullable: true,
+              example: 'https://cdn.advance.com.br/avatar.png',
+            },
+            descricao: {
+              type: 'string',
+              nullable: true,
+              example: 'Profissional com experiência em atendimento.',
+            },
+            aceitarTermos: { type: 'boolean', example: true },
+            informacoes: {
+              allOf: [{ $ref: '#/components/schemas/UsuarioInformacoes' }],
+              description: 'Dados completos vindos da entidade UsuariosInformation.',
+            },
+            socialLinks: {
+              allOf: [{ $ref: '#/components/schemas/UsuarioSocialLinks' }],
+              nullable: true,
+            },
+            enderecos: {
+              type: 'array',
+              items: { $ref: '#/components/schemas/UsuarioEndereco' },
             },
             emailVerification: {
               type: 'object',
@@ -3280,6 +3319,10 @@ const options: Options = {
               description: 'Retorna null quando a vaga é publicada em modo anônimo.',
             },
             codUsuario: { type: 'string', example: 'ABC1234' },
+            informacoes: {
+              allOf: [{ $ref: '#/components/schemas/UsuarioInformacoes' }],
+              description: 'Dados complementares da empresa obtidos via UsuariosInformation.',
+            },
           },
         },
         EmpresaClientePlano: {
@@ -3492,6 +3535,37 @@ const options: Options = {
             cep: { type: 'string', nullable: true, example: '01310-200' },
           },
         },
+        UsuarioInformacoes: {
+          type: 'object',
+          description:
+            'Informações complementares do usuário persistidas na tabela UsuariosInformation após a refatoração do domínio.',
+          properties: {
+            telefone: { type: 'string', example: '+55 11 99999-0000' },
+            genero: { type: 'string', nullable: true, example: 'MASCULINO' },
+            dataNasc: {
+              type: 'string',
+              format: 'date',
+              nullable: true,
+              example: '1990-01-01',
+            },
+            matricula: { type: 'string', nullable: true, example: 'MAT123' },
+            avatarUrl: {
+              type: 'string',
+              nullable: true,
+              example: 'https://cdn.advance.com.br/avatar.png',
+            },
+            descricao: {
+              type: 'string',
+              nullable: true,
+              example: 'Consultoria especializada em tecnologia e recrutamento.',
+            },
+            aceitarTermos: {
+              type: 'boolean',
+              example: true,
+              description: 'Indica se o usuário aceitou os termos e políticas vigentes.',
+            },
+          },
+        },
         UsuarioSocialLinks: {
           type: 'object',
           description: 'Links de redes sociais associados ao usuário ou empresa.',
@@ -3624,6 +3698,10 @@ const options: Options = {
               items: { $ref: '#/components/schemas/UsuarioEndereco' },
             },
             criadoEm: { type: 'string', format: 'date-time', example: '2024-01-05T12:00:00Z' },
+            informacoes: {
+              allOf: [{ $ref: '#/components/schemas/UsuarioInformacoes' }],
+              description: 'Dados complementares consolidados da tabela UsuariosInformation.',
+            },
             ativa: { type: 'boolean', example: true },
             parceira: { type: 'boolean', example: true },
             diasTesteDisponibilizados: { type: 'integer', nullable: true, example: 30 },
@@ -4047,6 +4125,10 @@ const options: Options = {
               type: 'string',
               nullable: true,
               example: 'Consultoria especializada em recrutamento e seleção para empresas de tecnologia.',
+            },
+            informacoes: {
+              allOf: [{ $ref: '#/components/schemas/UsuarioInformacoes' }],
+              description: 'Dados complementares da empresa conforme armazenados em UsuariosInformation.',
             },
             socialLinks: {
               allOf: [{ $ref: '#/components/schemas/UsuarioSocialLinks' }],
@@ -4520,6 +4602,10 @@ const options: Options = {
               nullable: true,
             },
             codUsuario: { type: 'string', example: 'ABC1234' },
+            informacoes: {
+              allOf: [{ $ref: '#/components/schemas/UsuarioInformacoes' }],
+              description: 'Dados complementares utilizados para montar a exibição da empresa na vaga.',
+            },
           },
         },
         Vaga: {
@@ -4910,6 +4996,15 @@ const options: Options = {
                   nullable: true,
                   example: 'Empresa focada em soluções tecnológicas para RH.',
                 },
+                aceitarTermos: {
+                  type: 'boolean',
+                  example: true,
+                  description: 'Indica se o usuário aceitou os termos vigentes durante o cadastro.',
+                },
+                informacoes: {
+                  allOf: [{ $ref: '#/components/schemas/UsuarioInformacoes' }],
+                  description: 'Objeto com os dados complementares provenientes da tabela UsuariosInformation.',
+                },
                 socialLinks: {
                   allOf: [{ $ref: '#/components/schemas/UsuarioSocialLinks' }],
                   nullable: true,
@@ -4967,6 +5062,15 @@ const options: Options = {
                   type: 'string',
                   nullable: true,
                   example: 'Profissional com experiência em atendimento.',
+                },
+                aceitarTermos: {
+                  type: 'boolean',
+                  example: true,
+                  description: 'Confirma o aceite dos termos pelo candidato.',
+                },
+                informacoes: {
+                  allOf: [{ $ref: '#/components/schemas/UsuarioInformacoes' }],
+                  description: 'Dados complementares extraídos da entidade UsuariosInformation.',
                 },
                 socialLinks: {
                   allOf: [{ $ref: '#/components/schemas/UsuarioSocialLinks' }],

--- a/src/modules/empresas/clientes/services/clientes.service.ts
+++ b/src/modules/empresas/clientes/services/clientes.service.ts
@@ -2,6 +2,7 @@ import { TiposDePlanos, Prisma, TiposDeUsuarios } from '@prisma/client';
 
 import { prisma } from '@/config/prisma';
 import { attachEnderecoResumo } from '@/modules/usuarios/utils/address';
+import { mergeUsuarioInformacoes, usuarioInformacoesSelect } from '@/modules/usuarios/utils/information';
 import { mapSocialLinks, usuarioRedesSociaisSelect } from '@/modules/usuarios/utils/social-links';
 import {
   CreateClientePlanoInput,
@@ -20,8 +21,9 @@ const includePlanoEmpresa = {
       select: {
         id: true,
         nomeCompleto: true,
-        avatarUrl: true,
-        descricao: true,
+        informacoes: {
+          select: usuarioInformacoesSelect,
+        },
         ...usuarioRedesSociaisSelect,
         codUsuario: true,
         role: true,
@@ -86,7 +88,9 @@ const transformarPlano = (plano: EmpresasPlanoWithRelations) => {
     plano.empresa && plano.empresa.tipoUsuario === TiposDeUsuarios.PESSOA_JURIDICA
       ? plano.empresa
       : null;
-  const empresaUsuario = empresaUsuarioRaw ? attachEnderecoResumo(empresaUsuarioRaw)! : null;
+  const empresaUsuario = empresaUsuarioRaw
+    ? attachEnderecoResumo(mergeUsuarioInformacoes(empresaUsuarioRaw))!
+    : null;
 
   const empresa = empresaUsuario
     ? {
@@ -99,6 +103,7 @@ const transformarPlano = (plano: EmpresasPlanoWithRelations) => {
         socialLinks: mapSocialLinks(empresaUsuario.redesSociais),
         codUsuario: empresaUsuario.codUsuario,
         enderecos: empresaUsuario.enderecos,
+        informacoes: empresaUsuario.informacoes,
       }
     : null;
 

--- a/src/modules/empresas/vagas/services/vagas.service.ts
+++ b/src/modules/empresas/vagas/services/vagas.service.ts
@@ -10,6 +10,7 @@ import {
 
 import { prisma } from '@/config/prisma';
 import { attachEnderecoResumo } from '@/modules/usuarios/utils/address';
+import { mergeUsuarioInformacoes, usuarioInformacoesSelect } from '@/modules/usuarios/utils/information';
 import { mapSocialLinks, usuarioRedesSociaisSelect } from '@/modules/usuarios/utils/social-links';
 import { clientesService } from '@/modules/empresas/clientes/services/clientes.service';
 import {
@@ -48,8 +49,9 @@ const includeEmpresa = {
       select: {
         id: true,
         nomeCompleto: true,
-        avatarUrl: true,
-        descricao: true,
+        informacoes: {
+          select: usuarioInformacoesSelect,
+        },
         ...usuarioRedesSociaisSelect,
         codUsuario: true,
         role: true,
@@ -198,7 +200,9 @@ const transformVaga = (vaga: VagaWithEmpresa) => {
     vaga.empresa && vaga.empresa.tipoUsuario === TiposDeUsuarios.PESSOA_JURIDICA
       ? vaga.empresa
       : null;
-  const empresaUsuario = empresaUsuarioRaw ? attachEnderecoResumo(empresaUsuarioRaw)! : null;
+  const empresaUsuario = empresaUsuarioRaw
+    ? attachEnderecoResumo(mergeUsuarioInformacoes(empresaUsuarioRaw))!
+    : null;
 
   const displayName = vaga.modoAnonimo
     ? anonymizedName(vaga.id)
@@ -222,6 +226,7 @@ const transformVaga = (vaga: VagaWithEmpresa) => {
         socialLinks: vaga.modoAnonimo ? null : mapSocialLinks(empresaUsuario.redesSociais),
         codUsuario: empresaUsuario.codUsuario,
         enderecos: empresaUsuario.enderecos,
+        informacoes: empresaUsuario.informacoes,
       }
     : null;
 

--- a/src/modules/usuarios/services/admin-service.ts
+++ b/src/modules/usuarios/services/admin-service.ts
@@ -12,6 +12,7 @@ import { prisma } from '@/config/prisma';
 import { invalidateUserCache } from '@/modules/usuarios/utils/cache';
 import { logger } from '@/utils/logger';
 import { attachEnderecoResumo } from '../utils/address';
+import { mergeUsuarioInformacoes, usuarioInformacoesSelect } from '../utils/information';
 import { mapSocialLinks, usuarioRedesSociaisSelect } from '../utils/social-links';
 export class AdminService {
   private readonly log = logger.child({ module: 'AdminService' });
@@ -182,7 +183,9 @@ export class AdminService {
       prisma.usuarios.count({ where }),
     ]);
 
-    const candidatosComEndereco = candidatos.map((candidato) => attachEnderecoResumo(candidato)!);
+    const candidatosComEndereco = candidatos.map((candidato) =>
+      attachEnderecoResumo(mergeUsuarioInformacoes(candidato))!,
+    );
 
     return {
       message: 'Lista de candidatos',
@@ -212,10 +215,6 @@ export class AdminService {
         nomeCompleto: true,
         cpf: true,
         cnpj: true,
-        telefone: true,
-        dataNasc: true,
-        genero: true,
-        matricula: true,
         role: true,
         status: true,
         tipoUsuario: true,
@@ -223,10 +222,11 @@ export class AdminService {
         ultimoLogin: true,
         criadoEm: true,
         atualizadoEm: true,
-        avatarUrl: true,
-        descricao: true,
         ...usuarioRedesSociaisSelect,
         codUsuario: true,
+        informacoes: {
+          select: usuarioInformacoesSelect,
+        },
         enderecos: {
           orderBy: { criadoEm: 'asc' },
           select: {
@@ -246,7 +246,8 @@ export class AdminService {
       return null;
     }
 
-    const usuarioNormalizado = attachEnderecoResumo(usuario);
+    const usuarioComInformacoes = mergeUsuarioInformacoes(usuario);
+    const usuarioNormalizado = attachEnderecoResumo(usuarioComInformacoes);
 
     if (!usuarioNormalizado) {
       return null;
@@ -255,6 +256,7 @@ export class AdminService {
     return {
       ...usuarioNormalizado,
       redesSociais: mapSocialLinks(usuario.redesSociais),
+      informacoes: usuarioComInformacoes.informacoes,
     };
   }
 
@@ -276,10 +278,6 @@ export class AdminService {
         email: true,
         nomeCompleto: true,
         cpf: true,
-        telefone: true,
-        dataNasc: true,
-        genero: true,
-        matricula: true,
         role: true,
         status: true,
         tipoUsuario: true,
@@ -287,10 +285,11 @@ export class AdminService {
         ultimoLogin: true,
         criadoEm: true,
         atualizadoEm: true,
-        avatarUrl: true,
-        descricao: true,
         ...usuarioRedesSociaisSelect,
         codUsuario: true,
+        informacoes: {
+          select: usuarioInformacoesSelect,
+        },
         enderecos: {
           orderBy: { criadoEm: 'asc' },
           select: {
@@ -310,7 +309,8 @@ export class AdminService {
       return null;
     }
 
-    const candidatoNormalizado = attachEnderecoResumo(candidato);
+    const candidatoComInformacoes = mergeUsuarioInformacoes(candidato);
+    const candidatoNormalizado = attachEnderecoResumo(candidatoComInformacoes);
 
     if (!candidatoNormalizado) {
       return null;
@@ -319,6 +319,7 @@ export class AdminService {
     return {
       ...candidatoNormalizado,
       redesSociais: mapSocialLinks(candidato.redesSociais),
+      informacoes: candidatoComInformacoes.informacoes,
     };
   }
 

--- a/src/modules/usuarios/utils/information.ts
+++ b/src/modules/usuarios/utils/information.ts
@@ -1,0 +1,75 @@
+import type { Prisma } from '@prisma/client';
+
+export const usuarioInformacoesSelect = {
+  telefone: true,
+  genero: true,
+  dataNasc: true,
+  matricula: true,
+  avatarUrl: true,
+  descricao: true,
+  aceitarTermos: true,
+} as const;
+
+export type UsuarioInformacoesSelect = typeof usuarioInformacoesSelect;
+
+export type UsuarioInformacoesRecord = Prisma.UsuariosInformationGetPayload<{
+  select: UsuarioInformacoesSelect;
+}>;
+
+type UsuarioInformacoesInput =
+  | UsuarioInformacoesRecord
+  | UsuarioInformacoesDto
+  | null
+  | undefined;
+
+export interface UsuarioInformacoesDto {
+  telefone: string | null;
+  genero: string | null;
+  dataNasc: Date | null;
+  matricula: string | null;
+  avatarUrl: string | null;
+  descricao: string | null;
+  aceitarTermos: boolean;
+}
+
+const resolveDate = (value: Date | string | null | undefined): Date | null => {
+  if (!value) {
+    return null;
+  }
+
+  return value instanceof Date ? value : new Date(value);
+};
+
+export const mapUsuarioInformacoes = (
+  informacoes?: UsuarioInformacoesInput,
+): UsuarioInformacoesDto => ({
+  telefone: informacoes?.telefone ?? null,
+  genero: informacoes?.genero ?? null,
+  dataNasc: resolveDate(informacoes?.dataNasc ?? null),
+  matricula: informacoes?.matricula ?? null,
+  avatarUrl: informacoes?.avatarUrl ?? null,
+  descricao: informacoes?.descricao ?? null,
+  aceitarTermos: informacoes?.aceitarTermos ?? false,
+});
+
+export const mergeUsuarioInformacoes = <
+  T extends { informacoes?: UsuarioInformacoesRecord | null }
+>(usuario: T): Omit<T, 'informacoes'> & {
+  informacoes: UsuarioInformacoesDto;
+  telefone: string | null;
+  genero: string | null;
+  dataNasc: Date | null;
+  matricula: string | null;
+  avatarUrl: string | null;
+  descricao: string | null;
+  aceitarTermos: boolean;
+} => {
+  const { informacoes: rawInformacoes, ...usuarioSemInformacoes } = usuario;
+  const informacoes = mapUsuarioInformacoes(rawInformacoes);
+
+  return {
+    ...usuarioSemInformacoes,
+    ...informacoes,
+    informacoes,
+  };
+};


### PR DESCRIPTION
## Summary
- create the UsuariosInformation model and migration, moving profile columns off Usuarios while preserving data
- centralize mapping helpers and update controllers/services to consume the new relation without breaking existing responses
- refresh Swagger documentation to describe the UsuariosInformation payload and expose the new informacoes object to clients

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68cf429bf0308332919e9ccb0d1f5913