### PR TITLE
feat: add dashboard candidate listing with optimized pagination

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -50,6 +50,7 @@ model Usuarios {
   @@index([role])
   @@index([tipoUsuario])
   @@index([criadoEm])
+  @@index([role, status, criadoEm], map: "usuarios_role_status_criadoem_idx")
 }
 
 model UsuariosInformation {

--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -6299,10 +6299,11 @@ const options: Options = {
                 },
                 limit: {
                   type: 'integer',
-                  example: 50,
+                  example: 10,
                   minimum: 1,
                   maximum: 100,
-                  description: 'Quantidade de registros retornados por página',
+                  description:
+                    'Quantidade de registros retornados por página. Na visão de dashboard o valor é fixado em 10.',
                 },
                 total: {
                   type: 'integer',

--- a/src/modules/usuarios/controllers/admin-controller.ts
+++ b/src/modules/usuarios/controllers/admin-controller.ts
@@ -61,7 +61,58 @@ export class AdminController {
       res.json(result);
     } catch (error) {
       const err = error instanceof Error ? error : new Error(String(error));
+      const statusCode = (error as any)?.statusCode;
+      if (typeof statusCode === 'number' && statusCode >= 400 && statusCode < 500) {
+        log.warn({ err }, 'Erro de validação ao listar candidatos');
+        const errorCode = (error as any)?.code ?? 'VALIDATION_ERROR';
+        return res.status(statusCode).json({
+          success: false,
+          code: errorCode,
+          message: err.message,
+          issues: {
+            search: [err.message],
+          },
+        });
+      }
+
       log.error({ err }, 'Erro ao listar candidatos');
+      return next(err);
+    }
+  };
+
+  /**
+   * Lista candidatos com limite otimizado para dashboards
+   */
+  public listarCandidatosDashboard = async (
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ) => {
+    const log = this.getLogger(req);
+    try {
+      const result = await this.adminService.listarCandidatos(req.query, {
+        defaultLimit: 10,
+        maxLimit: 10,
+        forceLimit: 10,
+      });
+      res.json(result);
+    } catch (error) {
+      const err = error instanceof Error ? error : new Error(String(error));
+      const statusCode = (error as any)?.statusCode;
+      if (typeof statusCode === 'number' && statusCode >= 400 && statusCode < 500) {
+        log.warn({ err }, 'Erro de validação ao listar candidatos para dashboard');
+        const errorCode = (error as any)?.code ?? 'VALIDATION_ERROR';
+        return res.status(statusCode).json({
+          success: false,
+          code: errorCode,
+          message: err.message,
+          issues: {
+            search: [err.message],
+          },
+        });
+      }
+
+      log.error({ err }, 'Erro ao listar candidatos para dashboard');
       return next(err);
     }
   };


### PR DESCRIPTION
## Summary
- add a composite index on `Usuarios` to optimize dashboard candidate queries
- extend the admin candidate listing service/controller with fixed-size pagination and validation helpers
- expose `/api/v1/usuarios/admin/candidatos/dashboard` to admins, moderadores and recrutadores and refresh the Swagger docs

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d0117dfd94832586adea4657f77d22