### PR TITLE
feat: add seniority enum and extend vacancy statuses

### DIFF
--- a/prisma/migrations/20250312000000_add_senioridade_and_update_status_de_vagas/migration.sql
+++ b/prisma/migrations/20250312000000_add_senioridade_and_update_status_de_vagas/migration.sql
@@ -1,0 +1,19 @@
+-- Alter enum StatusDeVagas to include new workflow stages
+ALTER TYPE "StatusDeVagas" ADD VALUE 'DESPUBLICADA';
+ALTER TYPE "StatusDeVagas" ADD VALUE 'PAUSADA';
+ALTER TYPE "StatusDeVagas" ADD VALUE 'ENCERRADA';
+
+-- Create Senioridade enum
+CREATE TYPE "Senioridade" AS ENUM (
+  'ABERTO',
+  'ESTAGIARIO',
+  'JUNIOR',
+  'PLENO',
+  'SENIOR',
+  'ESPECIALISTA',
+  'LIDER'
+);
+
+-- Add senioridade column to EmpresasVagas with default value
+ALTER TABLE "EmpresasVagas"
+  ADD COLUMN "senioridade" "Senioridade" NOT NULL DEFAULT 'ABERTO';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -158,6 +158,19 @@ enum StatusDeVagas {
   EM_ANALISE
   PUBLICADO
   EXPIRADO
+  DESPUBLICADA
+  PAUSADA
+  ENCERRADA
+}
+
+enum Senioridade {
+  ABERTO
+  ESTAGIARIO
+  JUNIOR
+  PLENO
+  SENIOR
+  ESPECIALISTA
+  LIDER
 }
 
 enum TiposDePlanos {
@@ -213,6 +226,7 @@ model EmpresasVagas {
   beneficios       String         @db.Text
   observacoes      String?        @db.Text
   jornada          Jornadas
+  senioridade      Senioridade    @default(ABERTO)
   inscricoesAte    DateTime?
   inseridaEm       DateTime       @default(now())
   atualizadoEm     DateTime       @updatedAt

--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -3634,9 +3634,10 @@ const options: Options = {
         },
         StatusDeVagas: {
           type: 'string',
-          description: 'Etapas do fluxo de publicação da vaga',
-          enum: ['RASCUNHO', 'EM_ANALISE', 'PUBLICADO', 'EXPIRADO'],
-          example: 'EM_ANALISE',
+          description:
+            'Etapas do fluxo de publicação da vaga (RASCUNHO, EM_ANALISE, PUBLICADO, DESPUBLICADA, PAUSADA, EXPIRADO ou ENCERRADA).',
+          enum: ['RASCUNHO', 'EM_ANALISE', 'PUBLICADO', 'DESPUBLICADA', 'PAUSADA', 'EXPIRADO', 'ENCERRADA'],
+          example: 'PUBLICADO',
         },
         RegimesDeTrabalhos: {
           type: 'string',
@@ -3656,6 +3657,13 @@ const options: Options = {
           description: 'Modalidades de atuação disponíveis para a vaga.',
           enum: ['PRESENCIAL', 'REMOTO', 'HIBRIDO'],
           example: 'REMOTO',
+        },
+        Senioridade: {
+          type: 'string',
+          description:
+            'Faixas de senioridade aceitas pela empresa para a vaga (ABERTO, ESTAGIARIO, JUNIOR, PLENO, SENIOR, ESPECIALISTA ou LIDER).',
+          enum: ['ABERTO', 'ESTAGIARIO', 'JUNIOR', 'PLENO', 'SENIOR', 'ESPECIALISTA', 'LIDER'],
+          example: 'PLENO',
         },
         PaginationMeta: {
           type: 'object',
@@ -5022,6 +5030,10 @@ const options: Options = {
               allOf: [{ $ref: '#/components/schemas/Jornadas' }],
               description: 'Classificação padronizada da carga horária da vaga.',
             },
+            senioridade: {
+              allOf: [{ $ref: '#/components/schemas/Senioridade' }],
+              description: 'Faixa de senioridade aceita para a posição.',
+            },
             inscricoesAte: {
               type: 'string',
               format: 'date-time',
@@ -5078,6 +5090,7 @@ const options: Options = {
             'atividades',
             'beneficios',
             'jornada',
+            'senioridade',
           ],
           properties: {
             usuarioId: {
@@ -5120,6 +5133,11 @@ const options: Options = {
               description: 'Selecione a jornada que melhor descreve a carga horária combinada.',
               example: 'INTEGRAL',
             },
+            senioridade: {
+              allOf: [{ $ref: '#/components/schemas/Senioridade' }],
+              description: 'Informe a faixa de senioridade aceita para a vaga.',
+              example: 'PLENO',
+            },
             inscricoesAte: {
               type: 'string',
               format: 'date-time',
@@ -5134,7 +5152,8 @@ const options: Options = {
         },
         VagaUpdateInput: {
           type: 'object',
-          description: 'Campos permitidos para atualização da vaga, inclusive o status do fluxo de aprovação.',
+          description:
+            'Campos permitidos para atualização da vaga, inclusive o status do fluxo de aprovação (RASCUNHO, EM_ANALISE, PUBLICADO, DESPUBLICADA, PAUSADA, EXPIRADO ou ENCERRADA).',
           properties: {
             usuarioId: {
               type: 'string',
@@ -5170,6 +5189,11 @@ const options: Options = {
               allOf: [{ $ref: '#/components/schemas/Jornadas' }],
               description: 'Atualize a jornada quando houver mudança na carga horária prevista.',
               example: 'MEIO_PERIODO',
+            },
+            senioridade: {
+              allOf: [{ $ref: '#/components/schemas/Senioridade' }],
+              description: 'Atualize a faixa de senioridade aceita para a vaga.',
+              example: 'SENIOR',
             },
             inscricoesAte: {
               type: 'string',

--- a/src/modules/empresas/admin/routes/index.ts
+++ b/src/modules/empresas/admin/routes/index.ts
@@ -637,7 +637,7 @@ router.post('/:id/banimentos', supabaseAuthMiddleware(adminRoles), AdminEmpresas
  *         name: status
  *         schema:
  *           type: string
- *         description: "Lista de status separados por vírgula (RASCUNHO, EM_ANALISE, PUBLICADO, EXPIRADO)"
+ *         description: "Lista de status separados por vírgula (RASCUNHO, EM_ANALISE, PUBLICADO, DESPUBLICADA, PAUSADA, ENCERRADA ou EXPIRADO)"
  *       - in: query
  *         name: page
  *         schema:

--- a/src/modules/empresas/admin/services/admin-empresas.service.ts
+++ b/src/modules/empresas/admin/services/admin-empresas.service.ts
@@ -10,6 +10,7 @@ import {
   Prisma,
   Roles,
   RegimesDeTrabalhos,
+  Senioridade,
   Status,
   StatusDeBanimentos,
   StatusDeVagas,
@@ -298,6 +299,7 @@ type AdminEmpresaJobResumo = {
   modalidade: ModalidadesDeVagas;
   regimeDeTrabalho: RegimesDeTrabalhos;
   paraPcd: boolean;
+  senioridade: Senioridade;
 };
 
 type AdminEmpresaDetail = {
@@ -1041,6 +1043,7 @@ export const adminEmpresasService = {
           modalidade: true,
           regimeDeTrabalho: true,
           paraPcd: true,
+          senioridade: true,
         },
       }),
     ]);
@@ -1057,6 +1060,7 @@ export const adminEmpresasService = {
       modalidade: vaga.modalidade,
       regimeDeTrabalho: vaga.regimeDeTrabalho,
       paraPcd: vaga.paraPcd,
+      senioridade: vaga.senioridade,
     }));
 
     return {
@@ -1109,6 +1113,7 @@ export const adminEmpresasService = {
           modalidade: true,
           regimeDeTrabalho: true,
           paraPcd: true,
+          senioridade: true,
         },
       });
     });
@@ -1125,6 +1130,7 @@ export const adminEmpresasService = {
       modalidade: vaga.modalidade,
       regimeDeTrabalho: vaga.regimeDeTrabalho,
       paraPcd: vaga.paraPcd,
+      senioridade: vaga.senioridade,
     } satisfies AdminEmpresaJobResumo;
   },
 

--- a/src/modules/empresas/admin/validators/admin-empresas.schema.ts
+++ b/src/modules/empresas/admin/validators/admin-empresas.schema.ts
@@ -201,7 +201,8 @@ const statusArraySchema = z
       value === undefined ||
       value.every((status) => Object.prototype.hasOwnProperty.call(StatusDeVagas, status as StatusDeVagas)),
     {
-      message: 'Informe status válidos (RASCUNHO, EM_ANALISE, PUBLICADO ou EXPIRADO)',
+      message:
+        'Informe status válidos (RASCUNHO, EM_ANALISE, PUBLICADO, DESPUBLICADA, PAUSADA, ENCERRADA ou EXPIRADO)',
     },
   )
   .transform((value) => value?.map((status) => status as StatusDeVagas));

--- a/src/modules/empresas/vagas/controllers/vagas.controller.ts
+++ b/src/modules/empresas/vagas/controllers/vagas.controller.ts
@@ -21,8 +21,22 @@ export class VagasController {
         pageSize?: string;
       };
 
-      const validStatuses = new Set<StatusDeVagas>(['RASCUNHO', 'EM_ANALISE', 'PUBLICADO', 'EXPIRADO'] as const);
-      const restrictedStatuses = new Set<StatusDeVagas>(['RASCUNHO', 'EM_ANALISE']);
+      const validStatuses = new Set<StatusDeVagas>([
+        'RASCUNHO',
+        'EM_ANALISE',
+        'PUBLICADO',
+        'EXPIRADO',
+        'DESPUBLICADA',
+        'PAUSADA',
+        'ENCERRADA',
+      ] as const);
+      const restrictedStatuses = new Set<StatusDeVagas>([
+        'RASCUNHO',
+        'EM_ANALISE',
+        'DESPUBLICADA',
+        'PAUSADA',
+        'ENCERRADA',
+      ]);
       const allowedRoles: Roles[] = [
         Roles.ADMIN,
         Roles.MODERADOR,
@@ -35,7 +49,15 @@ export class VagasController {
       if (typeof status === 'string' && status.trim() !== '') {
         const normalized = status.trim().toUpperCase();
         if (normalized === 'ALL' || normalized === 'TODAS' || normalized === 'TODOS') {
-          statusesFilter = ['RASCUNHO', 'EM_ANALISE', 'PUBLICADO', 'EXPIRADO'];
+          statusesFilter = [
+            'RASCUNHO',
+            'EM_ANALISE',
+            'PUBLICADO',
+            'EXPIRADO',
+            'DESPUBLICADA',
+            'PAUSADA',
+            'ENCERRADA',
+          ];
         } else {
           const parts = normalized.split(',').map((s) => s.trim()).filter(Boolean);
           const chosen = parts.filter((s): s is StatusDeVagas => validStatuses.has(s as StatusDeVagas));

--- a/src/modules/empresas/vagas/routes/index.ts
+++ b/src/modules/empresas/vagas/routes/index.ts
@@ -14,7 +14,7 @@ const updateRoles = [Roles.ADMIN, Roles.MODERADOR, Roles.RECRUTADOR];
  * /api/v1/empresas/vagas:
  *   get:
  *     summary: Listar vagas publicadas
- *     description: "Retorna as vagas disponíveis para visualização. Por padrão, apenas vagas PUBLICADAS são retornadas. É possível filtrar por status via query string. Consultas envolvendo os status RASCUNHO ou EM_ANALISE exigem autenticação com roles válidas (ADMIN, MODERADOR, EMPRESA, RECRUTADOR ou ALUNO_CANDIDATO)."
+ *     description: "Retorna as vagas disponíveis para visualização. Por padrão, apenas vagas PUBLICADAS são retornadas. É possível filtrar por status via query string. Consultas envolvendo os status RASCUNHO, EM_ANALISE, DESPUBLICADA, PAUSADA ou ENCERRADA exigem autenticação com roles válidas (ADMIN, MODERADOR, EMPRESA, RECRUTADOR ou ALUNO_CANDIDATO)."
  *     tags: [Empresas - EmpresasVagas]
  *     parameters:
  *       - in: query
@@ -23,7 +23,7 @@ const updateRoles = [Roles.ADMIN, Roles.MODERADOR, Roles.RECRUTADOR];
  *         schema:
  *           type: string
  *           example: PUBLICADO,EM_ANALISE
- *         description: "Filtra por um ou mais status separados por vírgula. Aceita RASCUNHO, EM_ANALISE, PUBLICADO ou EXPIRADO. Use ALL/TODAS/TODOS para trazer todos os status."
+ *         description: "Filtra por um ou mais status separados por vírgula. Aceita RASCUNHO, EM_ANALISE, PUBLICADO, DESPUBLICADA, PAUSADA, ENCERRADA ou EXPIRADO. Use ALL/TODAS/TODOS para trazer todos os status."
  *       - in: query
  *         name: usuarioId
  *         required: false
@@ -207,6 +207,7 @@ router.get('/:id', publicCache, VagasController.get);
  *                  "beneficios": "Vale transporte, vale alimentação e plano de saúde.",
  *                  "observacoes": "Processo seletivo confidencial.",
  *                  "jornada": "INTEGRAL",
+ *                  "senioridade": "PLENO",
  *                  "inscricoesAte": "2024-12-20T23:59:59.000Z"
  *                }'
 */
@@ -217,7 +218,7 @@ router.post('/', supabaseAuthMiddleware(protectedRoles), VagasController.create)
  * /api/v1/empresas/vagas/{id}:
  *   put:
  *     summary: Atualizar vaga
- *     description: "Permite editar os dados de uma vaga existente, incluindo o status do fluxo (RASCUNHO, EM_ANALISE, PUBLICADO ou EXPIRADO). Requer autenticação com perfil autorizado (roles: ADMIN, MODERADOR ou RECRUTADOR)."
+ *     description: "Permite editar os dados de uma vaga existente, incluindo o status do fluxo (RASCUNHO, EM_ANALISE, PUBLICADO, DESPUBLICADA, PAUSADA, EXPIRADO ou ENCERRADA). Requer autenticação com perfil autorizado (roles: ADMIN, MODERADOR ou RECRUTADOR)."
  *     tags: [Empresas - EmpresasVagas]
  *     security:
  *       - bearerAuth: []

--- a/src/modules/empresas/vagas/services/vagas.service.ts
+++ b/src/modules/empresas/vagas/services/vagas.service.ts
@@ -5,6 +5,7 @@ import {
   ModalidadesDeVagas,
   Prisma,
   RegimesDeTrabalhos,
+  Senioridade,
   StatusDeVagas,
   TiposDeUsuarios,
 } from '@prisma/client';
@@ -32,6 +33,7 @@ export type CreateVagaData = {
   beneficios: string;
   observacoes?: string;
   jornada: Jornadas;
+  senioridade: Senioridade;
   inscricoesAte?: Date;
   inseridaEm?: Date;
   status?: StatusDeVagas;
@@ -137,6 +139,7 @@ const sanitizeCreateData = (data: CreateVagaData, codigo: string): Prisma.Empres
   beneficios: data.beneficios.trim(),
   observacoes: nullableText(data.observacoes),
   jornada: data.jornada,
+  senioridade: data.senioridade,
   inscricoesAte: data.inscricoesAte ?? null,
   inseridaEm: data.inseridaEm ?? new Date(),
   status: data.status ?? StatusDeVagas.EM_ANALISE,
@@ -177,6 +180,9 @@ const sanitizeUpdateData = (data: UpdateVagaData): Prisma.EmpresasVagasUnchecked
   }
   if (data.jornada !== undefined) {
     update.jornada = data.jornada;
+  }
+  if (data.senioridade !== undefined) {
+    update.senioridade = data.senioridade;
   }
   if (data.inscricoesAte !== undefined) {
     update.inscricoesAte = data.inscricoesAte ?? null;
@@ -262,7 +268,7 @@ const ensurePlanoAtivoParaUsuario = async (usuarioId: string) => {
     const vagasAtivas = await prisma.empresasVagas.count({
       where: {
         usuarioId,
-      status: { in: [StatusDeVagas.EM_ANALISE, StatusDeVagas.PUBLICADO] },
+        status: { in: [StatusDeVagas.EM_ANALISE, StatusDeVagas.PUBLICADO, StatusDeVagas.PAUSADA] },
       },
     });
 

--- a/src/modules/empresas/vagas/validators/vagas.schema.ts
+++ b/src/modules/empresas/vagas/validators/vagas.schema.ts
@@ -1,4 +1,4 @@
-import { Jornadas, ModalidadesDeVagas, RegimesDeTrabalhos, StatusDeVagas } from '@prisma/client';
+import { Jornadas, ModalidadesDeVagas, RegimesDeTrabalhos, Senioridade, StatusDeVagas } from '@prisma/client';
 import { z } from 'zod';
 
 const longTextField = (field: string) =>
@@ -44,6 +44,10 @@ const baseVagaSchema = z.object({
   jornada: z.nativeEnum(Jornadas, {
     required_error: 'A jornada é obrigatória',
     invalid_type_error: 'jornada inválida',
+  }),
+  senioridade: z.nativeEnum(Senioridade, {
+    required_error: 'A senioridade da vaga é obrigatória',
+    invalid_type_error: 'senioridade inválida',
   }),
   inscricoesAte: dateField('A data limite de inscrições').optional(),
   inseridaEm: dateField('A data de publicação da vaga').optional(),

--- a/src/modules/mercadopago/assinaturas/routes/index.ts
+++ b/src/modules/mercadopago/assinaturas/routes/index.ts
@@ -60,7 +60,7 @@ router.post('/webhook', AssinaturasController.webhook);
  * /api/v1/mercadopago/assinaturas/cancelar:
  *   post:
  *     summary: Cancelar assinatura
- *     description: "Cancela o plano ativo do cliente. Todas as vagas PUBLICADO/EM_ANALISE são colocadas em RASCUNHO."
+ *     description: "Cancela o plano ativo do cliente. Todas as vagas PUBLICADO/EM_ANALISE/PAUSADA são colocadas em RASCUNHO."
  *     tags: [MercadoPago - Assinaturas]
  *     security:
  *       - bearerAuth: []
@@ -108,7 +108,7 @@ router.post('/upgrade', supabaseAuthMiddleware(empresaRoles), AssinaturasControl
  * /api/v1/mercadopago/assinaturas/downgrade:
  *   post:
  *     summary: Downgrade de plano
- *     description: "Realiza downgrade do plano do cliente e coloca vagas PUBLICADO/EM_ANALISE em RASCUNHO."
+ *     description: "Realiza downgrade do plano do cliente e coloca vagas PUBLICADO/EM_ANALISE/PAUSADA em RASCUNHO."
  *     tags: [MercadoPago - Assinaturas]
  *     security:
  *       - bearerAuth: []

--- a/src/modules/mercadopago/assinaturas/services/assinaturas.service.ts
+++ b/src/modules/mercadopago/assinaturas/services/assinaturas.service.ts
@@ -219,7 +219,10 @@ function normalizeMercadoPagoError(error: unknown): { message: string; payload?:
 
 async function setVagasToDraft(usuarioId: string) {
   await prisma.empresasVagas.updateMany({
-    where: { usuarioId, status: { in: [StatusDeVagas.PUBLICADO, StatusDeVagas.EM_ANALISE] } },
+    where: {
+      usuarioId,
+      status: { in: [StatusDeVagas.PUBLICADO, StatusDeVagas.EM_ANALISE, StatusDeVagas.PAUSADA] },
+    },
     data: { status: StatusDeVagas.RASCUNHO },
   });
 }


### PR DESCRIPTION
## Summary
- extend the Prisma schema with the Senioridade enum, update StatusDeVagas values, and add the required migration
- update vacancy flows, validations, and admin/mercado pago services to accept the new seniority field and vacancy statuses
- refresh Swagger/Redoc documentation and public route descriptions to document the new statuses and seniority requirements

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68cf6f6069f48332bc42d5164677deaa