### PR TITLE
feat: add course categories structure

### DIFF
--- a/prisma/migrations/20250116120000_add_curso_structure/migration.sql
+++ b/prisma/migrations/20250116120000_add_curso_structure/migration.sql
@@ -1,0 +1,29 @@
+CREATE TYPE "CursoMetodo" AS ENUM ('ONLINE', 'PRESENCIAL', 'LIVE', 'SEMI_PRESENCIAL');
+
+CREATE TABLE "CursoCategoria" (
+    "id" SERIAL PRIMARY KEY,
+    "nome" VARCHAR(120) NOT NULL,
+    "descricao" VARCHAR(255)
+);
+
+CREATE TABLE "CursoSubcategoria" (
+    "id" SERIAL PRIMARY KEY,
+    "nome" VARCHAR(120) NOT NULL,
+    "descricao" VARCHAR(255),
+    "categoriaId" INTEGER NOT NULL REFERENCES "CursoCategoria"("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+CREATE TABLE "Curso" (
+    "id" SERIAL PRIMARY KEY,
+    "categoriaId" INTEGER REFERENCES "CursoCategoria"("id") ON DELETE SET NULL ON UPDATE CASCADE,
+    "subcategoriaId" INTEGER REFERENCES "CursoSubcategoria"("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+
+CREATE UNIQUE INDEX "CursoCategoria_nome_key" ON "CursoCategoria"("nome");
+CREATE INDEX "CursoCategoria_nome_idx" ON "CursoCategoria"("nome");
+
+CREATE UNIQUE INDEX "CursoSubcategoria_categoriaId_nome_key" ON "CursoSubcategoria"("categoriaId", "nome");
+CREATE INDEX "CursoSubcategoria_nome_idx" ON "CursoSubcategoria"("nome");
+
+CREATE INDEX "Curso_categoriaId_idx" ON "Curso"("categoriaId");
+CREATE INDEX "Curso_subcategoriaId_idx" ON "Curso"("subcategoriaId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -91,6 +91,40 @@ model CandidatosSubareasInteresse {
   @@index([nome])
 }
 
+model CursoCategoria {
+  id        Int                @id @default(autoincrement())
+  nome      String             @db.VarChar(120)
+  descricao String?            @db.VarChar(255)
+  subcats   CursoSubcategoria[]
+  cursos    Curso[]
+
+  @@unique([nome])
+  @@index([nome])
+}
+
+model CursoSubcategoria {
+  id           Int             @id @default(autoincrement())
+  nome         String          @db.VarChar(120)
+  descricao    String?         @db.VarChar(255)
+  categoriaId  Int
+  categoria    CursoCategoria  @relation(fields: [categoriaId], references: [id], onDelete: Cascade)
+  cursos       Curso[]
+
+  @@unique([categoriaId, nome])
+  @@index([nome])
+}
+
+model Curso {
+  id              Int               @id @default(autoincrement())
+  categoriaId     Int?
+  subcategoriaId  Int?
+  categoria       CursoCategoria?   @relation(fields: [categoriaId], references: [id], onDelete: SetNull)
+  subcategoria    CursoSubcategoria? @relation(fields: [subcategoriaId], references: [id], onDelete: SetNull)
+
+  @@index([categoriaId])
+  @@index([subcategoriaId])
+}
+
 model UsuariosVerificacaoEmail {
   usuarioId                  String   @id
   emailVerificado            Boolean  @default(false)
@@ -989,6 +1023,13 @@ enum Senioridade {
   SENIOR
   ESPECIALISTA
   LIDER
+}
+
+enum CursoMetodo {
+  ONLINE
+  PRESENCIAL
+  LIVE
+  SEMI_PRESENCIAL
 }
 
 enum EmpresasPlanoStatus {


### PR DESCRIPTION
## Summary
- add Prisma models for CursoCategoria, CursoSubcategoria and Curso with indices and relations
- define CursoMetodo enum to support course delivery methods
- create SQL migration to provision the new tables and enum in PostgreSQL

## Testing
- pnpm prisma:generate

------
https://chatgpt.com/codex/tasks/task_e_68d08306c6b483329499d6429b353d15