### PR TITLE
feat: add website scripts management

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -627,6 +627,19 @@ model WebsiteImagemLogin {
   atualizadoEm DateTime @updatedAt
 }
 
+model WebsiteScript {
+  id          String                    @id @default(uuid())
+  nome        String?
+  descricao   String?
+  codigo      String                    @db.Text
+  orientacao  WebsiteScriptOrientation
+  status      WebsiteStatus             @default(RASCUNHO)
+  criadoEm    DateTime                  @default(now())
+  atualizadoEm DateTime                 @updatedAt
+
+  @@index([orientacao, status])
+}
+
 model WebsitePlaninhas {
   id           String   @id @default(uuid())
   titulo       String
@@ -872,6 +885,12 @@ enum WebsiteHeaderPageType {
   CURSOS
   POLITICA_PRIVACIDADE
   OUVIDORIA
+}
+
+enum WebsiteScriptOrientation {
+  HEADER
+  BODY
+  FOOTER
 }
 
 // ===============================

--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -103,6 +103,10 @@ const options: Options = {
         description: 'Cabeçalhos de páginas',
       },
       {
+        name: 'Website - Scripts',
+        description: 'Scripts e pixels do site',
+      },
+      {
         name: 'Empresas - Planos Empresariais',
         description: 'Gestão dos planos empresariais corporativos',
       },
@@ -167,6 +171,7 @@ const options: Options = {
           'Website - InformacoesGerais',
           'Website - ImagemLogin',
           'Website - Header Pages',
+          'Website - Scripts',
         ],
       },
       {
@@ -1552,6 +1557,7 @@ const options: Options = {
                   example: '/informacoes-gerais',
                 },
                 imagemLogin: { type: 'string', example: '/imagem-login' },
+                scripts: { type: 'string', example: '/scripts' },
               },
             },
             status: { type: 'string', example: 'operational' },
