### PR TITLE
feat: add aulas management for course turmas

### DIFF
--- a/prisma/migrations/20250315120000_add_cursos_turmas_aulas/migration.sql
+++ b/prisma/migrations/20250315120000_add_cursos_turmas_aulas/migration.sql
@@ -1,0 +1,69 @@
+-- Create enums for aulas and materiais
+CREATE TYPE "CursosMateriais" AS ENUM (
+  'APOSTILA',
+  'SLIDE',
+  'VIDEOAULA',
+  'AUDIOAULA',
+  'ARTIGO',
+  'EXERCICIO',
+  'SIMULADO',
+  'LIVRO',
+  'CERTIFICADO',
+  'OUTRO'
+);
+
+CREATE TYPE "TiposDeArquivos" AS ENUM (
+  'pdf',
+  'docx',
+  'xlsx',
+  'pptx',
+  'imagem',
+  'video',
+  'audio',
+  'zip',
+  'link',
+  'outro'
+);
+
+-- Create table for aulas vinculadas às turmas
+CREATE TABLE "CursosTurmasAulas" (
+  "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+  "turmaId" UUID NOT NULL,
+  "nome" VARCHAR(255) NOT NULL,
+  "descricao" TEXT,
+  "ordem" INTEGER NOT NULL DEFAULT 0,
+  "criadoEm" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "atualizadoEm" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "CursosTurmasAulas_pkey" PRIMARY KEY ("id")
+);
+
+ALTER TABLE "CursosTurmasAulas"
+  ADD CONSTRAINT "CursosTurmasAulas_turmaId_fkey"
+  FOREIGN KEY ("turmaId") REFERENCES "CursosTurmas"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+CREATE INDEX "CursosTurmasAulas_turmaId_idx" ON "CursosTurmasAulas"("turmaId");
+CREATE INDEX "CursosTurmasAulas_turmaId_ordem_idx" ON "CursosTurmasAulas"("turmaId", "ordem");
+
+-- Create table for materiais vinculados às aulas
+CREATE TABLE "CursosTurmasAulasMateriais" (
+  "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+  "aulaId" UUID NOT NULL,
+  "titulo" VARCHAR(255) NOT NULL,
+  "descricao" VARCHAR(2000),
+  "tipo" "CursosMateriais" NOT NULL,
+  "tipoArquivo" "TiposDeArquivos",
+  "url" VARCHAR(2048),
+  "duracaoEmSegundos" INTEGER,
+  "tamanhoEmBytes" INTEGER,
+  "ordem" INTEGER NOT NULL DEFAULT 0,
+  "criadoEm" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "atualizadoEm" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "CursosTurmasAulasMateriais_pkey" PRIMARY KEY ("id")
+);
+
+ALTER TABLE "CursosTurmasAulasMateriais"
+  ADD CONSTRAINT "CursosTurmasAulasMateriais_aulaId_fkey"
+  FOREIGN KEY ("aulaId") REFERENCES "CursosTurmasAulas"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+CREATE INDEX "CursosTurmasAulasMateriais_aulaId_idx" ON "CursosTurmasAulasMateriais"("aulaId");
+CREATE INDEX "CursosTurmasAulasMateriais_tipo_idx" ON "CursosTurmasAulasMateriais"("tipo");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -154,9 +154,46 @@ model CursosTurmas {
   atualizadoEm         DateTime                 @updatedAt
   curso                Cursos                   @relation(fields: [cursoId], references: [id], onDelete: Cascade)
   matriculas           CursosTurmasMatriculas[]
+  aulas                CursosTurmasAulas[]
 
   @@index([cursoId])
   @@index([status])
+}
+
+model CursosTurmasAulas {
+  id          String   @id @default(uuid())
+  turmaId     String
+  nome        String   @db.VarChar(255)
+  descricao   String?  @db.Text
+  ordem       Int      @default(0)
+  criadoEm    DateTime @default(now())
+  atualizadoEm DateTime @updatedAt
+
+  turma      CursosTurmas                @relation(fields: [turmaId], references: [id], onDelete: Cascade)
+  materiais  CursosTurmasAulasMateriais[]
+
+  @@index([turmaId])
+  @@index([turmaId, ordem])
+}
+
+model CursosTurmasAulasMateriais {
+  id                String            @id @default(uuid())
+  aulaId            String
+  titulo            String            @db.VarChar(255)
+  descricao         String?           @db.VarChar(2000)
+  tipo              CursosMateriais
+  tipoArquivo       TiposDeArquivos?
+  url               String?           @db.VarChar(2048)
+  duracaoEmSegundos Int?
+  tamanhoEmBytes    Int?
+  ordem             Int               @default(0)
+  criadoEm          DateTime          @default(now())
+  atualizadoEm      DateTime          @updatedAt
+
+  aula CursosTurmasAulas @relation(fields: [aulaId], references: [id], onDelete: Cascade)
+
+  @@index([aulaId])
+  @@index([tipo])
 }
 
 model CursosTurmasMatriculas {
@@ -176,6 +213,32 @@ enum CursosStatusPadrao {
   PUBLICADO
   RASCUNHO
   DESPUBLICADO
+}
+
+enum CursosMateriais {
+  APOSTILA
+  SLIDE
+  VIDEOAULA
+  AUDIOAULA
+  ARTIGO
+  EXERCICIO
+  SIMULADO
+  LIVRO
+  CERTIFICADO
+  OUTRO
+}
+
+enum TiposDeArquivos {
+  pdf
+  docx
+  xlsx
+  pptx
+  imagem
+  video
+  audio
+  zip
+  link
+  outro
 }
 
 model UsuariosVerificacaoEmail {

--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -144,6 +144,10 @@ const options: Options = {
         description: 'Gestão de turmas, inscrições e matrículas dos cursos',
       },
       {
+        name: 'Cursos - Aulas',
+        description: 'Gestão de aulas e materiais vinculados às turmas',
+      },
+      {
         name: 'MercadoPago - Assinaturas',
         description: 'Assinaturas e cobranças recorrentes (Mercado Pago)',
       },
@@ -196,7 +200,7 @@ const options: Options = {
         name: 'Candidatos',
         tags: ['Candidatos', 'Candidatos - Áreas de Interesse'],
       },
-      { name: 'Cursos', tags: ['Cursos', 'Cursos - Turmas'] },
+      { name: 'Cursos', tags: ['Cursos', 'Cursos - Turmas', 'Cursos - Aulas'] },
       { name: 'Pagamentos', tags: ['MercadoPago - Assinaturas'] },
     ],
     components: {
@@ -272,6 +276,29 @@ const options: Options = {
           example: 'PUBLICADO',
           description: 'Status operacionais das turmas de cursos.',
         },
+        CursosMateriais: {
+          type: 'string',
+          enum: [
+            'APOSTILA',
+            'SLIDE',
+            'VIDEOAULA',
+            'AUDIOAULA',
+            'ARTIGO',
+            'EXERCICIO',
+            'SIMULADO',
+            'LIVRO',
+            'CERTIFICADO',
+            'OUTRO',
+          ],
+          example: 'VIDEOAULA',
+          description: 'Tipos de materiais pedagógicos vinculados às aulas das turmas.',
+        },
+        TiposDeArquivos: {
+          type: 'string',
+          enum: ['pdf', 'docx', 'xlsx', 'pptx', 'imagem', 'video', 'audio', 'zip', 'link', 'outro'],
+          example: 'pdf',
+          description: 'Extensões e formatos de arquivos aceitos para os materiais das aulas.',
+        },
         CursoInstrutor: {
           type: 'object',
           properties: {
@@ -287,6 +314,47 @@ const options: Options = {
             nome: { type: 'string', example: 'Maria Oliveira' },
             email: { type: 'string', format: 'email', example: 'maria.oliveira@example.com' },
             matricula: { type: 'string', nullable: true, example: 'MAT12345' },
+          },
+        },
+        CursoTurmaAulaMaterial: {
+          type: 'object',
+          properties: {
+            id: { type: 'string', format: 'uuid', example: 'mat-001' },
+            aulaId: { type: 'string', format: 'uuid', example: 'aul-001' },
+            titulo: { type: 'string', example: 'Slides de apresentação' },
+            descricao: {
+              type: 'string',
+              nullable: true,
+              example: 'Material de apoio utilizado na aula',
+            },
+            tipo: { $ref: '#/components/schemas/CursosMateriais' },
+            tipoArquivo: { $ref: '#/components/schemas/TiposDeArquivos', nullable: true },
+            url: { type: 'string', format: 'uri', nullable: true, example: 'https://cdn.example.com/video.mp4' },
+            duracaoEmSegundos: { type: 'integer', nullable: true, example: 1800 },
+            tamanhoEmBytes: { type: 'integer', nullable: true, example: 5242880 },
+            ordem: { type: 'integer', example: 1 },
+            criadoEm: { type: 'string', format: 'date-time', example: '2024-02-10T14:30:00Z' },
+            atualizadoEm: { type: 'string', format: 'date-time', example: '2024-02-11T09:00:00Z' },
+          },
+        },
+        CursoTurmaAula: {
+          type: 'object',
+          properties: {
+            id: { type: 'string', format: 'uuid', example: 'aul-001' },
+            turmaId: { type: 'string', format: 'uuid', example: 'f8a6c3b5-1234-4d9c-9a1b-abcdef123456' },
+            nome: { type: 'string', example: 'Introdução ao Excel' },
+            descricao: {
+              type: 'string',
+              nullable: true,
+              example: 'Apresentação dos conceitos básicos e visão geral do curso',
+            },
+            ordem: { type: 'integer', example: 1 },
+            criadoEm: { type: 'string', format: 'date-time', example: '2024-02-10T14:00:00Z' },
+            atualizadoEm: { type: 'string', format: 'date-time', example: '2024-02-10T15:00:00Z' },
+            materiais: {
+              type: 'array',
+              items: { $ref: '#/components/schemas/CursoTurmaAulaMaterial' },
+            },
           },
         },
         CursoTurma: {
@@ -315,6 +383,10 @@ const options: Options = {
             alunos: {
               type: 'array',
               items: { $ref: '#/components/schemas/CursoTurmaAluno' },
+            },
+            aulas: {
+              type: 'array',
+              items: { $ref: '#/components/schemas/CursoTurmaAula' },
             },
           },
         },
@@ -401,6 +473,64 @@ const options: Options = {
             vagasTotais: { type: 'integer', example: 35 },
             vagasDisponiveis: { type: 'integer', nullable: true, example: 20 },
             status: { $ref: '#/components/schemas/CursoStatus' },
+          },
+        },
+        CursoTurmaAulaMaterialInput: {
+          type: 'object',
+          required: ['titulo', 'tipo'],
+          properties: {
+            titulo: { type: 'string', example: 'Slides de apoio' },
+            descricao: {
+              type: 'string',
+              nullable: true,
+              example: 'Conteúdo complementar apresentado em sala',
+            },
+            tipo: { $ref: '#/components/schemas/CursosMateriais' },
+            tipoArquivo: { $ref: '#/components/schemas/TiposDeArquivos', nullable: true },
+            url: {
+              type: 'string',
+              format: 'uri',
+              nullable: true,
+              example: 'https://cdn.example.com/material.pdf',
+            },
+            duracaoEmSegundos: { type: 'integer', nullable: true, example: 900 },
+            tamanhoEmBytes: { type: 'integer', nullable: true, example: 2048000 },
+            ordem: { type: 'integer', nullable: true, example: 1 },
+          },
+        },
+        CursoTurmaAulaCreateInput: {
+          type: 'object',
+          required: ['nome'],
+          properties: {
+            nome: { type: 'string', example: 'Módulo 01 - Conceitos Básicos' },
+            descricao: {
+              type: 'string',
+              nullable: true,
+              example: 'Introdução aos principais conceitos da disciplina',
+            },
+            ordem: { type: 'integer', nullable: true, example: 1 },
+            materiais: {
+              type: 'array',
+              items: { $ref: '#/components/schemas/CursoTurmaAulaMaterialInput' },
+              nullable: true,
+            },
+          },
+        },
+        CursoTurmaAulaUpdateInput: {
+          type: 'object',
+          properties: {
+            nome: { type: 'string', example: 'Módulo 01 - Revisado' },
+            descricao: {
+              type: 'string',
+              nullable: true,
+              example: 'Atualização das instruções e materiais da aula',
+            },
+            ordem: { type: 'integer', nullable: true, example: 2 },
+            materiais: {
+              type: 'array',
+              items: { $ref: '#/components/schemas/CursoTurmaAulaMaterialInput' },
+              nullable: true,
+            },
           },
         },
         CursoTurmaEnrollmentInput: {

--- a/src/modules/cursos/controllers/aulas.controller.ts
+++ b/src/modules/cursos/controllers/aulas.controller.ts
@@ -1,0 +1,229 @@
+import { Request, Response } from 'express';
+import { ZodError } from 'zod';
+
+import { aulasService } from '../services/aulas.service';
+import { createAulaSchema, updateAulaSchema } from '../validators/aulas.schema';
+
+const parseCursoId = (raw: string) => {
+  const id = Number(raw);
+  if (!Number.isInteger(id) || id <= 0) {
+    return null;
+  }
+
+  return id;
+};
+
+const parseTurmaId = (raw: string) => {
+  if (typeof raw !== 'string' || raw.trim().length === 0) {
+    return null;
+  }
+
+  return raw;
+};
+
+const parseAulaId = (raw: string) => {
+  if (typeof raw !== 'string' || raw.trim().length === 0) {
+    return null;
+  }
+
+  return raw;
+};
+
+export class AulasController {
+  static list = async (req: Request, res: Response) => {
+    const cursoId = parseCursoId(req.params.cursoId);
+    const turmaId = parseTurmaId(req.params.turmaId);
+
+    if (!cursoId || !turmaId) {
+      return res.status(400).json({
+        success: false,
+        code: 'VALIDATION_ERROR',
+        message: 'Identificadores de curso ou turma inválidos',
+      });
+    }
+
+    try {
+      const aulas = await aulasService.list(cursoId, turmaId);
+      res.json({ data: aulas });
+    } catch (error: any) {
+      if (error?.code === 'TURMA_NOT_FOUND') {
+        return res.status(404).json({
+          success: false,
+          code: 'TURMA_NOT_FOUND',
+          message: 'Turma não encontrada para o curso informado',
+        });
+      }
+
+      res.status(500).json({
+        success: false,
+        code: 'AULAS_LIST_ERROR',
+        message: 'Erro ao listar aulas da turma',
+        error: error?.message,
+      });
+    }
+  };
+
+  static get = async (req: Request, res: Response) => {
+    const cursoId = parseCursoId(req.params.cursoId);
+    const turmaId = parseTurmaId(req.params.turmaId);
+    const aulaId = parseAulaId(req.params.aulaId);
+
+    if (!cursoId || !turmaId || !aulaId) {
+      return res.status(400).json({
+        success: false,
+        code: 'VALIDATION_ERROR',
+        message: 'Identificadores de curso, turma ou aula inválidos',
+      });
+    }
+
+    try {
+      const aula = await aulasService.get(cursoId, turmaId, aulaId);
+      res.json(aula);
+    } catch (error: any) {
+      if (error?.code === 'AULA_NOT_FOUND' || error?.code === 'TURMA_NOT_FOUND') {
+        return res.status(404).json({
+          success: false,
+          code: 'AULA_NOT_FOUND',
+          message: 'Aula não encontrada para a turma informada',
+        });
+      }
+
+      res.status(500).json({
+        success: false,
+        code: 'AULA_GET_ERROR',
+        message: 'Erro ao buscar aula da turma',
+        error: error?.message,
+      });
+    }
+  };
+
+  static create = async (req: Request, res: Response) => {
+    const cursoId = parseCursoId(req.params.cursoId);
+    const turmaId = parseTurmaId(req.params.turmaId);
+
+    if (!cursoId || !turmaId) {
+      return res.status(400).json({
+        success: false,
+        code: 'VALIDATION_ERROR',
+        message: 'Identificadores de curso ou turma inválidos',
+      });
+    }
+
+    try {
+      const data = createAulaSchema.parse(req.body);
+      const aula = await aulasService.create(cursoId, turmaId, data);
+      res.status(201).json(aula);
+    } catch (error: any) {
+      if (error instanceof ZodError) {
+        return res.status(400).json({
+          success: false,
+          code: 'VALIDATION_ERROR',
+          message: 'Dados inválidos para criação da aula',
+          issues: error.flatten().fieldErrors,
+        });
+      }
+
+      if (error?.code === 'TURMA_NOT_FOUND') {
+        return res.status(404).json({
+          success: false,
+          code: 'TURMA_NOT_FOUND',
+          message: 'Turma não encontrada para o curso informado',
+        });
+      }
+
+      res.status(500).json({
+        success: false,
+        code: 'AULA_CREATE_ERROR',
+        message: 'Erro ao criar aula para a turma',
+        error: error?.message,
+      });
+    }
+  };
+
+  static update = async (req: Request, res: Response) => {
+    const cursoId = parseCursoId(req.params.cursoId);
+    const turmaId = parseTurmaId(req.params.turmaId);
+    const aulaId = parseAulaId(req.params.aulaId);
+
+    if (!cursoId || !turmaId || !aulaId) {
+      return res.status(400).json({
+        success: false,
+        code: 'VALIDATION_ERROR',
+        message: 'Identificadores de curso, turma ou aula inválidos',
+      });
+    }
+
+    try {
+      const data = updateAulaSchema.parse(req.body);
+
+      if (Object.keys(data).length === 0) {
+        return res.status(400).json({
+          success: false,
+          code: 'VALIDATION_ERROR',
+          message: 'Informe ao menos um campo para atualização da aula',
+        });
+      }
+
+      const aula = await aulasService.update(cursoId, turmaId, aulaId, data);
+      res.json(aula);
+    } catch (error: any) {
+      if (error instanceof ZodError) {
+        return res.status(400).json({
+          success: false,
+          code: 'VALIDATION_ERROR',
+          message: 'Dados inválidos para atualização da aula',
+          issues: error.flatten().fieldErrors,
+        });
+      }
+
+      if (error?.code === 'AULA_NOT_FOUND' || error?.code === 'TURMA_NOT_FOUND') {
+        return res.status(404).json({
+          success: false,
+          code: 'AULA_NOT_FOUND',
+          message: 'Aula não encontrada para a turma informada',
+        });
+      }
+
+      res.status(500).json({
+        success: false,
+        code: 'AULA_UPDATE_ERROR',
+        message: 'Erro ao atualizar aula da turma',
+        error: error?.message,
+      });
+    }
+  };
+
+  static delete = async (req: Request, res: Response) => {
+    const cursoId = parseCursoId(req.params.cursoId);
+    const turmaId = parseTurmaId(req.params.turmaId);
+    const aulaId = parseAulaId(req.params.aulaId);
+
+    if (!cursoId || !turmaId || !aulaId) {
+      return res.status(400).json({
+        success: false,
+        code: 'VALIDATION_ERROR',
+        message: 'Identificadores de curso, turma ou aula inválidos',
+      });
+    }
+
+    try {
+      await aulasService.remove(cursoId, turmaId, aulaId);
+      res.json({ success: true });
+    } catch (error: any) {
+      if (error?.code === 'AULA_NOT_FOUND' || error?.code === 'TURMA_NOT_FOUND') {
+        return res.status(404).json({
+          success: false,
+          code: 'AULA_NOT_FOUND',
+          message: 'Aula não encontrada para a turma informada',
+        });
+      }
+
+      res.status(500).json({
+        success: false,
+        code: 'AULA_DELETE_ERROR',
+        message: 'Erro ao remover aula da turma',
+        error: error?.message,
+      });
+    }
+  };
+}

--- a/src/modules/cursos/routes/index.ts
+++ b/src/modules/cursos/routes/index.ts
@@ -5,6 +5,7 @@ import { publicCache } from '@/middlewares/cache-control';
 import { supabaseAuthMiddleware } from '@/modules/usuarios/auth';
 
 import { CursosController } from '../controllers/cursos.controller';
+import { AulasController } from '../controllers/aulas.controller';
 import { TurmasController } from '../controllers/turmas.controller';
 
 const router = Router();
@@ -423,6 +424,194 @@ router.delete(
   '/:cursoId/turmas/:turmaId/enrollments/:alunoId',
   supabaseAuthMiddleware([Roles.ADMIN, Roles.MODERADOR, Roles.PEDAGOGICO, Roles.PROFESSOR]),
   TurmasController.unenroll,
+);
+
+/**
+ * @openapi
+ * /api/v1/cursos/{cursoId}/turmas/{turmaId}/aulas:
+ *   get:
+ *     summary: Listar aulas de uma turma
+ *     tags: ['Cursos - Aulas']
+ *     parameters:
+ *       - in: path
+ *         name: cursoId
+ *         required: true
+ *         schema: { type: integer, minimum: 1 }
+ *       - in: path
+ *         name: turmaId
+ *         required: true
+ *         schema: { type: string, format: uuid }
+ *     responses:
+ *       200:
+ *         description: Lista de aulas cadastradas para a turma
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 data:
+ *                   type: array
+ *                   items:
+ *                     $ref: '#/components/schemas/CursoTurmaAula'
+ *       404:
+ *         description: Turma não encontrada para o curso informado
+ */
+router.get('/:cursoId/turmas/:turmaId/aulas', publicCache, AulasController.list);
+
+/**
+ * @openapi
+ * /api/v1/cursos/{cursoId}/turmas/{turmaId}/aulas/{aulaId}:
+ *   get:
+ *     summary: Obter detalhes de uma aula específica
+ *     tags: ['Cursos - Aulas']
+ *     parameters:
+ *       - in: path
+ *         name: cursoId
+ *         required: true
+ *         schema: { type: integer, minimum: 1 }
+ *       - in: path
+ *         name: turmaId
+ *         required: true
+ *         schema: { type: string, format: uuid }
+ *       - in: path
+ *         name: aulaId
+ *         required: true
+ *         schema: { type: string, format: uuid }
+ *     responses:
+ *       200:
+ *         description: Dados completos da aula
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/CursoTurmaAula'
+ *       404:
+ *         description: Aula ou turma não encontrada
+ */
+router.get('/:cursoId/turmas/:turmaId/aulas/:aulaId', publicCache, AulasController.get);
+
+/**
+ * @openapi
+ * /api/v1/cursos/{cursoId}/turmas/{turmaId}/aulas:
+ *   post:
+ *     summary: Criar uma nova aula para a turma
+ *     tags: ['Cursos - Aulas']
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: cursoId
+ *         required: true
+ *         schema: { type: integer, minimum: 1 }
+ *       - in: path
+ *         name: turmaId
+ *         required: true
+ *         schema: { type: string, format: uuid }
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/CursoTurmaAulaCreateInput'
+ *     responses:
+ *       201:
+ *         description: Aula criada com sucesso
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/CursoTurmaAula'
+ *       400:
+ *         description: Dados inválidos para criação da aula
+ *       404:
+ *         description: Turma não encontrada para o curso informado
+ */
+router.post(
+  '/:cursoId/turmas/:turmaId/aulas',
+  supabaseAuthMiddleware([Roles.ADMIN, Roles.MODERADOR, Roles.PEDAGOGICO, Roles.PROFESSOR]),
+  AulasController.create,
+);
+
+/**
+ * @openapi
+ * /api/v1/cursos/{cursoId}/turmas/{turmaId}/aulas/{aulaId}:
+ *   put:
+ *     summary: Atualizar informações de uma aula
+ *     tags: ['Cursos - Aulas']
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: cursoId
+ *         required: true
+ *         schema: { type: integer, minimum: 1 }
+ *       - in: path
+ *         name: turmaId
+ *         required: true
+ *         schema: { type: string, format: uuid }
+ *       - in: path
+ *         name: aulaId
+ *         required: true
+ *         schema: { type: string, format: uuid }
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/CursoTurmaAulaUpdateInput'
+ *     responses:
+ *       200:
+ *         description: Aula atualizada com sucesso
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/CursoTurmaAula'
+ *       400:
+ *         description: Dados inválidos para atualização da aula
+ *       404:
+ *         description: Aula ou turma não encontrada
+ */
+router.put(
+  '/:cursoId/turmas/:turmaId/aulas/:aulaId',
+  supabaseAuthMiddleware([Roles.ADMIN, Roles.MODERADOR, Roles.PEDAGOGICO, Roles.PROFESSOR]),
+  AulasController.update,
+);
+
+/**
+ * @openapi
+ * /api/v1/cursos/{cursoId}/turmas/{turmaId}/aulas/{aulaId}:
+ *   delete:
+ *     summary: Remover uma aula da turma
+ *     tags: ['Cursos - Aulas']
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: cursoId
+ *         required: true
+ *         schema: { type: integer, minimum: 1 }
+ *       - in: path
+ *         name: turmaId
+ *         required: true
+ *         schema: { type: string, format: uuid }
+ *       - in: path
+ *         name: aulaId
+ *         required: true
+ *         schema: { type: string, format: uuid }
+ *     responses:
+ *       200:
+ *         description: Aula removida com sucesso
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success: { type: boolean, example: true }
+ *       404:
+ *         description: Aula ou turma não encontrada
+ */
+router.delete(
+  '/:cursoId/turmas/:turmaId/aulas/:aulaId',
+  supabaseAuthMiddleware([Roles.ADMIN, Roles.MODERADOR, Roles.PEDAGOGICO, Roles.PROFESSOR]),
+  AulasController.delete,
 );
 
 export { router as cursosRoutes };

--- a/src/modules/cursos/services/aulas.mapper.ts
+++ b/src/modules/cursos/services/aulas.mapper.ts
@@ -1,0 +1,40 @@
+import { Prisma } from '@prisma/client';
+
+export const aulaWithMateriaisInclude = {
+  include: {
+    materiais: {
+      orderBy: [
+        { ordem: 'asc' },
+        { criadoEm: 'asc' },
+      ],
+    },
+  },
+} as const;
+
+export type AulaWithMateriais = Prisma.CursosTurmasAulasGetPayload<typeof aulaWithMateriaisInclude>;
+
+export const mapMaterial = (material: AulaWithMateriais['materiais'][number]) => ({
+  id: material.id,
+  aulaId: material.aulaId,
+  titulo: material.titulo,
+  descricao: material.descricao,
+  tipo: material.tipo,
+  tipoArquivo: material.tipoArquivo ?? null,
+  url: material.url ?? null,
+  duracaoEmSegundos: material.duracaoEmSegundos ?? null,
+  tamanhoEmBytes: material.tamanhoEmBytes ?? null,
+  ordem: material.ordem,
+  criadoEm: material.criadoEm.toISOString(),
+  atualizadoEm: material.atualizadoEm.toISOString(),
+});
+
+export const mapAula = (aula: AulaWithMateriais) => ({
+  id: aula.id,
+  turmaId: aula.turmaId,
+  nome: aula.nome,
+  descricao: aula.descricao,
+  ordem: aula.ordem,
+  criadoEm: aula.criadoEm.toISOString(),
+  atualizadoEm: aula.atualizadoEm.toISOString(),
+  materiais: aula.materiais.map(mapMaterial),
+});

--- a/src/modules/cursos/services/aulas.service.ts
+++ b/src/modules/cursos/services/aulas.service.ts
@@ -1,0 +1,190 @@
+import { CursosMateriais, Prisma, TiposDeArquivos } from '@prisma/client';
+
+import { prisma } from '@/config/prisma';
+import { logger } from '@/utils/logger';
+
+import { AulaWithMateriais, aulaWithMateriaisInclude, mapAula } from './aulas.mapper';
+
+const aulasLogger = logger.child({ module: 'CursosAulasService' });
+
+type PrismaClientOrTx = Prisma.TransactionClient | typeof prisma;
+
+type AulaMaterialInput = {
+  titulo: string;
+  descricao?: string | null;
+  tipo: CursosMateriais;
+  tipoArquivo?: TiposDeArquivos | null;
+  url?: string | null;
+  duracaoEmSegundos?: number | null;
+  tamanhoEmBytes?: number | null;
+  ordem?: number | null;
+};
+
+type AulaInput = {
+  nome?: string;
+  descricao?: string | null;
+  ordem?: number | null;
+  materiais?: AulaMaterialInput[];
+};
+
+const ensureTurmaBelongsToCurso = async (
+  client: PrismaClientOrTx,
+  cursoId: number,
+  turmaId: string,
+): Promise<void> => {
+  const turma = await client.cursosTurmas.findFirst({
+    where: { id: turmaId, cursoId },
+    select: { id: true },
+  });
+
+  if (!turma) {
+    const error = new Error('Turma não encontrada para o curso informado');
+    (error as any).code = 'TURMA_NOT_FOUND';
+    throw error;
+  }
+};
+
+const ensureAulaBelongsToTurma = async (
+  client: PrismaClientOrTx,
+  cursoId: number,
+  turmaId: string,
+  aulaId: string,
+): Promise<void> => {
+  const aula = await client.cursosTurmasAulas.findFirst({
+    where: {
+      id: aulaId,
+      turmaId,
+      turma: { cursoId },
+    },
+    select: { id: true },
+  });
+
+  if (!aula) {
+    const error = new Error('Aula não encontrada para a turma informada');
+    (error as any).code = 'AULA_NOT_FOUND';
+    throw error;
+  }
+};
+
+const fetchAula = async (client: PrismaClientOrTx, aulaId: string): Promise<ReturnType<typeof mapAula>> => {
+  const aula = await client.cursosTurmasAulas.findUnique({
+    where: { id: aulaId },
+    ...aulaWithMateriaisInclude,
+  });
+
+  if (!aula) {
+    const error = new Error('Aula não encontrada');
+    (error as any).code = 'AULA_NOT_FOUND';
+    throw error;
+  }
+
+  return mapAula(aula as AulaWithMateriais);
+};
+
+const normalizeMaterialInput = (material: AulaMaterialInput) => ({
+  titulo: material.titulo,
+  descricao: material.descricao ?? null,
+  tipo: material.tipo,
+  tipoArquivo: material.tipoArquivo ?? null,
+  url: material.url ?? null,
+  duracaoEmSegundos: material.duracaoEmSegundos ?? null,
+  tamanhoEmBytes: material.tamanhoEmBytes ?? null,
+  ordem: material.ordem ?? 0,
+});
+
+export const aulasService = {
+  async list(cursoId: number, turmaId: string) {
+    await ensureTurmaBelongsToCurso(prisma, cursoId, turmaId);
+
+    const aulas = await prisma.cursosTurmasAulas.findMany({
+      where: { turmaId },
+      orderBy: [
+        { ordem: 'asc' },
+        { criadoEm: 'asc' },
+      ],
+      ...aulaWithMateriaisInclude,
+    });
+
+    return (aulas as AulaWithMateriais[]).map(mapAula);
+  },
+
+  async get(cursoId: number, turmaId: string, aulaId: string) {
+    await ensureAulaBelongsToTurma(prisma, cursoId, turmaId, aulaId);
+
+    return fetchAula(prisma, aulaId);
+  },
+
+  async create(cursoId: number, turmaId: string, data: AulaInput & { nome: string }) {
+    return prisma.$transaction(async (tx) => {
+      await ensureTurmaBelongsToCurso(tx, cursoId, turmaId);
+
+      const ordem = data.ordem ?? (await tx.cursosTurmasAulas.count({ where: { turmaId } })) + 1;
+
+      const aula = await tx.cursosTurmasAulas.create({
+        data: {
+          turmaId,
+          nome: data.nome,
+          descricao: data.descricao ?? null,
+          ordem,
+        },
+      });
+
+      if (Array.isArray(data.materiais) && data.materiais.length > 0) {
+        await tx.cursosTurmasAulasMateriais.createMany({
+          data: data.materiais.map((material) => ({
+            aulaId: aula.id,
+            ...normalizeMaterialInput(material),
+          })),
+        });
+      }
+
+      aulasLogger.info({ turmaId, aulaId: aula.id }, 'Aula criada com sucesso');
+
+      return fetchAula(tx, aula.id);
+    });
+  },
+
+  async update(cursoId: number, turmaId: string, aulaId: string, data: AulaInput) {
+    return prisma.$transaction(async (tx) => {
+      await ensureAulaBelongsToTurma(tx, cursoId, turmaId, aulaId);
+
+      await tx.cursosTurmasAulas.update({
+        where: { id: aulaId },
+        data: {
+          nome: data.nome ?? undefined,
+          descricao: data.descricao ?? undefined,
+          ordem: data.ordem ?? undefined,
+        },
+      });
+
+      if (Array.isArray(data.materiais)) {
+        await tx.cursosTurmasAulasMateriais.deleteMany({ where: { aulaId } });
+
+        if (data.materiais.length > 0) {
+          await tx.cursosTurmasAulasMateriais.createMany({
+            data: data.materiais.map((material) => ({
+              aulaId,
+              ...normalizeMaterialInput(material),
+            })),
+          });
+        }
+      }
+
+      aulasLogger.info({ turmaId, aulaId }, 'Aula atualizada com sucesso');
+
+      return fetchAula(tx, aulaId);
+    });
+  },
+
+  async remove(cursoId: number, turmaId: string, aulaId: string) {
+    return prisma.$transaction(async (tx) => {
+      await ensureAulaBelongsToTurma(tx, cursoId, turmaId, aulaId);
+
+      await tx.cursosTurmasAulas.delete({ where: { id: aulaId } });
+
+      aulasLogger.info({ turmaId, aulaId }, 'Aula removida com sucesso');
+
+      return { success: true } as const;
+    });
+  },
+};

--- a/src/modules/cursos/services/cursos.service.ts
+++ b/src/modules/cursos/services/cursos.service.ts
@@ -4,6 +4,7 @@ import { prisma } from '@/config/prisma';
 import { logger } from '@/utils/logger';
 
 import { generateUniqueCourseCode } from '../utils/code-generator';
+import { aulaWithMateriaisInclude, mapAula } from './aulas.mapper';
 
 const cursosLogger = logger.child({ module: 'CursosService' });
 
@@ -41,6 +42,13 @@ const turmaDetailedInclude = {
           },
         },
       },
+    },
+    aulas: {
+      orderBy: [
+        { ordem: 'asc' },
+        { criadoEm: 'asc' },
+      ],
+      include: aulaWithMateriaisInclude.include,
     },
   },
 } as const;
