### PR TITLE
feat(curriculos): add principal resume support

### DIFF
--- a/prisma/migrations/20250107120000_add_principal_to_usuarios_curriculos/migration.sql
+++ b/prisma/migrations/20250107120000_add_principal_to_usuarios_curriculos/migration.sql
@@ -1,0 +1,14 @@
+ALTER TABLE "UsuariosCurriculos"
+ADD COLUMN "principal" BOOLEAN NOT NULL DEFAULT false;
+
+WITH ranked AS (
+  SELECT
+    id,
+    ROW_NUMBER() OVER (PARTITION BY "usuarioId" ORDER BY "atualizadoEm" DESC, "criadoEm" DESC) AS row_number
+  FROM "UsuariosCurriculos"
+)
+UPDATE "UsuariosCurriculos" uc
+SET "principal" = true
+FROM ranked r
+WHERE uc.id = r.id
+  AND r.row_number = 1;

--- a/prisma/migrations/migration_lock.toml
+++ b/prisma/migrations/migration_lock.toml
@@ -1,0 +1,2 @@
+# This file is created by Prisma Migrate to track the provider of your database.
+provider = "postgresql"

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -226,6 +226,7 @@ model UsuariosCurriculos {
   titulo              String?  @db.VarChar(255)
   resumo              String?  @db.Text
   objetivo            String?  @db.VarChar(1000)
+  principal           Boolean  @default(false)
   areasInteresse      Json?
   preferencias        Json?
   habilidades         Json?

--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -1421,6 +1421,10 @@ const options: Options = {
             titulo: { type: 'string', nullable: true },
             resumo: { type: 'string', nullable: true },
             objetivo: { type: 'string', nullable: true },
+            principal: {
+              type: 'boolean',
+              description: 'Indica se o currículo é o principal do candidato',
+            },
             areasInteresse: { type: 'object', nullable: true },
             preferencias: { type: 'object', nullable: true },
             habilidades: { type: 'object', nullable: true },

--- a/src/modules/candidatos/curriculos/controllers.ts
+++ b/src/modules/candidatos/curriculos/controllers.ts
@@ -55,6 +55,8 @@ export const CurriculosController = {
           .json({ success: false, code: 'VALIDATION_ERROR', issues: error.flatten().fieldErrors });
       if (error?.code === 'NOT_FOUND')
         return res.status(404).json({ success: false, code: error.code, message: error.message });
+      if (error?.code === 'CURRICULO_PRINCIPAL_REQUIRED')
+        return res.status(400).json({ success: false, code: error.code, message: error.message });
       res.status(500).json({ success: false, code: 'UPDATE_ERROR', message: error?.message });
     }
   },

--- a/src/modules/candidatos/curriculos/services.ts
+++ b/src/modules/candidatos/curriculos/services.ts
@@ -8,7 +8,10 @@ export const curriculosService = {
   listOwn: async (usuarioId: string) => {
     return prisma.usuariosCurriculos.findMany({
       where: { usuarioId },
-      orderBy: { atualizadoEm: 'desc' },
+      orderBy: [
+        { principal: 'desc' },
+        { atualizadoEm: 'desc' },
+      ],
     });
   },
 
@@ -28,21 +31,112 @@ export const curriculosService = {
         code: 'CURRICULO_LIMIT',
       });
     }