@@ -1561,6 +1567,108 @@ const options: Options = {
           type: 'string',
           enum: ['PUBLICADO', 'RASCUNHO'],
           example: 'PUBLICADO',
+        },
+        WebsiteScriptOrientation: {
+          type: 'string',
+          enum: ['HEADER', 'BODY', 'FOOTER'],
+          example: 'HEADER',
+          description: 'Define em qual parte do documento o script será injetado.',
+        },
+        WebsiteScript: {
+          type: 'object',
+          properties: {
+            id: { type: 'string', example: 'script-uuid' },
+            nome: {
+              type: 'string',
+              nullable: true,
+              example: 'Facebook Pixel',
+            },
+            descricao: {
+              type: 'string',
+              nullable: true,
+              example: 'Script utilizado para monitoramento de conversões.',
+            },
+            codigo: {
+              type: 'string',
+              description: 'Código completo do script/pixel a ser injetado.',
+              example: '<script>/* código do pixel */</script>',
+            },
+            orientacao: {
+              $ref: '#/components/schemas/WebsiteScriptOrientation',
+            },
+            status: {
+              $ref: '#/components/schemas/WebsiteStatus',
+            },
+            criadoEm: {
+              type: 'string',
+              format: 'date-time',
+              example: '2024-01-01T12:00:00Z',
+            },
+            atualizadoEm: {
+              type: 'string',
+              format: 'date-time',
+              example: '2024-01-02T15:30:00Z',
+            },
+          },
+        },
+        WebsiteScriptCreateInput: {
+          type: 'object',
+          required: ['codigo', 'orientacao'],
+          properties: {
+            nome: {
+              type: 'string',
+              nullable: true,
+              example: 'Facebook Pixel',
+            },
+            descricao: {
+              type: 'string',
+              nullable: true,
+              example: 'Script utilizado para monitoramento de conversões.',
+            },
+            codigo: {
+              type: 'string',
+              description: 'Conteúdo do script/pixel. Aceita HTML e JavaScript.',
+              example: '<script>/* código do pixel */</script>',
+            },
+            orientacao: {
+              $ref: '#/components/schemas/WebsiteScriptOrientation',
+            },
+            status: {
+              description:
+                'Estado de publicação. Aceita boolean (true = PUBLICADO, false = RASCUNHO) ou string.',
+              oneOf: [{ $ref: '#/components/schemas/WebsiteStatus' }, { type: 'boolean' }],
+              example: 'PUBLICADO',
+            },
+          },
+        },
+        WebsiteScriptUpdateInput: {
+          type: 'object',
+          properties: {
+            nome: {
+              type: 'string',
+              nullable: true,
+              example: 'Facebook Pixel',
+            },
+            descricao: {
+              type: 'string',
+              nullable: true,
+              example: 'Script utilizado para monitoramento de conversões.',
+            },
+            codigo: {
+              type: 'string',
+              description: 'Conteúdo atualizado do script/pixel.',
+              example: '<script>/* novo código */</script>',
+            },
+            orientacao: {
+              $ref: '#/components/schemas/WebsiteScriptOrientation',
+            },
+            status: {
+              description:
+                'Estado de publicação. Aceita boolean (true = PUBLICADO, false = RASCUNHO) ou string.',
+              oneOf: [{ $ref: '#/components/schemas/WebsiteStatus' }, { type: 'boolean' }],
+              example: false,
+            },
+          },
         },
         WebsiteBanner: {
           type: 'object',

--- a/src/modules/website/controllers/scripts.controller.ts
+++ b/src/modules/website/controllers/scripts.controller.ts
@@ -1,0 +1,181 @@
+import { Request, Response } from 'express';
+import { WebsiteScriptOrientation, WebsiteStatus } from '@prisma/client';
+
+import { websiteScriptsService } from '@/modules/website/services/scripts.service';
+import { respondWithCache } from '@/modules/website/utils/cache-response';
+
+const ORIENTATIONS = new Set(
+  Object.values(WebsiteScriptOrientation).map((value) => value.toString()),
+);
+const STATUSES = new Set(Object.values(WebsiteStatus).map((value) => value.toString()));
+
+function normalizeStatus(value: unknown): WebsiteStatus | undefined {
+  if (value === undefined || value === null || value === '') {
+    return undefined;
+  }
+  if (typeof value === 'boolean') {
+    return value ? WebsiteStatus.PUBLICADO : WebsiteStatus.RASCUNHO;
+  }
+  if (typeof value === 'string') {
+    const normalized = value.trim().toUpperCase();
+    if (STATUSES.has(normalized)) {
+      return normalized as WebsiteStatus;
+    }
+  }
+  throw new Error('Status inválido. Valores aceitos: PUBLICADO, RASCUNHO, true ou false.');
+}
+
+function normalizeOrientation(value: unknown): WebsiteScriptOrientation {
+  if (typeof value !== 'string') {
+    throw new Error('Orientação inválida. Informe HEADER, BODY ou FOOTER.');
+  }
+  const normalized = value.trim().toUpperCase();
+  if (!ORIENTATIONS.has(normalized)) {
+    throw new Error('Orientação inválida. Valores aceitos: HEADER, BODY ou FOOTER.');
+  }
+  return normalized as WebsiteScriptOrientation;
+}
+
+export class WebsiteScriptsController {
+  static list = async (req: Request, res: Response) => {
+    try {
+      const { orientacao, status } = req.query;
+
+      const filters: {
+        orientacao?: WebsiteScriptOrientation;
+        status?: WebsiteStatus;
+      } = {};
+
+      if (orientacao !== undefined) {
+        filters.orientacao = normalizeOrientation(String(orientacao));
+      }
+
+      if (status !== undefined) {
+        filters.status = normalizeStatus(status);
+      }
+
+      const scripts = await websiteScriptsService.list(filters);
+      return respondWithCache(req, res, scripts);
+    } catch (error: any) {
+      if (error instanceof Error && error.message.includes('inválid')) {
+        return res.status(400).json({ message: error.message });
+      }
+      return res.status(500).json({
+        message: 'Erro ao listar scripts',
+        error: error.message,
+      });
+    }
+  };
+
+  static get = async (req: Request, res: Response) => {
+    try {
+      const { id } = req.params;
+      const script = await websiteScriptsService.get(id);
+      if (!script) {
+        return res.status(404).json({ message: 'Script não encontrado' });
+      }
+      return respondWithCache(req, res, script);
+    } catch (error: any) {
+      return res.status(500).json({
+        message: 'Erro ao buscar script',
+        error: error.message,
+      });
+    }
+  };
+
+  static create = async (req: Request, res: Response) => {
+    try {
+      const { nome, descricao, codigo, orientacao, status } = req.body;
+
+      if (orientacao === undefined || orientacao === null || orientacao === '') {
+        return res
+          .status(400)
+          .json({ message: 'O campo "orientacao" é obrigatório.' });
+      }
+
+      if (typeof codigo !== 'string' || !codigo.trim()) {
+        return res.status(400).json({ message: 'O campo "codigo" é obrigatório.' });
+      }
+
+      const normalizedOrientation = normalizeOrientation(orientacao);
+      const normalizedStatus = normalizeStatus(status);
+
+      const script = await websiteScriptsService.create({
+        nome,
+        descricao,
+        codigo,
+        orientacao: normalizedOrientation,
+        status: normalizedStatus,
+      });
+
+      return res.status(201).json(script);
+    } catch (error: any) {
+      if (error instanceof Error && error.message.includes('inválid')) {
+        return res.status(400).json({ message: error.message });
+      }
+      return res.status(500).json({
+        message: 'Erro ao criar script',
+        error: error.message,
+      });
+    }
+  };
+
+  static update = async (req: Request, res: Response) => {
+    try {
+      const { id } = req.params;
+      const { nome, descricao, codigo, orientacao, status } = req.body;
+      const data: {
+        nome?: string;
+        descricao?: string;
+        codigo?: string;
+        orientacao?: WebsiteScriptOrientation;
+        status?: WebsiteStatus;
+      } = {};
+
+      if (nome !== undefined) data.nome = nome;
+      if (descricao !== undefined) data.descricao = descricao;
+      if (codigo !== undefined) {
+        if (typeof codigo !== 'string' || !codigo.trim()) {
+          return res.status(400).json({ message: 'O campo "codigo" deve ser um texto não vazio.' });
+        }
+        data.codigo = codigo;
+      }
+      if (orientacao !== undefined) {
+        data.orientacao = normalizeOrientation(orientacao);
+      }
+      if (status !== undefined) {
+        data.status = normalizeStatus(status);
+      }
+
+      const script = await websiteScriptsService.update(id, data);
+      return res.json(script);
+    } catch (error: any) {
+      if (error instanceof Error && error.message.includes('inválid')) {
+        return res.status(400).json({ message: error.message });
+      }
+      if (error.code === 'P2025') {
+        return res.status(404).json({ message: 'Script não encontrado' });
+      }
+      return res.status(500).json({
+        message: 'Erro ao atualizar script',
+        error: error.message,
+      });
+    }
+  };
+
+  static remove = async (req: Request, res: Response) => {
+    try {
+      const { id } = req.params;
+      await websiteScriptsService.remove(id);
+      return res.status(204).send();
+    } catch (error: any) {
+      if (error.code === 'P2025') {
+        return res.status(404).json({ message: 'Script não encontrado' });
+      }
+      return res.status(500).json({
+        message: 'Erro ao remover script',
+        error: error.message,
+      });
+    }
+  };
+}

--- a/src/modules/website/routes/index.ts
+++ b/src/modules/website/routes/index.ts
@@ -20,6 +20,7 @@ import { headerPagesRoutes } from './header-pages';
 import { depoimentosRoutes } from './depoimentos';
 import { informacoesGeraisRoutes } from './informacoes-gerais';
 import { imagemLoginRoutes } from './imagem-login';
+import { websiteScriptsRoutes } from './scripts';
 
 const router = Router();
 
@@ -74,6 +75,7 @@ router.get('/', publicCache, (req, res) => {
       depoimentos: '/depoimentos',
       informacoesGerais: '/informacoes-gerais',
       imagemLogin: '/imagem-login',
+      scripts: '/scripts',
     },
     status: 'operational',
   });
