### PR TITLE
Remove Prisma map overrides for candidate interest tables

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -75,7 +75,6 @@ model CandidatosAreasInteresse {
   criadoEm  DateTime                       @default(now())
   atualizadoEm DateTime                     @updatedAt
 
-  @@map("candidatos_areas_interesse")
   @@index([categoria])
 }
 
@@ -88,8 +87,6 @@ model CandidatosSubareasInteresse {
   atualizadoEm DateTime                @updatedAt
 
   area CandidatosAreasInteresse @relation(fields: [areaId], references: [id], onDelete: Cascade)
-
-  @@map("candidatos_subareas_interesse")
   @@unique([areaId, nome])
   @@index([nome])
 }

--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -1454,6 +1454,7 @@ const options: Options = {
         },
         CandidatoAreaInteresse: {
           type: 'object',
+          description: 'Representa um registro da tabela CandidatosAreasInteresse utilizando a nomenclatura padrão do schema Prisma.',
           properties: {
             id: { type: 'integer', example: 1 },
             categoria: {
@@ -1481,6 +1482,7 @@ const options: Options = {
         },
         CandidatoAreaInteresseCreateInput: {
           type: 'object',
+          description: 'Payload para criação de registros em CandidatosAreasInteresse e suas subáreas relacionadas.',
           required: ['categoria', 'subareas'],
           properties: {
             categoria: {
@@ -1501,6 +1503,7 @@ const options: Options = {
         },
         CandidatoAreaInteresseUpdateInput: {
           type: 'object',
+          description: 'Payload para atualização de registros em CandidatosAreasInteresse mantendo a convenção padrão de nomes.',
           properties: {
             categoria: {
               type: 'string',


### PR DESCRIPTION
## Summary
- remove the @@map overrides from the candidate interest Prisma models to rely on default table names
- document the default naming in the Swagger/Redoc schemas for candidate areas de interesse

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d018f7f8788325b4195b7254afd8ae