### PR TITLE
feat: add vacancy process workflows

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -29,6 +29,7 @@ model Usuarios {
   // RELACIONAMENTOS EXISTENTES
   enderecos            UsuariosEnderecos[]
   vagasCriadas         EmpresasVagas[]    @relation("UsuarioVagas")
+  processosCandidatados EmpresasVagasProcesso[] @relation("UsuariosProcessos")
   planosContratados    EmpresasPlano[]    @relation("UsuarioPlanos")
   banimentosRecebidos  UsuariosEmBanimentos[] @relation("UsuariosEmBanimentosUsuario")
   banimentosAplicados  UsuariosEmBanimentos[] @relation("UsuariosEmBanimentosAdmin")
@@ -58,11 +59,12 @@ model UsuariosInformation {
 }
 
 model CandidatosAreasInteresse {
-  id           Int                             @id @default(autoincrement())
-  categoria    String                          @db.VarChar(120)
-  subareas     CandidatosSubareasInteresse[]
-  criadoEm     DateTime                        @default(now())
-  atualizadoEm DateTime                        @updatedAt
+  id        Int                             @id @default(autoincrement())
+  categoria String                          @db.VarChar(120)
+  subareas  CandidatosSubareasInteresse[]
+  vagas     EmpresasVagas[]                @relation("EmpresasVagasAreaInteresse")
+  criadoEm  DateTime                       @default(now())
+  atualizadoEm DateTime                     @updatedAt
 
   @@map("candidatos_areas_interesse")
   @@index([categoria])
@@ -72,6 +74,7 @@ model CandidatosSubareasInteresse {
   id        Int                        @id @default(autoincrement())
   areaId    Int
   nome      String                     @db.VarChar(120)
+  vagas     EmpresasVagas[]            @relation("EmpresasVagasSubareaInteresse")
   criadoEm  DateTime                   @default(now())
   atualizadoEm DateTime                @updatedAt
 
@@ -163,6 +166,27 @@ enum StatusDeVagas {
   ENCERRADA
 }
 
+enum StatusProcesso {
+  RECEBIDA
+  EM_ANALISE
+  EM_TRIAGEM
+  ENTREVISTA
+  DESAFIO
+  DOCUMENTACAO
+  CONTRATADO
+  RECUSADO
+  DESISTIU
+  NAO_COMPARECEU
+  ARQUIVADO
+  CANCELADO
+}
+
+enum OrigemVagas {
+  SITE
+  DASHBOARD
+  OUTROS
+}
+
 enum Senioridade {
   ABERTO
   ESTAGIARIO
@@ -245,12 +269,34 @@ model EmpresasVagas {
 
   empresa Usuarios @relation("UsuarioVagas", fields: [usuarioId], references: [id], onDelete: Cascade)
   destaqueInfo EmpresasVagasDestaque?
-  areaInteresse   CandidatosAreasInteresse?    @relation(fields: [areaInteresseId], references: [id], onDelete: SetNull)
-  subareaInteresse CandidatosSubareasInteresse? @relation(fields: [subareaInteresseId], references: [id], onDelete: SetNull)
+  areaInteresse   CandidatosAreasInteresse?    @relation("EmpresasVagasAreaInteresse", fields: [areaInteresseId], references: [id], onDelete: SetNull)
+  subareaInteresse CandidatosSubareasInteresse? @relation("EmpresasVagasSubareaInteresse", fields: [subareaInteresseId], references: [id], onDelete: SetNull)
+  processos        EmpresasVagasProcesso[]
 
   @@index([usuarioId])
   @@index([areaInteresseId])
   @@index([subareaInteresseId])
+}
+
+model EmpresasVagasProcesso {
+  id           String         @id @default(uuid())
+  vagaId       String
+  candidatoId  String
+  status       StatusProcesso @default(RECEBIDA)
+  origem       OrigemVagas    @default(SITE)
+  observacoes  String?        @db.VarChar(1000)
+  agendadoEm   DateTime?
+  criadoEm     DateTime       @default(now())
+  atualizadoEm DateTime       @updatedAt
+
+  vaga      EmpresasVagas @relation(fields: [vagaId], references: [id], onDelete: Cascade)
+  candidato Usuarios      @relation("UsuariosProcessos", fields: [candidatoId], references: [id], onDelete: Cascade)
+
+  @@unique([vagaId, candidatoId])
+  @@index([vagaId])
+  @@index([candidatoId])
+  @@index([status])
+  @@index([origem])
 }
 
 model EmpresasVagasDestaque {

--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -115,6 +115,10 @@ const options: Options = {
         description: 'Administração de vagas corporativas vinculadas às empresas',
       },
       {
+        name: 'Empresas - VagasProcessos',
+        description: 'Gestão das etapas e candidatos vinculados aos processos seletivos das vagas',
+      },
+      {
         name: 'Empresas - Admin',
         description:
           'Gestão administrativa completa das empresas: cadastro, planos, pagamentos, vagas, banimentos e monitoramento operacional',
@@ -168,6 +172,7 @@ const options: Options = {
           'Empresas - Planos Empresariais',
           'Empresas - Clientes',
           'Empresas - EmpresasVagas',
+          'Empresas - VagasProcessos',
           'Empresas - Admin',
         ],
       },
@@ -3668,6 +3673,32 @@ const options: Options = {
           enum: ['RASCUNHO', 'EM_ANALISE', 'PUBLICADO', 'DESPUBLICADA', 'PAUSADA', 'EXPIRADO', 'ENCERRADA'],
           example: 'PUBLICADO',
         },
+        StatusProcesso: {
+          type: 'string',
+          description:
+            'Etapas do acompanhamento do candidato durante o processo seletivo da vaga.',
+          enum: [
+            'RECEBIDA',
+            'EM_ANALISE',
+            'EM_TRIAGEM',
+            'ENTREVISTA',
+            'DESAFIO',
+            'DOCUMENTACAO',
+            'CONTRATADO',
+            'RECUSADO',
+            'DESISTIU',
+            'NAO_COMPARECEU',
+            'ARQUIVADO',
+            'CANCELADO',
+          ],
+          example: 'EM_ANALISE',
+        },
+        OrigemVagas: {
+          type: 'string',
+          description: 'Origem do cadastro do processo seletivo associado à vaga.',
+          enum: ['SITE', 'DASHBOARD', 'OUTROS'],
+          example: 'DASHBOARD',
+        },
         RegimesDeTrabalhos: {
           type: 'string',
           description: 'Formatos de contratação oferecidos pelas empresas nas vagas.',
@@ -3889,6 +3920,159 @@ const options: Options = {
               example: '2025-03-13T14:00:00.000Z',
             },
           },
+        },
+        VagaProcessoCandidato: {
+          type: 'object',
+          description: 'Resumo do candidato vinculado a um processo seletivo da vaga.',
+          properties: {
+            id: { type: 'string', format: 'uuid', example: 'candidate-uuid' },
+            nomeCompleto: { type: 'string', example: 'João da Silva' },
+            email: { type: 'string', example: 'candidato@example.com' },
+            codUsuario: { type: 'string', example: 'ALU1234' },
+            role: {
+              allOf: [{ $ref: '#/components/schemas/Roles' }],
+              example: 'ALUNO_CANDIDATO',
+            },
+            status: {
+              allOf: [{ $ref: '#/components/schemas/Status' }],
+              example: 'ATIVO',
+            },
+            tipoUsuario: {
+              allOf: [{ $ref: '#/components/schemas/TiposDeUsuarios' }],
+              example: 'PESSOA_FISICA',
+            },
+            criadoEm: {
+              type: 'string',
+              format: 'date-time',
+              example: '2024-01-01T12:00:00Z',
+            },
+            ultimoLogin: {
+              type: 'string',
+              format: 'date-time',
+              nullable: true,
+              example: '2024-02-10T09:30:00Z',
+            },
+            telefone: { type: 'string', nullable: true, example: '+55 82 99999-0000' },
+            genero: { type: 'string', nullable: true, example: 'FEMININO' },
+            dataNasc: {
+              type: 'string',
+              format: 'date',
+              nullable: true,
+              example: '1995-07-15',
+            },
+            matricula: { type: 'string', nullable: true, example: 'MAT-2024-001' },
+            avatarUrl: {
+              type: 'string',
+              nullable: true,
+              example: 'https://cdn.advance.com.br/candidates/avatar.png',
+            },
+            descricao: {
+              type: 'string',
+              nullable: true,
+              example: 'Desenvolvedora full-stack com foco em produtos digitais.',
+            },
+            aceitarTermos: {
+              type: 'boolean',
+              example: true,
+              description: 'Indica se o candidato aceitou os termos durante o cadastro.',
+            },
+            informacoes: {
+              allOf: [{ $ref: '#/components/schemas/UsuarioInformacoes' }],
+              description: 'Dados complementares persistidos na tabela UsuariosInformation.',
+            },
+            enderecos: {
+              type: 'array',
+              description: 'Endereços cadastrados pelo candidato. O primeiro item representa o endereço principal.',
+              items: { $ref: '#/components/schemas/UsuarioEndereco' },
+            },
+            cidade: { type: 'string', nullable: true, example: 'Maceió' },
+            estado: { type: 'string', nullable: true, example: 'AL' },
+          },
+        },
+        VagaProcesso: {
+          type: 'object',
+          description: 'Representa o acompanhamento de um candidato dentro de uma vaga corporativa.',
+          required: ['id', 'vagaId', 'candidatoId', 'status', 'origem', 'criadoEm', 'atualizadoEm'],
+          properties: {
+            id: { type: 'string', format: 'uuid', example: 'processo-uuid' },
+            vagaId: { type: 'string', format: 'uuid', example: 'vaga-uuid' },
+            candidatoId: { type: 'string', format: 'uuid', example: 'candidate-uuid' },
+            status: { allOf: [{ $ref: '#/components/schemas/StatusProcesso' }] },
+            origem: { allOf: [{ $ref: '#/components/schemas/OrigemVagas' }] },
+            observacoes: {
+              type: 'string',
+              nullable: true,
+              example: 'Candidato com excelente aderência técnica, aguardando entrevista final.',
+            },
+            agendadoEm: {
+              type: 'string',
+              format: 'date-time',
+              nullable: true,
+              example: '2025-03-20T14:00:00Z',
+            },
+            criadoEm: {
+              type: 'string',
+              format: 'date-time',
+              example: '2025-03-15T12:34:00Z',
+            },
+            atualizadoEm: {
+              type: 'string',
+              format: 'date-time',
+              example: '2025-03-18T09:10:00Z',
+            },
+            candidato: {
+              allOf: [{ $ref: '#/components/schemas/VagaProcessoCandidato' }],
+              nullable: true,
+            },
+          },
+        },
+        VagaProcessoCreateInput: {
+          type: 'object',
+          required: ['candidatoId'],
+          properties: {
+            candidatoId: { type: 'string', format: 'uuid', example: 'candidate-uuid' },
+            status: {
+              allOf: [{ $ref: '#/components/schemas/StatusProcesso' }],
+              nullable: true,
+              description: 'Quando omitido, o status padrão RECEBIDA é aplicado automaticamente.',
+            },
+            origem: {
+              allOf: [{ $ref: '#/components/schemas/OrigemVagas' }],
+              nullable: true,
+              description: 'Origem da candidatura. O valor padrão é SITE.',
+            },
+            observacoes: {
+              type: 'string',
+              nullable: true,
+              example: 'Candidato indicado por parceiro estratégico.',
+            },
+            agendadoEm: {
+              type: 'string',
+              format: 'date-time',
+              nullable: true,
+              example: '2025-03-21T10:00:00Z',
+            },
+          },
+        },
+        VagaProcessoUpdateInput: {
+          type: 'object',
+          description: 'Campos disponíveis para atualização parcial do processo seletivo vinculado à vaga.',
+          properties: {
+            status: { allOf: [{ $ref: '#/components/schemas/StatusProcesso' }] },
+            origem: { allOf: [{ $ref: '#/components/schemas/OrigemVagas' }] },
+            observacoes: {
+              type: 'string',
+              nullable: true,
+              example: 'Feedback registrado após a entrevista técnica.',
+            },
+            agendadoEm: {
+              type: 'string',
+              format: 'date-time',
+              nullable: true,
+              example: '2025-03-22T15:00:00Z',
+            },
+          },
+          minProperties: 1,
         },
         AdminEmpresaListItem: {
           type: 'object',
@@ -6417,6 +6601,7 @@ export function setupSwagger(app: Application): void {
               'Empresas - Planos Empresariais',
               'Empresas - Clientes',
               'Empresas - EmpresasVagas',
+              'Empresas - VagasProcessos',
             ];
             const ai = order.indexOf(a);
             const bi = order.indexOf(b);

--- a/src/modules/empresas/vagas-processos/controllers/vagas-processos.controller.ts
+++ b/src/modules/empresas/vagas-processos/controllers/vagas-processos.controller.ts
@@ -1,0 +1,212 @@
+import type { Request, Response } from 'express';
+import { ZodError } from 'zod';
+
+import {
+  createVagaProcessoSchema,
+  updateVagaProcessoSchema,
+  vagaProcessoDetailParamsSchema,
+  vagaProcessoListQuerySchema,
+  vagaProcessoParamsSchema,
+} from '@/modules/empresas/vagas-processos/validators/vagas-processos.schema';
+import {
+  VagaProcessoCandidatoInvalidoError,
+  VagaProcessoCandidatoNaoEncontradoError,
+  VagaProcessoDuplicadoError,
+  VagaProcessoNaoEncontradoError,
+  VagaProcessoVagaNaoEncontradaError,
+} from '@/modules/empresas/vagas-processos/services/errors';
+import { vagasProcessosService } from '@/modules/empresas/vagas-processos/services/vagas-processos.service';
+
+const buildErrorResponse = (res: Response, error: Error & { status?: number; code?: string }) =>
+  res.status(error.status ?? 500).json({
+    success: false,
+    code: error.code ?? 'VAGA_PROCESSO_ERROR',
+    message: error.message,
+  });
+
+export class VagasProcessosController {
+  static list = async (req: Request, res: Response) => {
+    try {
+      const { vagaId } = vagaProcessoParamsSchema.parse(req.params);
+      const query = vagaProcessoListQuerySchema.parse({
+        status: typeof req.query.status === 'string' ? req.query.status : undefined,
+        origem: typeof req.query.origem === 'string' ? req.query.origem : undefined,
+        candidatoId: typeof req.query.candidatoId === 'string' ? req.query.candidatoId : undefined,
+      });
+
+      const processos = await vagasProcessosService.list(vagaId, query);
+
+      res.json({
+        message: 'Lista de processos seletivos vinculados à vaga.',
+        vagaId,
+        total: processos.length,
+        processos,
+      });
+    } catch (error: any) {
+      if (error instanceof ZodError) {
+        return res.status(400).json({
+          success: false,
+          code: 'VALIDATION_ERROR',
+          message: 'Parâmetros inválidos para listar os processos seletivos da vaga.',
+          issues: error.flatten().fieldErrors,
+        });
+      }
+
+      if (error instanceof VagaProcessoVagaNaoEncontradaError) {
+        return buildErrorResponse(res, error);
+      }
+
+      res.status(500).json({
+        success: false,
+        code: 'VAGA_PROCESSO_LIST_ERROR',
+        message: 'Erro ao listar os processos seletivos da vaga.',
+        error: error?.message,
+      });
+    }
+  };
+
+  static get = async (req: Request, res: Response) => {
+    try {
+      const { vagaId, processoId } = vagaProcessoDetailParamsSchema.parse({
+        vagaId: req.params.vagaId,
+        processoId: req.params.processoId,
+      });
+
+      const processo = await vagasProcessosService.get(vagaId, processoId);
+
+      res.json({
+        message: 'Processo seletivo recuperado com sucesso.',
+        processo,
+      });
+    } catch (error: any) {
+      if (error instanceof ZodError) {
+        return res.status(400).json({
+          success: false,
+          code: 'VALIDATION_ERROR',
+          message: 'Parâmetros inválidos para consulta do processo seletivo.',
+          issues: error.flatten().fieldErrors,
+        });
+      }
+
+      if (error instanceof VagaProcessoNaoEncontradoError) {
+        return buildErrorResponse(res, error);
+      }
+
+      res.status(500).json({
+        success: false,
+        code: 'VAGA_PROCESSO_GET_ERROR',
+        message: 'Erro ao buscar o processo seletivo da vaga.',
+        error: error?.message,
+      });
+    }
+  };
+
+  static create = async (req: Request, res: Response) => {
+    try {
+      const { vagaId } = vagaProcessoParamsSchema.parse(req.params);
+      const payload = createVagaProcessoSchema.parse(req.body);
+
+      const processo = await vagasProcessosService.create(vagaId, payload);
+
+      res.status(201).json({
+        message: 'Processo seletivo criado com sucesso.',
+        processo,
+      });
+    } catch (error: any) {
+      if (error instanceof ZodError) {
+        return res.status(400).json({
+          success: false,
+          code: 'VALIDATION_ERROR',
+          message: 'Dados inválidos para criação do processo seletivo.',
+          issues: error.flatten().fieldErrors,
+        });
+      }
+
+      if (
+        error instanceof VagaProcessoVagaNaoEncontradaError ||
+        error instanceof VagaProcessoCandidatoNaoEncontradoError ||
+        error instanceof VagaProcessoCandidatoInvalidoError ||
+        error instanceof VagaProcessoDuplicadoError
+      ) {
+        return buildErrorResponse(res, error);
+      }
+
+      res.status(500).json({
+        success: false,
+        code: 'VAGA_PROCESSO_CREATE_ERROR',
+        message: 'Erro ao cadastrar o processo seletivo da vaga.',
+        error: error?.message,
+      });
+    }
+  };
+
+  static update = async (req: Request, res: Response) => {
+    try {
+      const { vagaId, processoId } = vagaProcessoDetailParamsSchema.parse({
+        vagaId: req.params.vagaId,
+        processoId: req.params.processoId,
+      });
+      const payload = updateVagaProcessoSchema.parse(req.body);
+
+      const processo = await vagasProcessosService.update(vagaId, processoId, payload);
+
+      res.json({
+        message: 'Processo seletivo atualizado com sucesso.',
+        processo,
+      });
+    } catch (error: any) {
+      if (error instanceof ZodError) {
+        return res.status(400).json({
+          success: false,
+          code: 'VALIDATION_ERROR',
+          message: 'Dados inválidos para atualização do processo seletivo.',
+          issues: error.flatten().fieldErrors,
+        });
+      }
+
+      if (error instanceof VagaProcessoNaoEncontradoError) {
+        return buildErrorResponse(res, error);
+      }
+
+      res.status(500).json({
+        success: false,
+        code: 'VAGA_PROCESSO_UPDATE_ERROR',
+        message: 'Erro ao atualizar o processo seletivo da vaga.',
+        error: error?.message,
+      });
+    }
+  };
+
+  static remove = async (req: Request, res: Response) => {
+    try {
+      const { vagaId, processoId } = vagaProcessoDetailParamsSchema.parse({
+        vagaId: req.params.vagaId,
+        processoId: req.params.processoId,
+      });
+
+      await vagasProcessosService.remove(vagaId, processoId);
+
+      res.status(204).send();
+    } catch (error: any) {
+      if (error instanceof ZodError) {
+        return res.status(400).json({
+          success: false,
+          code: 'VALIDATION_ERROR',
+          message: 'Parâmetros inválidos para remover o processo seletivo.',
+          issues: error.flatten().fieldErrors,
+        });
+      }
+
+      if (error instanceof VagaProcessoNaoEncontradoError) {
+        return buildErrorResponse(res, error);
+      }
+
+      res.status(500).json({
+        success: false,
+        code: 'VAGA_PROCESSO_DELETE_ERROR',
+        message: 'Erro ao remover o processo seletivo da vaga.',
+        error: error?.message,
+      });
+    }
+  };
+}

--- a/src/modules/empresas/vagas-processos/index.ts
+++ b/src/modules/empresas/vagas-processos/index.ts
@@ -1,0 +1,1 @@
+export { vagasProcessosRoutes } from './routes';

--- a/src/modules/empresas/vagas-processos/routes/index.ts
+++ b/src/modules/empresas/vagas-processos/routes/index.ts
@@ -1,0 +1,384 @@
+import { Router } from 'express';
+
+import { VagasProcessosController } from '@/modules/empresas/vagas-processos/controllers/vagas-processos.controller';
+
+const router = Router({ mergeParams: true });
+
+/**
+ * @openapi
+ * /api/v1/empresas/vagas/{vagaId}/processos:
+ *   get:
+ *     summary: Listar processos seletivos da vaga
+ *     description: "Retorna todos os processos seletivos vinculados a uma vaga específica. Permite filtrar por status, origem e candidato."
+ *     tags: [Empresas - VagasProcessos]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: vagaId
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *         description: Identificador da vaga.
+ *       - in: query
+ *         name: status
+ *         required: false
+ *         schema:
+ *           type: string
+ *           example: RECEBIDA,EM_ANALISE
+ *         description: Lista de status separados por vírgula.
+ *       - in: query
+ *         name: origem
+ *         required: false
+ *         schema:
+ *           type: string
+ *           example: SITE,DASHBOARD
+ *         description: Lista de origens separados por vírgula.
+ *       - in: query
+ *         name: candidatoId
+ *         required: false
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *         description: Filtra processos por candidato específico.
+ *     responses:
+ *       200:
+ *         description: Lista de processos seletivos da vaga.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: Lista de processos seletivos vinculados à vaga.
+ *                 vagaId:
+ *                   type: string
+ *                   format: uuid
+ *                 total:
+ *                   type: integer
+ *                 processos:
+ *                   type: array
+ *                   items:
+ *                     $ref: '#/components/schemas/VagaProcesso'
+ *       400:
+ *         description: Parâmetros inválidos.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ValidationErrorResponse'
+ *       401:
+ *         description: Token inválido ou ausente.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/UnauthorizedResponse'
+ *       404:
+ *         description: Vaga não encontrada.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno ao listar processos.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X GET "http://localhost:3000/api/v1/empresas/vagas/{vagaId}/processos" \
+ *            -H "Authorization: Bearer <TOKEN>"
+ */
+router.get('/', VagasProcessosController.list);
+
+/**
+ * @openapi
+ * /api/v1/empresas/vagas/{vagaId}/processos:
+ *   post:
+ *     summary: Criar novo processo seletivo para a vaga
+ *     description: "Cria um processo seletivo para um candidato em uma vaga específica."
+ *     tags: [Empresas - VagasProcessos]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: vagaId
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/VagaProcessoCreateInput'
+ *     responses:
+ *       201:
+ *         description: Processo criado com sucesso.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: Processo seletivo criado com sucesso.
+ *                 processo:
+ *                   $ref: '#/components/schemas/VagaProcesso'
+ *       400:
+ *         description: Dados inválidos.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ValidationErrorResponse'
+ *       401:
+ *         description: Token inválido ou ausente.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/UnauthorizedResponse'
+ *       404:
+ *         description: Vaga ou candidato não encontrado.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       409:
+ *         description: Processo duplicado para o candidato na vaga.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno ao criar processo.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X POST "http://localhost:3000/api/v1/empresas/vagas/{vagaId}/processos" \
+ *            -H "Authorization: Bearer <TOKEN>" \
+ *            -H "Content-Type: application/json" \
+ *            -d '{
+ *                  "candidatoId": "candidate-uuid",
+ *                  "status": "RECEBIDA",
+ *                  "origem": "SITE"
+ *                }'
+ */
+router.post('/', VagasProcessosController.create);
+
+/**
+ * @openapi
+ * /api/v1/empresas/vagas/{vagaId}/processos/{processoId}:
+ *   get:
+ *     summary: Consultar processo seletivo específico
+ *     description: Retorna os detalhes de um processo seletivo associado a uma vaga.
+ *     tags: [Empresas - VagasProcessos]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: vagaId
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *       - in: path
+ *         name: processoId
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *     responses:
+ *       200:
+ *         description: Processo retornado com sucesso.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: Processo seletivo recuperado com sucesso.
+ *                 processo:
+ *                   $ref: '#/components/schemas/VagaProcesso'
+ *       400:
+ *         description: Parâmetros inválidos.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ValidationErrorResponse'
+ *       401:
+ *         description: Token inválido ou ausente.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/UnauthorizedResponse'
+ *       404:
+ *         description: Processo não encontrado para a vaga.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno ao buscar processo.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X GET "http://localhost:3000/api/v1/empresas/vagas/{vagaId}/processos/{processoId}" \
+ *            -H "Authorization: Bearer <TOKEN>"
+ */
+router.get('/:processoId', VagasProcessosController.get);
+
+/**
+ * @openapi
+ * /api/v1/empresas/vagas/{vagaId}/processos/{processoId}:
+ *   patch:
+ *     summary: Atualizar processo seletivo da vaga
+ *     description: Atualiza status, origem ou observações de um processo seletivo existente.
+ *     tags: [Empresas - VagasProcessos]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: vagaId
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *       - in: path
+ *         name: processoId
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/VagaProcessoUpdateInput'
+ *     responses:
+ *       200:
+ *         description: Processo atualizado com sucesso.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: Processo seletivo atualizado com sucesso.
+ *                 processo:
+ *                   $ref: '#/components/schemas/VagaProcesso'
+ *       400:
+ *         description: Dados inválidos.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ValidationErrorResponse'
+ *       401:
+ *         description: Token inválido ou ausente.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/UnauthorizedResponse'
+ *       404:
+ *         description: Processo não encontrado.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno ao atualizar processo.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X PATCH "http://localhost:3000/api/v1/empresas/vagas/{vagaId}/processos/{processoId}" \
+ *            -H "Authorization: Bearer <TOKEN>" \
+ *            -H "Content-Type: application/json" \
+ *            -d '{
+ *                  "status": "ENTREVISTA",
+ *                  "origem": "DASHBOARD",
+ *                  "observacoes": "Entrevista agendada com o time de tecnologia."
+ *                }'
+ */
+router.patch('/:processoId', VagasProcessosController.update);
+
+/**
+ * @openapi
+ * /api/v1/empresas/vagas/{vagaId}/processos/{processoId}:
+ *   delete:
+ *     summary: Remover processo seletivo da vaga
+ *     description: Remove definitivamente um processo seletivo vinculado à vaga.
+ *     tags: [Empresas - VagasProcessos]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: vagaId
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *       - in: path
+ *         name: processoId
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *     responses:
+ *       204:
+ *         description: Processo removido com sucesso.
+ *       400:
+ *         description: Parâmetros inválidos.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ValidationErrorResponse'
+ *       401:
+ *         description: Token inválido ou ausente.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/UnauthorizedResponse'
+ *       404:
+ *         description: Processo não encontrado.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno ao remover processo.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X DELETE "http://localhost:3000/api/v1/empresas/vagas/{vagaId}/processos/{processoId}" \
+ *            -H "Authorization: Bearer <TOKEN>"
+ */
+router.delete('/:processoId', VagasProcessosController.remove);
+
+export { router as vagasProcessosRoutes };

--- a/src/modules/empresas/vagas-processos/services/errors.ts
+++ b/src/modules/empresas/vagas-processos/services/errors.ts
@@ -1,0 +1,49 @@
+export class VagaProcessoVagaNaoEncontradaError extends Error {
+  readonly code = 'VAGA_PROCESSO_VAGA_NOT_FOUND';
+  readonly status = 404;
+
+  constructor() {
+    super('Vaga não encontrada para associar o processo seletivo.');
+    this.name = 'VagaProcessoVagaNaoEncontradaError';
+  }
+}
+
+export class VagaProcessoCandidatoNaoEncontradoError extends Error {
+  readonly code = 'VAGA_PROCESSO_CANDIDATO_NOT_FOUND';
+  readonly status = 404;
+
+  constructor() {
+    super('Candidato não encontrado ou com perfil inválido para o processo seletivo.');
+    this.name = 'VagaProcessoCandidatoNaoEncontradoError';
+  }
+}
+
+export class VagaProcessoCandidatoInvalidoError extends Error {
+  readonly code = 'VAGA_PROCESSO_INVALID_CANDIDATE_ROLE';
+  readonly status = 400;
+
+  constructor() {
+    super('Somente perfis com role ALUNO_CANDIDATO podem ser vinculados a processos seletivos.');
+    this.name = 'VagaProcessoCandidatoInvalidoError';
+  }
+}
+
+export class VagaProcessoDuplicadoError extends Error {
+  readonly code = 'VAGA_PROCESSO_DUPLICATED';
+  readonly status = 409;
+
+  constructor() {
+    super('Já existe um processo seletivo ativo para o candidato nesta vaga.');
+    this.name = 'VagaProcessoDuplicadoError';
+  }
+}
+
+export class VagaProcessoNaoEncontradoError extends Error {
+  readonly code = 'VAGA_PROCESSO_NOT_FOUND';
+  readonly status = 404;
+
+  constructor() {
+    super('Processo seletivo não encontrado para a vaga informada.');
+    this.name = 'VagaProcessoNaoEncontradoError';
+  }
+}

--- a/src/modules/empresas/vagas-processos/services/vagas-processos.service.ts
+++ b/src/modules/empresas/vagas-processos/services/vagas-processos.service.ts
@@ -1,0 +1,208 @@
+import { Prisma, OrigemVagas, StatusProcesso } from '@prisma/client';
+
+import { prisma } from '@/config/prisma';
+import { attachEnderecoResumo } from '@/modules/usuarios/utils/address';
+import { mergeUsuarioInformacoes, usuarioInformacoesSelect } from '@/modules/usuarios/utils/information';
+import {
+  VagaProcessoCandidatoInvalidoError,
+  VagaProcessoCandidatoNaoEncontradoError,
+  VagaProcessoDuplicadoError,
+  VagaProcessoNaoEncontradoError,
+  VagaProcessoVagaNaoEncontradaError,
+} from '@/modules/empresas/vagas-processos/services/errors';
+
+const processoSelect = {
+  id: true,
+  vagaId: true,
+  candidatoId: true,
+  status: true,
+  origem: true,
+  observacoes: true,
+  agendadoEm: true,
+  criadoEm: true,
+  atualizadoEm: true,
+  candidato: {
+    select: {
+      id: true,
+      nomeCompleto: true,
+      email: true,
+      codUsuario: true,
+      role: true,
+      status: true,
+      tipoUsuario: true,
+      criadoEm: true,
+      ultimoLogin: true,
+      informacoes: {
+        select: usuarioInformacoesSelect,
+      },
+      enderecos: {
+        orderBy: { criadoEm: 'asc' },
+        select: {
+          id: true,
+          logradouro: true,
+          numero: true,
+          bairro: true,
+          cidade: true,
+          estado: true,
+          cep: true,
+        },
+      },
+    },
+  },
+} satisfies Prisma.EmpresasVagasProcessoSelect;
+
+type ProcessoSelect = typeof processoSelect;
+
+type ProcessoResult = Prisma.EmpresasVagasProcessoGetPayload<{ select: ProcessoSelect }>;
+
+const mapProcesso = (processo: ProcessoResult) => {
+  if (!processo.candidato) {
+    return { ...processo, candidato: null };
+  }
+
+  const candidatoComInformacoes = mergeUsuarioInformacoes(processo.candidato);
+  const candidatoComEndereco = attachEnderecoResumo(candidatoComInformacoes);
+
+  return {
+    ...processo,
+    candidato: candidatoComEndereco ?? candidatoComInformacoes,
+  };
+};
+
+const ensureVagaExists = async (vagaId: string) => {
+  const vaga = await prisma.empresasVagas.findUnique({
+    where: { id: vagaId },
+    select: { id: true },
+  });
+
+  if (!vaga) {
+    throw new VagaProcessoVagaNaoEncontradaError();
+  }
+};
+
+const ensureCandidatoElegivel = async (candidatoId: string) => {
+  const candidato = await prisma.usuarios.findUnique({
+    where: { id: candidatoId },
+    select: {
+      id: true,
+      role: true,
+    },
+  });
+
+  if (!candidato) {
+    throw new VagaProcessoCandidatoNaoEncontradoError();
+  }
+
+  if (candidato.role !== 'ALUNO_CANDIDATO') {
+    throw new VagaProcessoCandidatoInvalidoError();
+  }
+};
+
+const findProcessoOrThrow = async (vagaId: string, processoId: string) => {
+  const processo = await prisma.empresasVagasProcesso.findFirst({
+    where: { id: processoId, vagaId },
+    select: processoSelect,
+  });
+
+  if (!processo) {
+    throw new VagaProcessoNaoEncontradoError();
+  }
+
+  return processo;
+};
+
+export type VagaProcessoListFilters = {
+  status?: StatusProcesso[];
+  origem?: OrigemVagas[];
+  candidatoId?: string;
+};
+
+export type VagaProcessoCreateInput = {
+  candidatoId: string;
+  status?: StatusProcesso;
+  origem?: OrigemVagas;
+  observacoes?: string | null;
+  agendadoEm?: Date | null;
+};
+
+export type VagaProcessoUpdateInput = {
+  status?: StatusProcesso;
+  origem?: OrigemVagas;
+  observacoes?: string | null;
+  agendadoEm?: Date | null;
+};
+
+export const vagasProcessosService = {
+  list: async (vagaId: string, filters?: VagaProcessoListFilters) => {
+    await ensureVagaExists(vagaId);
+
+    const where: Prisma.EmpresasVagasProcessoWhereInput = {
+      vagaId,
+      ...(filters?.status && filters.status.length > 0 ? { status: { in: filters.status } } : {}),
+      ...(filters?.origem && filters.origem.length > 0 ? { origem: { in: filters.origem } } : {}),
+      ...(filters?.candidatoId ? { candidatoId: filters.candidatoId } : {}),
+    };
+
+    const processos = await prisma.empresasVagasProcesso.findMany({
+      where,
+      select: processoSelect,
+      orderBy: { criadoEm: 'desc' },
+    });
+
+    return processos.map(mapProcesso);
+  },
+
+  get: async (vagaId: string, processoId: string) => {
+    const processo = await findProcessoOrThrow(vagaId, processoId);
+    return mapProcesso(processo);
+  },
+
+  create: async (vagaId: string, input: VagaProcessoCreateInput) => {
+    await ensureVagaExists(vagaId);
+    await ensureCandidatoElegivel(input.candidatoId);
+
+    try {
+      const processo = await prisma.empresasVagasProcesso.create({
+        data: {
+          vagaId,
+          candidatoId: input.candidatoId,
+          status: input.status ?? StatusProcesso.RECEBIDA,
+          origem: input.origem ?? OrigemVagas.SITE,
+          observacoes: input.observacoes ?? null,
+          agendadoEm: input.agendadoEm ?? null,
+        },
+        select: processoSelect,
+      });
+
+      return mapProcesso(processo);
+    } catch (error: any) {
+      if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002') {
+        throw new VagaProcessoDuplicadoError();
+      }
+      throw error;
+    }
+  },
+
+  update: async (vagaId: string, processoId: string, input: VagaProcessoUpdateInput) => {
+    await findProcessoOrThrow(vagaId, processoId);
+
+    const processo = await prisma.empresasVagasProcesso.update({
+      where: { id: processoId },
+      data: {
+        ...(input.status ? { status: input.status } : {}),
+        ...(input.origem ? { origem: input.origem } : {}),
+        ...(input.observacoes !== undefined ? { observacoes: input.observacoes } : {}),
+        ...(input.agendadoEm !== undefined ? { agendadoEm: input.agendadoEm } : {}),
+      },
+      select: processoSelect,
+    });
+
+    return mapProcesso(processo);
+  },
+
+  remove: async (vagaId: string, processoId: string) => {
+    await findProcessoOrThrow(vagaId, processoId);
+
+    await prisma.empresasVagasProcesso.delete({ where: { id: processoId } });
+  },
+};

--- a/src/modules/empresas/vagas-processos/validators/vagas-processos.schema.ts
+++ b/src/modules/empresas/vagas-processos/validators/vagas-processos.schema.ts
@@ -1,0 +1,70 @@
+import { OrigemVagas, StatusProcesso } from '@prisma/client';
+import { z } from 'zod';
+
+const observacoesSchema = z
+  .string()
+  .trim()
+  .min(3, 'Descreva a observação com pelo menos 3 caracteres.')
+  .max(1000, 'As observações devem ter no máximo 1000 caracteres.')
+  .or(z.literal(''))
+  .or(z.null())
+  .optional()
+  .transform((value) => {
+    if (value === undefined) return undefined;
+    if (value === '' || value === null) return null;
+    return value;
+  });
+
+export const vagaProcessoParamsSchema = z.object({
+  vagaId: z.string({ required_error: 'O identificador da vaga é obrigatório.' }).uuid('Informe um ID de vaga válido.'),
+});
+
+export const vagaProcessoDetailParamsSchema = vagaProcessoParamsSchema.extend({
+  processoId: z.string({ required_error: 'O identificador do processo é obrigatório.' }).uuid('Informe um ID de processo válido.'),
+});
+
+export const vagaProcessoListQuerySchema = z
+  .object({
+    status: z
+      .string()
+      .transform((value) =>
+        value
+          .split(',')
+          .map((item) => item.trim())
+          .filter(Boolean)
+          .map((item) => item.toUpperCase()),
+      )
+      .pipe(z.array(z.nativeEnum(StatusProcesso)))
+      .optional(),
+    origem: z
+      .string()
+      .transform((value) =>
+        value
+          .split(',')
+          .map((item) => item.trim())
+          .filter(Boolean)
+          .map((item) => item.toUpperCase()),
+      )
+      .pipe(z.array(z.nativeEnum(OrigemVagas)))
+      .optional(),
+    candidatoId: z.string().uuid('Informe um ID de candidato válido.').optional(),
+  })
+  .partial();
+
+export const createVagaProcessoSchema = z.object({
+  candidatoId: z
+    .string({ required_error: 'O identificador do candidato é obrigatório.' })
+    .uuid('Informe um ID de candidato válido.'),
+  status: z.nativeEnum(StatusProcesso).optional(),
+  origem: z.nativeEnum(OrigemVagas).optional(),
+  observacoes: observacoesSchema,
+  agendadoEm: z.coerce.date().optional(),
+});
+
+export const updateVagaProcessoSchema = createVagaProcessoSchema
+  .partial()
+  .extend({ candidatoId: z.never().optional() })
+  .refine((data) => Object.keys(data).length > 0, {
+    message: 'Informe ao menos um campo para atualização do processo seletivo.',
+    path: ['status'],
+  });

--- a/src/modules/empresas/vagas/routes/index.ts
+++ b/src/modules/empresas/vagas/routes/index.ts
@@ -4,6 +4,7 @@ import { publicCache } from '@/middlewares/cache-control';
 import { supabaseAuthMiddleware, optionalSupabaseAuth } from '@/modules/usuarios/auth';
 import { Roles } from '@/modules/usuarios/enums/Roles';
 import { VagasController } from '@/modules/empresas/vagas/controllers/vagas.controller';
+import { vagasProcessosRoutes } from '@/modules/empresas/vagas-processos';
 
 const router = Router();
 const protectedRoles = [Roles.ADMIN, Roles.MODERADOR, Roles.EMPRESA, Roles.RECRUTADOR];
@@ -126,6 +127,8 @@ router.get('/', optionalSupabaseAuth(), publicCache, VagasController.list);
  *         source: |
  *           curl -X GET "http://localhost:3000/api/v1/empresas/vagas/{id}"
  */
+router.use('/:vagaId/processos', supabaseAuthMiddleware(protectedRoles), vagasProcessosRoutes);
+
 router.get('/:id', publicCache, VagasController.get);
 
 /**


### PR DESCRIPTION
## Summary
- add StatusProcesso and OrigemVagas enums with the EmpresasVagasProcesso model and relations in Prisma
- expose vacancy process management endpoints with validation, error handling and service logic
- document the new enums, schemas and routes in the Swagger/Redoc configuration

## Testing
- pnpm lint
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68cf8c8715e08332997298c8e96ad19d