-    return prisma.usuariosCurriculos.create({ data: { usuarioId, ...data } });
+    const { principal, ...rest } = data;
+    const shouldBePrincipal = total === 0 || principal === true;
+
+    return prisma.$transaction(async (tx) => {
+      if (shouldBePrincipal) {
+        await tx.usuariosCurriculos.updateMany({
+          where: { usuarioId, principal: true },
+          data: { principal: false },
+        });
+      }
+
+      const created = await tx.usuariosCurriculos.create({
+        data: {
+          usuarioId,
+          ...rest,
+          principal: shouldBePrincipal,
+        },
+      });
+
+      if (!shouldBePrincipal) {
+        const principalExists = await tx.usuariosCurriculos.count({
+          where: { usuarioId, principal: true },
+        });
+
+        if (principalExists === 0) {
+          return tx.usuariosCurriculos.update({
+            where: { id: created.id },
+            data: { principal: true, ultimaAtualizacao: new Date() },
+          });
+        }
+      }
+
+      return created;
+    });
   },
 
   update: async (usuarioId: string, id: string, data: CurriculoUpdateInput) => {
     const exists = await prisma.usuariosCurriculos.findFirst({ where: { id, usuarioId } });
     if (!exists) throw Object.assign(new Error('Currículo não encontrado'), { code: 'NOT_FOUND' });
-    return prisma.usuariosCurriculos.update({
-      where: { id },
-      data: { ...data, ultimaAtualizacao: new Date() },
+    const { principal, ...rest } = data;
+
+    return prisma.$transaction(async (tx) => {
+      if (principal === true) {
+        await tx.usuariosCurriculos.updateMany({
+          where: { usuarioId, principal: true, id: { not: id } },
+          data: { principal: false },
+        });
+      }
+
+      if (principal === false) {
+        const otherPrincipal = await tx.usuariosCurriculos.count({
+          where: { usuarioId, principal: true, id: { not: id } },
+        });
+        if (otherPrincipal === 0) {
+          throw Object.assign(new Error('É necessário manter ao menos um currículo principal'), {
+            code: 'CURRICULO_PRINCIPAL_REQUIRED',
+          });
+        }
+      }
+
+      const updated = await tx.usuariosCurriculos.update({
+        where: { id },
+        data: {
+          ...rest,
+          ...(principal !== undefined ? { principal } : {}),
+          ultimaAtualizacao: new Date(),
+        },
+      });
+
+      const principalExists = await tx.usuariosCurriculos.count({
+        where: { usuarioId, principal: true },
+      });
+
+      if (principalExists === 0) {
+        return tx.usuariosCurriculos.update({
+          where: { id },
+          data: { principal: true, ultimaAtualizacao: new Date() },
+        });
+      }
+
+      return updated;
     });
   },
 
   remove: async (usuarioId: string, id: string) => {
     const exists = await prisma.usuariosCurriculos.findFirst({ where: { id, usuarioId } });
     if (!exists) throw Object.assign(new Error('Currículo não encontrado'), { code: 'NOT_FOUND' });
-    await prisma.usuariosCurriculos.delete({ where: { id } });
+    await prisma.$transaction(async (tx) => {
+      await tx.usuariosCurriculos.delete({ where: { id } });
+
+      if (exists.principal) {
+        const nextPrincipal = await tx.usuariosCurriculos.findFirst({
+          where: { usuarioId },
+          orderBy: [
+            { principal: 'desc' },
+            { atualizadoEm: 'desc' },
+          ],
+        });
+
+        if (nextPrincipal) {
+          await tx.usuariosCurriculos.update({
+            where: { id: nextPrincipal.id },
+            data: { principal: true, ultimaAtualizacao: new Date() },
+          });
+        }
+      }
+    });
   },
 };

--- a/src/modules/candidatos/curriculos/validators.ts
+++ b/src/modules/candidatos/curriculos/validators.ts
@@ -14,6 +14,7 @@ export const curriculoCreateSchema = z.object({
   premiosPublicacoes: z.any().optional(),
   acessibilidade: z.any().optional(),
   consentimentos: z.any().optional(),
+  principal: z.boolean().optional(),
 });
 
 export const curriculoUpdateSchema = curriculoCreateSchema.partial();


### PR DESCRIPTION
## Summary
- adiciona campo `principal` em `UsuariosCurriculos` com migração e ajuste de geração do Prisma
- permite definir currículo principal na criação/edição e garante sempre um currículo destacado
- documenta o novo atributo nas validações, respostas da API e schema do Swagger/Redoc

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d03ce9fdf48325ac2f7afc793de73c