### PR TITLE
Fix telefone retrieval in Supabase auth middlewares

### DIFF
--- a/src/modules/usuarios/auth/optional-supabase.ts
+++ b/src/modules/usuarios/auth/optional-supabase.ts
@@ -72,29 +72,40 @@ export const optionalSupabaseAuth =
             nomeCompleto: true,
             cpf: true,
             cnpj: true,
-            telefone: true,
             role: true,
             status: true,
             tipoUsuario: true,
             supabaseId: true,
             ultimoLogin: true,
+            informacoes: {
+              select: { telefone: true },
+            },
           } as const;
 
-          type UsuarioCache = Prisma.UsuariosGetPayload<{
+          type UsuarioSelect = Prisma.UsuariosGetPayload<{
             select: typeof usuarioSelect;
           }>;
+
+          type UsuarioCache = Omit<UsuarioSelect, 'informacoes'> & {
+            telefone: string | null;
+          };
 
           let usuario: UsuarioCache | null = await getCache<UsuarioCache>(cacheKey);
 
           if (!usuario) {
-            usuario = await prisma.usuarios.findFirst({
+            const usuarioDb = await prisma.usuarios.findFirst({
               where: {
                 OR: [{ supabaseId: decoded.sub as string }, { id: decoded.sub as string }],
               },
               select: usuarioSelect,
             });
 
-            if (usuario) {
+            if (usuarioDb) {
+              const { informacoes, ...rest } = usuarioDb;
+              usuario = {
+                ...rest,
+                telefone: informacoes?.telefone ?? null,
+              };
               await setCache(cacheKey, usuario, 300);
             }
           }


### PR DESCRIPTION
## Summary
- update Supabase authentication middlewares to select telefone from UsuariosInformation instead of the removed column
- normalize the cached user payload so downstream consumers still receive the telefone field

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d047b3159c8325a4beed6668e61cb9