@@ -99,5 +101,6 @@ router.use('/header-pages', headerPagesRoutes);
 router.use('/depoimentos', depoimentosRoutes);
 router.use('/informacoes-gerais', informacoesGeraisRoutes);
 router.use('/imagem-login', imagemLoginRoutes);
+router.use('/scripts', websiteScriptsRoutes);
 
 export { router as websiteRoutes };

--- a/src/modules/website/routes/scripts.ts
+++ b/src/modules/website/routes/scripts.ts
@@ -1,0 +1,246 @@
+import { Router } from 'express';
+
+import { publicCache } from '../../../middlewares/cache-control';
+import { supabaseAuthMiddleware } from '../../usuarios/auth';
+import { WebsiteScriptsController } from '../controllers/scripts.controller';
+
+const router = Router();
+
+/**
+ * @openapi
+ * /api/v1/website/scripts:
+ *   get:
+ *     summary: Listar scripts e pixels configurados para o website
+ *     tags: [Website - Scripts]
+ *     parameters:
+ *       - in: query
+ *         name: orientacao
+ *         description: Filtro pela área onde o script será injetado
+ *         schema:
+ *           $ref: '#/components/schemas/WebsiteScriptOrientation'
+ *       - in: query
+ *         name: status
+ *         description: Filtro pelo status de publicação
+ *         schema:
+ *           oneOf:
+ *             - $ref: '#/components/schemas/WebsiteStatus'
+ *             - type: boolean
+ *     responses:
+ *       200:
+ *         description: Lista de scripts cadastrados
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 $ref: '#/components/schemas/WebsiteScript'
+ *       400:
+ *         description: Parâmetros inválidos
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X GET "http://localhost:3000/api/v1/website/scripts?orientacao=HEADER"
+ */
+router.get('/', publicCache, WebsiteScriptsController.list);
+
+/**
+ * @openapi
+ * /api/v1/website/scripts/{id}:
+ *   get:
+ *     summary: Obter um script específico por ID
+ *     tags: [Website - Scripts]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Script localizado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/WebsiteScript'
+ *       404:
+ *         description: Script não encontrado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X GET "http://localhost:3000/api/v1/website/scripts/{id}"
+ */
+router.get('/:id', publicCache, WebsiteScriptsController.get);
+
+/**
+ * @openapi
+ * /api/v1/website/scripts:
+ *   post:
+ *     summary: Cadastrar um novo script para o website
+ *     tags: [Website - Scripts]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/WebsiteScriptCreateInput'
+ *     responses:
+ *       201:
+ *         description: Script criado com sucesso
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/WebsiteScript'
+ *       400:
+ *         description: Dados inválidos
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X POST "http://localhost:3000/api/v1/website/scripts" \\
+ *            -H "Authorization: Bearer <TOKEN>" \\
+ *            -H "Content-Type: application/json" \\
+ *            -d '{"nome":"Facebook Pixel","codigo":"<script>...</script>","orientacao":"HEADER","status":"PUBLICADO"}'
+ */
+router.post(
+  '/',
+  supabaseAuthMiddleware(['ADMIN', 'MODERADOR']),
+  WebsiteScriptsController.create,
+);
+
+/**
+ * @openapi
+ * /api/v1/website/scripts/{id}:
+ *   put:
+ *     summary: Atualizar um script existente
+ *     tags: [Website - Scripts]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/WebsiteScriptUpdateInput'
+ *     responses:
+ *       200:
+ *         description: Script atualizado com sucesso
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/WebsiteScript'
+ *       400:
+ *         description: Dados inválidos
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       404:
+ *         description: Script não encontrado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X PUT "http://localhost:3000/api/v1/website/scripts/{id}" \\
+ *            -H "Authorization: Bearer <TOKEN>" \\
+ *            -H "Content-Type: application/json" \\
+ *            -d '{"status":false}'
+ */
+router.put(
+  '/:id',
+  supabaseAuthMiddleware(['ADMIN', 'MODERADOR']),
+  WebsiteScriptsController.update,
+);
+
+/**
+ * @openapi
+ * /api/v1/website/scripts/{id}:
+ *   delete:
+ *     summary: Remover um script cadastrado
+ *     tags: [Website - Scripts]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       204:
+ *         description: Script removido
+ *       404:
+ *         description: Script não encontrado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X DELETE "http://localhost:3000/api/v1/website/scripts/{id}" \\
+ *            -H "Authorization: Bearer <TOKEN>"
+ */
+router.delete(
+  '/:id',
+  supabaseAuthMiddleware(['ADMIN', 'MODERADOR']),
+  WebsiteScriptsController.remove,
+);
+
+export { router as websiteScriptsRoutes };

