### PR TITLE
refactor: renomeia entidades de cursos para plural

### DIFF
--- a/prisma/migrations/20250116120000_add_curso_structure/migration.sql
+++ b/prisma/migrations/20250116120000_add_curso_structure/migration.sql
@@ -1,29 +1,29 @@
-CREATE TYPE "CursoMetodo" AS ENUM ('ONLINE', 'PRESENCIAL', 'LIVE', 'SEMI_PRESENCIAL');
+CREATE TYPE "CursosMetodo" AS ENUM ('ONLINE', 'PRESENCIAL', 'LIVE', 'SEMI_PRESENCIAL');
 
-CREATE TABLE "CursoCategoria" (
+CREATE TABLE "CursosCategorias" (
     "id" SERIAL PRIMARY KEY,
     "nome" VARCHAR(120) NOT NULL,
     "descricao" VARCHAR(255)
 );
 
-CREATE TABLE "CursoSubcategoria" (
+CREATE TABLE "CursosSubcategorias" (
     "id" SERIAL PRIMARY KEY,
     "nome" VARCHAR(120) NOT NULL,
     "descricao" VARCHAR(255),
-    "categoriaId" INTEGER NOT NULL REFERENCES "CursoCategoria"("id") ON DELETE CASCADE ON UPDATE CASCADE
+    "categoriaId" INTEGER NOT NULL REFERENCES "CursosCategorias"("id") ON DELETE CASCADE ON UPDATE CASCADE
 );
 
-CREATE TABLE "Curso" (
+CREATE TABLE "Cursos" (
     "id" SERIAL PRIMARY KEY,
-    "categoriaId" INTEGER REFERENCES "CursoCategoria"("id") ON DELETE SET NULL ON UPDATE CASCADE,
-    "subcategoriaId" INTEGER REFERENCES "CursoSubcategoria"("id") ON DELETE SET NULL ON UPDATE CASCADE
+    "categoriaId" INTEGER REFERENCES "CursosCategorias"("id") ON DELETE SET NULL ON UPDATE CASCADE,
+    "subcategoriaId" INTEGER REFERENCES "CursosSubcategorias"("id") ON DELETE SET NULL ON UPDATE CASCADE
 );
 
-CREATE UNIQUE INDEX "CursoCategoria_nome_key" ON "CursoCategoria"("nome");
-CREATE INDEX "CursoCategoria_nome_idx" ON "CursoCategoria"("nome");
+CREATE UNIQUE INDEX "CursosCategorias_nome_key" ON "CursosCategorias"("nome");
+CREATE INDEX "CursosCategorias_nome_idx" ON "CursosCategorias"("nome");
 
-CREATE UNIQUE INDEX "CursoSubcategoria_categoriaId_nome_key" ON "CursoSubcategoria"("categoriaId", "nome");
-CREATE INDEX "CursoSubcategoria_nome_idx" ON "CursoSubcategoria"("nome");
+CREATE UNIQUE INDEX "CursosSubcategorias_categoriaId_nome_key" ON "CursosSubcategorias"("categoriaId", "nome");
+CREATE INDEX "CursosSubcategorias_nome_idx" ON "CursosSubcategorias"("nome");
 
-CREATE INDEX "Curso_categoriaId_idx" ON "Curso"("categoriaId");
-CREATE INDEX "Curso_subcategoriaId_idx" ON "Curso"("subcategoriaId");
+CREATE INDEX "Cursos_categoriaId_idx" ON "Cursos"("categoriaId");
+CREATE INDEX "Cursos_subcategoriaId_idx" ON "Cursos"("subcategoriaId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -91,35 +91,35 @@ model CandidatosSubareasInteresse {
   @@index([nome])
 }
 
-model CursoCategoria {
+model CursosCategorias {
   id        Int                @id @default(autoincrement())
   nome      String             @db.VarChar(120)
   descricao String?            @db.VarChar(255)
-  subcats   CursoSubcategoria[]
-  cursos    Curso[]
+  subcats   CursosSubcategorias[]
+  cursos    Cursos[]
 
   @@unique([nome])
   @@index([nome])
 }
 
-model CursoSubcategoria {
+model CursosSubcategorias {
   id           Int             @id @default(autoincrement())
   nome         String          @db.VarChar(120)
   descricao    String?         @db.VarChar(255)
   categoriaId  Int
-  categoria    CursoCategoria  @relation(fields: [categoriaId], references: [id], onDelete: Cascade)
-  cursos       Curso[]
+  categoria    CursosCategorias  @relation(fields: [categoriaId], references: [id], onDelete: Cascade)
+  cursos       Cursos[]
 
   @@unique([categoriaId, nome])
   @@index([nome])
 }
 
-model Curso {
+model Cursos {
   id              Int               @id @default(autoincrement())
   categoriaId     Int?
   subcategoriaId  Int?
-  categoria       CursoCategoria?   @relation(fields: [categoriaId], references: [id], onDelete: SetNull)
-  subcategoria    CursoSubcategoria? @relation(fields: [subcategoriaId], references: [id], onDelete: SetNull)
+  categoria       CursosCategorias?    @relation(fields: [categoriaId], references: [id], onDelete: SetNull)
+  subcategoria    CursosSubcategorias? @relation(fields: [subcategoriaId], references: [id], onDelete: SetNull)
 
   @@index([categoriaId])
   @@index([subcategoriaId])
@@ -1025,7 +1025,7 @@ enum Senioridade {
   LIDER
 }
 
-enum CursoMetodo {
+enum CursosMetodo {
   ONLINE
   PRESENCIAL
   LIVE


### PR DESCRIPTION
## Summary
- atualiza a migration de cursos para usar as tabelas e índices no plural
- renomeia os modelos do Prisma relacionados a cursos e o enum de método para manter consistência

## Testing
- pnpm prisma:generate

------
https://chatgpt.com/codex/tasks/task_e_68d14c813e8083328591e28058676981