@@ -101,6 +109,7 @@ const mapTurmaDetailed = (
     email: matricula.aluno.email,
     matricula: matricula.aluno.informacoes?.matricula ?? null,
   })),
+  aulas: turma.aulas?.map(mapAula) ?? [],
 });
 
 const mapCourse = (course: RawCourse) => ({

--- a/src/modules/cursos/services/turmas.service.ts
+++ b/src/modules/cursos/services/turmas.service.ts
@@ -7,6 +7,7 @@ import {
   generateUniqueEnrollmentCode,
   generateUniqueTurmaCode,
 } from '../utils/code-generator';
+import { aulaWithMateriaisInclude } from './aulas.mapper';
 import { cursosTurmasMapper } from './cursos.service';
 
 const turmasLogger = logger.child({ module: 'CursosTurmasService' });
@@ -46,6 +47,13 @@ const turmaDetailedInclude = {
           },
         },
       },
+    },
+    aulas: {
+      orderBy: [
+        { ordem: 'asc' },
+        { criadoEm: 'asc' },
+      ],
+      include: aulaWithMateriaisInclude.include,
     },
   },
 } as const;

--- a/src/modules/cursos/validators/aulas.schema.ts
+++ b/src/modules/cursos/validators/aulas.schema.ts
@@ -1,0 +1,51 @@
+import { CursosMateriais, TiposDeArquivos } from '@prisma/client';
+import { z } from 'zod';
+
+const nonNegativeInt = z
+  .preprocess((value) => {
+    if (value === undefined || value === '') {
+      return undefined;
+    }
+
+    if (value === null) {
+      return null;
+    }
+
+    const parsed = Number(value);
+    return Number.isNaN(parsed) ? value : parsed;
+  }, z.union([z.number({ invalid_type_error: 'Informe um número válido' }).int('Valor deve ser inteiro').min(0), z.null()]))
+  .optional();
+
+const materialSchema = z.object({
+  titulo: z.string().trim().min(3).max(255),
+  descricao: z
+    .string({ invalid_type_error: 'Descrição deve ser um texto' })
+    .trim()
+    .max(2000)
+    .nullish(),
+  tipo: z.nativeEnum(CursosMateriais),
+  tipoArquivo: z.nativeEnum(TiposDeArquivos).nullish(),
+  url: z
+    .string({ invalid_type_error: 'Informe uma URL válida' })
+    .trim()
+    .url('Informe uma URL válida')
+    .nullish(),
+  duracaoEmSegundos: nonNegativeInt,
+  tamanhoEmBytes: nonNegativeInt,
+  ordem: nonNegativeInt,
+});
+
+const aulaBaseSchema = z.object({
+  nome: z.string().trim().min(3).max(255),
+  descricao: z
+    .string({ invalid_type_error: 'Descrição deve ser um texto' })
+    .trim()
+    .max(2000)
+    .nullish(),
+  ordem: nonNegativeInt,
+  materiais: z.array(materialSchema).optional(),
+});
+
+export const createAulaSchema = aulaBaseSchema;
+
+export const updateAulaSchema = aulaBaseSchema.partial();

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -81,6 +81,7 @@ router.get('/', publicCache, (req, res) => {
       empresas: '/api/v1/empresas',
       candidatos: '/api/v1/candidatos',
       cursos: '/api/v1/cursos',
+      cursosTurmasAulas: '/api/v1/cursos/{cursoId}/turmas/{turmaId}/aulas',
       candidatosAreasInteresse: '/api/v1/candidatos/areas-interesse',
       planosEmpresariais: '/api/v1/empresas/planos-empresariais',
       clientesEmpresas: '/api/v1/empresas/clientes',


### PR DESCRIPTION
## Summary
- add Prisma enums and models plus migration to store aulas and materiais for curso turmas
- implement aulas service, controller, validators and routes to manage lessons and their resources
- update Swagger docs and public metadata with the new enums and endpoints

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d176481fd88332be56a1cfaa2497c5