--- a/src/modules/website/services/scripts.service.ts
+++ b/src/modules/website/services/scripts.service.ts
@@ -1,0 +1,111 @@
+import { WebsiteScriptOrientation, WebsiteStatus } from '@prisma/client';
+
+import { prisma } from '@/config/prisma';
+import { WEBSITE_CACHE_TTL } from '@/modules/website/config';
+import { getCache, invalidateCacheByPrefix, setCache } from '@/utils/cache';
+
+const CACHE_PREFIX = 'website:scripts:list';
+
+type ListFilters = {
+  orientacao?: WebsiteScriptOrientation;
+  status?: WebsiteStatus;
+};
+
+const buildCacheKey = ({ orientacao, status }: ListFilters = {}) =>
+  `${CACHE_PREFIX}:${orientacao ?? 'all'}:${status ?? 'all'}`;
+
+const selectFields = {
+  id: true,
+  nome: true,
+  descricao: true,
+  codigo: true,
+  orientacao: true,
+  status: true,
+  criadoEm: true,
+  atualizadoEm: true,
+} satisfies Parameters<typeof prisma.websiteScript.findMany>[0]['select'];
+
+export const websiteScriptsService = {
+  list: async (filters: ListFilters = {}) => {
+    const cacheKey = buildCacheKey(filters);
+    const cached = await getCache<Awaited<ReturnType<typeof prisma.websiteScript.findMany>>>(cacheKey);
+    if (cached) return cached;
+
+    const where: Record<string, any> = {};
+    if (filters.orientacao) {
+      where.orientacao = filters.orientacao;
+    }
+    if (filters.status) {
+      where.status = filters.status;
+    }
+
+    const result = await prisma.websiteScript.findMany({
+      where,
+      orderBy: [
+        { orientacao: 'asc' },
+        { criadoEm: 'desc' },
+      ],
+      select: selectFields,
+    });
+
+    await setCache(cacheKey, result, WEBSITE_CACHE_TTL);
+    return result;
+  },
+
+  get: (id: string) =>
+    prisma.websiteScript.findUnique({
+      where: { id },
+      select: selectFields,
+    }),
+
+  create: async (data: {
+    nome?: string;
+    descricao?: string;
+    codigo: string;
+    orientacao: WebsiteScriptOrientation;
+    status?: WebsiteStatus;
+  }) => {
+    const result = await prisma.websiteScript.create({
+      data: {
+        nome: data.nome,
+        descricao: data.descricao,
+        codigo: data.codigo,
+        orientacao: data.orientacao,
+        status: data.status ?? 'RASCUNHO',
+      },
+      select: selectFields,
+    });
+    await invalidateCacheByPrefix(CACHE_PREFIX);
+    return result;
+  },
+
+  update: async (
+    id: string,
+    data: {
+      nome?: string;
+      descricao?: string;
+      codigo?: string;
+      orientacao?: WebsiteScriptOrientation;
+      status?: WebsiteStatus;
+    },
+  ) => {
+    const result = await prisma.websiteScript.update({
+      where: { id },
+      data,
+      select: selectFields,
+    });
+    await invalidateCacheByPrefix(CACHE_PREFIX);
+    return result;
+  },
+
+  remove: async (id: string) => {
+    const result = await prisma.websiteScript.delete({
+      where: { id },
+      select: { id: true },
+    });
+    await invalidateCacheByPrefix(CACHE_PREFIX);
+    return result;
+  },
+};
+
+export type WebsiteScriptListResult = Awaited<ReturnType<typeof websiteScriptsService.list>>;


### PR DESCRIPTION
## Summary
- add Prisma model and enum to store website scripts with orientation metadata
- expose service, controller and routes to manage website scripts with caching and validation
- document new endpoints, schemas and tag in Swagger including module overview updates

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d01c3327c48325aebe1ad9161094bb