### PR TITLE
Fix Prisma type usage for user and website scripts

### DIFF
--- a/src/modules/usuarios/register/user-creation-helpers.ts
+++ b/src/modules/usuarios/register/user-creation-helpers.ts
@@ -14,6 +14,7 @@ import {
 import { emailVerificationSelect, normalizeEmailVerification } from '../utils/email-verification';
 import { mergeUsuarioInformacoes, usuarioInformacoesSelect } from '../utils/information';
 import {
+  type AdminCreateUserInput,
   type RegisterInput,
   type RegisterPessoaFisicaInput,
   type RegisterPessoaJuridicaInput,
@@ -65,9 +66,18 @@ export interface ProcessUserTypeSpecificDataResult {
   generoValidado?: string;
 }
 
-type CriarPessoaFisicaData = RegisterPessoaFisicaInput;
-type CriarPessoaJuridicaData = RegisterPessoaJuridicaInput;
-type CriarUsuarioData = RegisterInput;
+type AdminPessoaFisicaInput = Extract<
+  AdminCreateUserInput,
+  { tipoUsuario: TiposDeUsuarios.PESSOA_FISICA }
+>;
+type AdminPessoaJuridicaInput = Extract<
+  AdminCreateUserInput,
+  { tipoUsuario: TiposDeUsuarios.PESSOA_JURIDICA }
+>;
+
+type CriarPessoaFisicaData = RegisterPessoaFisicaInput | AdminPessoaFisicaInput;
+type CriarPessoaJuridicaData = RegisterPessoaJuridicaInput | AdminPessoaJuridicaInput;
+type CriarUsuarioData = RegisterInput | AdminCreateUserInput;
 
 const generateCodePrefix = (): string => {
   const letters = 'ABCDEFGHJKLMNPQRSTUVWXYZ';
@@ -269,7 +279,7 @@ export interface BuildUserDataForDatabaseParams {
 }
 
 export const buildUserDataForDatabase = (params: BuildUserDataForDatabaseParams) => {
-  const usuario: Prisma.UsuariosCreateInput = {
+  const usuario: Omit<Prisma.UsuariosCreateInput, 'codUsuario'> = {
     nomeCompleto: params.nomeCompleto.trim(),
     email: params.email.toLowerCase().trim(),
     senha: params.senha,

--- a/src/modules/website/services/scripts.service.ts
+++ b/src/modules/website/services/scripts.service.ts
@@ -1,4 +1,4 @@
-import { WebsiteScriptOrientation, WebsiteStatus } from '@prisma/client';
+import { Prisma, WebsiteScriptOrientation, WebsiteStatus } from '@prisma/client';
 
 import { prisma } from '@/config/prisma';
 import { WEBSITE_CACHE_TTL } from '@/modules/website/config';
@@ -23,7 +23,7 @@ const selectFields = {
   status: true,
   criadoEm: true,
   atualizadoEm: true,
-} satisfies Parameters<typeof prisma.websiteScript.findMany>[0]['select'];
+} satisfies Prisma.WebsiteScriptSelect;
 
 export const websiteScriptsService = {
   list: async (filters: ListFilters = {}) => {


### PR DESCRIPTION
## Summary
- allow the user creation helpers to accept admin user payloads while omitting the codUsuario field that is generated during persistence
- tighten the website scripts service select typing by relying on Prisma-generated types

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d042d945448325b9959eb8c1a61930