### PR TITLE
feat: implementar módulos e avaliação flexível nos cursos

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -155,24 +155,49 @@ model CursosTurmas {
   curso                Cursos                   @relation(fields: [cursoId], references: [id], onDelete: Cascade)
   matriculas           CursosTurmasMatriculas[]
   aulas                CursosTurmasAulas[]
+  modulos              CursosTurmasModulos[]
+  provas               CursosTurmasProvas[]
+  regrasAvaliacao      CursosTurmasRegrasAvaliacao?
+  recuperacoes         CursosTurmasRecuperacoes[]
 
   @@index([cursoId])
   @@index([status])
 }
 
+model CursosTurmasModulos {
+  id          String   @id @default(uuid())
+  turmaId     String
+  nome        String   @db.VarChar(255)
+  descricao   String?  @db.Text
+  obrigatorio Boolean  @default(true)
+  ordem       Int      @default(0)
+  criadoEm    DateTime @default(now())
+  atualizadoEm DateTime @updatedAt
+
+  turma   CursosTurmas       @relation(fields: [turmaId], references: [id], onDelete: Cascade)
+  aulas   CursosTurmasAulas[]
+  provas  CursosTurmasProvas[]
+
+  @@index([turmaId])
+  @@index([turmaId, ordem])
+}
+
 model CursosTurmasAulas {
   id          String   @id @default(uuid())
   turmaId     String
+  moduloId    String?
   nome        String   @db.VarChar(255)
   descricao   String?  @db.Text
   ordem       Int      @default(0)
   criadoEm    DateTime @default(now())
   atualizadoEm DateTime @updatedAt
 
-  turma      CursosTurmas                @relation(fields: [turmaId], references: [id], onDelete: Cascade)
-  materiais  CursosTurmasAulasMateriais[]
+  turma     CursosTurmas               @relation(fields: [turmaId], references: [id], onDelete: Cascade)
+  modulo    CursosTurmasModulos?       @relation(fields: [moduloId], references: [id], onDelete: SetNull)
+  materiais CursosTurmasAulasMateriais[]
 
   @@index([turmaId])
+  @@index([moduloId])
   @@index([turmaId, ordem])
 }
 
@@ -204,9 +229,119 @@ model CursosTurmasMatriculas {
 
   turma CursosTurmas @relation(fields: [turmaId], references: [id], onDelete: Cascade)
   aluno Usuarios     @relation(fields: [alunoId], references: [id], onDelete: Cascade)
+  envios CursosTurmasProvasEnvios[]
+  recuperacoes CursosTurmasRecuperacoes[]
 
   @@unique([turmaId, alunoId])
   @@index([alunoId])
+}
+
+model CursosTurmasProvas {
+  id           String             @id @default(uuid())
+  turmaId      String
+  moduloId     String?
+  titulo       String             @db.VarChar(255)
+  etiqueta     String             @db.VarChar(30)
+  descricao    String?            @db.Text
+  peso         Decimal            @db.Decimal(5, 2)
+  ativo        Boolean            @default(true)
+  localizacao  CursosLocalProva   @default(TURMA)
+  ordem        Int                @default(0)
+  criadoEm     DateTime           @default(now())
+  atualizadoEm DateTime           @updatedAt
+
+  turma      CursosTurmas         @relation(fields: [turmaId], references: [id], onDelete: Cascade)
+  modulo     CursosTurmasModulos? @relation(fields: [moduloId], references: [id], onDelete: SetNull)
+  envios     CursosTurmasProvasEnvios[]
+  recuperacoes CursosTurmasRecuperacoes[]
+
+  @@unique([turmaId, etiqueta])
+  @@index([turmaId])
+  @@index([moduloId])
+  @@index([turmaId, ativo])
+}
+
+model CursosTurmasProvasEnvios {
+  id          String   @id @default(uuid())
+  provaId     String
+  matriculaId String
+  nota        Decimal? @db.Decimal(4, 1)
+  pesoTotal   Decimal? @db.Decimal(5, 2)
+  realizadoEm DateTime?
+  observacoes String?  @db.Text
+  criadoEm    DateTime @default(now())
+  atualizadoEm DateTime @updatedAt
+
+  prova      CursosTurmasProvas     @relation(fields: [provaId], references: [id], onDelete: Cascade)
+  matricula  CursosTurmasMatriculas @relation(fields: [matriculaId], references: [id], onDelete: Cascade)
+  recuperacoes CursosTurmasRecuperacoes[]
+
+  @@unique([provaId, matriculaId])
+  @@index([matriculaId])
+}
+
+model CursosTurmasRegrasAvaliacao {
+  id                         String                       @id @default(uuid())
+  turmaId                    String                       @unique
+  mediaMinima                Decimal                      @db.Decimal(4, 1)
+  politicaRecuperacaoAtiva   Boolean                      @default(false)
+  modelosRecuperacao         CursosModelosRecuperacao[]   @default([])
+  ordemAplicacaoRecuperacao  CursosModelosRecuperacao[]   @default([])
+  notaMaximaRecuperacao      Decimal?                     @db.Decimal(4, 1)
+  pesoProvaFinal             Decimal?                     @db.Decimal(5, 2)
+  observacoes                String?                      @db.VarChar(500)
+  criadoEm                   DateTime                     @default(now())
+  atualizadoEm               DateTime                     @updatedAt
+
+  turma        CursosTurmas              @relation(fields: [turmaId], references: [id], onDelete: Cascade)
+  recuperacoes CursosTurmasRecuperacoes[]
+}
+
+model CursosTurmasRecuperacoes {
+  id              String                 @id @default(uuid())
+  turmaId         String
+  matriculaId     String
+  regraId         String?
+  provaId         String?
+  envioId         String?
+  notaRecuperacao Decimal?               @db.Decimal(4, 1)
+  notaFinal       Decimal?               @db.Decimal(4, 1)
+  mediaCalculada  Decimal?               @db.Decimal(4, 2)
+  modeloAplicado  CursosModelosRecuperacao?
+  statusFinal     CursosSituacaoFinal    @default(EM_ANALISE)
+  detalhes        Json?
+  observacoes     String?                @db.VarChar(500)
+  aplicadoEm      DateTime?              @default(now())
+  criadoEm        DateTime               @default(now())
+  atualizadoEm    DateTime               @updatedAt
+
+  turma     CursosTurmas               @relation(fields: [turmaId], references: [id], onDelete: Cascade)
+  matricula CursosTurmasMatriculas     @relation(fields: [matriculaId], references: [id], onDelete: Cascade)
+  regra     CursosTurmasRegrasAvaliacao? @relation(fields: [regraId], references: [id], onDelete: SetNull)
+  prova     CursosTurmasProvas?        @relation(fields: [provaId], references: [id], onDelete: SetNull)
+  envio     CursosTurmasProvasEnvios?  @relation(fields: [envioId], references: [id], onDelete: SetNull)
+
+  @@index([turmaId])
+  @@index([matriculaId])
+  @@index([statusFinal])
+}
+
+enum CursosSituacaoFinal {
+  EM_ANALISE
+  APROVADO
+  REPROVADO
+}
+
+enum CursosModelosRecuperacao {
+  SUBSTITUI_MENOR
+  MEDIA_MINIMA_DIRETA
+  PROVA_FINAL_UNICA
+  NOTA_MAXIMA_LIMITADA
+}
+
+enum CursosLocalProva {
+  TURMA
+  MODULO
 }
 
 enum CursosStatusPadrao {

--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -388,6 +388,20 @@ const options: Options = {
               type: 'array',
               items: { $ref: '#/components/schemas/CursoTurmaAula' },
             },
+            modulos: {
+              type: 'array',
+              items: { $ref: '#/components/schemas/CursoTurmaModulo' },
+              nullable: true,
+            },
+            provas: {
+              type: 'array',
+              items: { $ref: '#/components/schemas/CursoTurmaProva' },
+              nullable: true,
+            },
+            regrasAvaliacao: {
+              nullable: true,
+              allOf: [{ $ref: '#/components/schemas/CursoTurmaRegrasAvaliacao' }],
+            },
           },
         },
         Curso: {
@@ -531,6 +545,267 @@ const options: Options = {
               items: { $ref: '#/components/schemas/CursoTurmaAulaMaterialInput' },
               nullable: true,
             },
+          },
+        },
+        CursosLocalProva: {
+          type: 'string',
+          enum: ['TURMA', 'MODULO'],
+          example: 'TURMA',
+        },
+        CursosModelosRecuperacao: {
+          type: 'string',
+          enum: ['SUBSTITUI_MENOR', 'MEDIA_MINIMA_DIRETA', 'PROVA_FINAL_UNICA', 'NOTA_MAXIMA_LIMITADA'],
+          example: 'SUBSTITUI_MENOR',
+        },
+        CursoTurmaModulo: {
+          type: 'object',
+          properties: {
+            id: { type: 'string', format: 'uuid' },
+            turmaId: { type: 'string', format: 'uuid' },
+            nome: { type: 'string', example: 'Módulo 1 - Fundamentos' },
+            descricao: { type: 'string', nullable: true, example: 'Conteúdos essenciais do módulo.' },
+            obrigatorio: { type: 'boolean', example: true },
+            ordem: { type: 'integer', example: 1 },
+            aulas: {
+              type: 'array',
+              items: { $ref: '#/components/schemas/CursoTurmaAula' },
+            },
+            provas: {
+              type: 'array',
+              items: { $ref: '#/components/schemas/CursoTurmaProva' },
+            },
+          },
+        },
+        CursoTurmaModuloCreateInput: {
+          type: 'object',
+          required: ['nome'],
+          properties: {
+            nome: { type: 'string', example: 'Módulo 1 - Fundamentos' },
+            descricao: { type: 'string', nullable: true, example: 'Conteúdos essenciais do módulo.' },
+            obrigatorio: { type: 'boolean', nullable: true, example: true },
+            ordem: { type: 'integer', nullable: true, example: 1 },
+          },
+        },
+        CursoTurmaModuloUpdateInput: {
+          type: 'object',
+          properties: {
+            nome: { type: 'string', example: 'Módulo 1 - Atualizado' },
+            descricao: { type: 'string', nullable: true },
+            obrigatorio: { type: 'boolean', nullable: true },
+            ordem: { type: 'integer', nullable: true },
+          },
+        },
+        CursoTurmaProva: {
+          type: 'object',
+          properties: {
+            id: { type: 'string', format: 'uuid' },
+            turmaId: { type: 'string', format: 'uuid' },
+            moduloId: { type: 'string', format: 'uuid', nullable: true },
+            titulo: { type: 'string', example: 'Prova Parcial' },
+            etiqueta: { type: 'string', example: 'P1' },
+            descricao: { type: 'string', nullable: true },
+            peso: { type: 'number', format: 'float', example: 1 },
+            ativo: { type: 'boolean', example: true },
+            localizacao: { $ref: '#/components/schemas/CursosLocalProva' },
+            ordem: { type: 'integer', example: 1 },
+            modulo: {
+              type: 'object',
+              nullable: true,
+              properties: {
+                id: { type: 'string', format: 'uuid' },
+                nome: { type: 'string', example: 'Módulo 1 - Fundamentos' },
+              },
+            },
+          },
+        },
+        CursoTurmaProvaCreateInput: {
+          type: 'object',
+          required: ['titulo', 'etiqueta', 'peso'],
+          properties: {
+            titulo: { type: 'string', example: 'Prova Parcial' },
+            etiqueta: { type: 'string', example: 'P1' },
+            descricao: { type: 'string', nullable: true },
+            peso: { type: 'number', example: 1, minimum: 0.01 },
+            moduloId: { type: 'string', format: 'uuid', nullable: true },
+            ativo: { type: 'boolean', nullable: true },
+            ordem: { type: 'integer', nullable: true },
+          },
+        },
+        CursoTurmaProvaUpdateInput: {
+          type: 'object',
+          properties: {
+            titulo: { type: 'string', example: 'Prova Final' },
+            etiqueta: { type: 'string', example: 'PF' },
+            descricao: { type: 'string', nullable: true },
+            peso: { type: 'number', nullable: true },
+            moduloId: { type: 'string', format: 'uuid', nullable: true },
+            ativo: { type: 'boolean', nullable: true },
+            ordem: { type: 'integer', nullable: true },
+          },
+        },
+        CursoTurmaProvaNotaInput: {
+          type: 'object',
+          required: ['matriculaId', 'nota'],
+          properties: {
+            matriculaId: { type: 'string', format: 'uuid' },
+            nota: { type: 'number', example: 7.5, minimum: 0, maximum: 10 },
+            pesoTotal: { type: 'number', nullable: true, example: 1 },
+            realizadoEm: { type: 'string', format: 'date-time', nullable: true },
+            observacoes: { type: 'string', nullable: true },
+          },
+        },
+        CursoTurmaRegrasAvaliacao: {
+          type: 'object',
+          properties: {
+            mediaMinima: { type: 'number', example: 7 },
+            politicaRecuperacaoAtiva: { type: 'boolean', example: true },
+            modelosRecuperacao: {
+              type: 'array',
+              items: { $ref: '#/components/schemas/CursosModelosRecuperacao' },
+            },
+            ordemAplicacaoRecuperacao: {
+              type: 'array',
+              items: { $ref: '#/components/schemas/CursosModelosRecuperacao' },
+            },
+            notaMaximaRecuperacao: { type: 'number', nullable: true, example: 7 },
+            pesoProvaFinal: { type: 'number', nullable: true, example: 1 },
+            observacoes: { type: 'string', nullable: true },
+          },
+        },
+        CursoTurmaRegrasAvaliacaoInput: {
+          type: 'object',
+          properties: {
+            mediaMinima: { type: 'number', nullable: true },
+            politicaRecuperacaoAtiva: { type: 'boolean', nullable: true },
+            modelosRecuperacao: {
+              type: 'array',
+              items: { $ref: '#/components/schemas/CursosModelosRecuperacao' },
+              nullable: true,
+            },
+            ordemAplicacaoRecuperacao: {
+              type: 'array',
+              items: { $ref: '#/components/schemas/CursosModelosRecuperacao' },
+              nullable: true,
+            },
+            notaMaximaRecuperacao: { type: 'number', nullable: true },
+            pesoProvaFinal: { type: 'number', nullable: true },
+            observacoes: { type: 'string', nullable: true },
+          },
+        },
+        CursoTurmaRecuperacaoInput: {
+          type: 'object',
+          required: ['matriculaId'],
+          properties: {
+            matriculaId: { type: 'string', format: 'uuid' },
+            provaId: { type: 'string', format: 'uuid', nullable: true },
+            envioId: { type: 'string', format: 'uuid', nullable: true },
+            notaRecuperacao: { type: 'number', nullable: true, example: 8 },
+            notaFinal: { type: 'number', nullable: true, example: 8 },
+            mediaCalculada: { type: 'number', nullable: true, example: 7.5 },
+            modeloAplicado: {
+              nullable: true,
+              $ref: '#/components/schemas/CursosModelosRecuperacao',
+            },
+            observacoes: { type: 'string', nullable: true },
+            aplicadoEm: { type: 'string', format: 'date-time', nullable: true },
+            detalhes: {
+              type: 'object',
+              nullable: true,
+              additionalProperties: true,
+            },
+          },
+        },
+        CursoPublico: {
+          type: 'object',
+          properties: {
+            id: { type: 'integer', example: 1 },
+            codigo: { type: 'string', example: 'CRS1234' },
+            nome: { type: 'string', example: 'Excel Básico' },
+            descricao: { type: 'string', nullable: true },
+            cargaHoraria: { type: 'integer', example: 20 },
+            statusPadrao: { $ref: '#/components/schemas/CursosStatusPadrao' },
+            turmas: {
+              type: 'array',
+              items: { $ref: '#/components/schemas/CursoTurmaPublicResumo' },
+            },
+          },
+        },
+        TurmaPublicaDetalhada: {
+          type: 'object',
+          properties: {
+            id: { type: 'string', format: 'uuid' },
+            codigo: { type: 'string' },
+            nome: { type: 'string' },
+            status: { $ref: '#/components/schemas/CursoStatus' },
+            vagasTotais: { type: 'integer' },
+            vagasDisponiveis: { type: 'integer' },
+            dataInicio: { type: 'string', format: 'date-time', nullable: true },
+            dataFim: { type: 'string', format: 'date-time', nullable: true },
+            dataInscricaoInicio: { type: 'string', format: 'date-time', nullable: true },
+            dataInscricaoFim: { type: 'string', format: 'date-time', nullable: true },
+            curso: {
+              type: 'object',
+              nullable: true,
+              properties: {
+                id: { type: 'integer' },
+                codigo: { type: 'string' },
+                nome: { type: 'string' },
+              },
+            },
+            modulos: {
+              type: 'array',
+              items: { $ref: '#/components/schemas/CursoTurmaModulo' },
+            },
+            aulas: {
+              type: 'array',
+              items: { $ref: '#/components/schemas/CursoTurmaAula' },
+            },
+            provas: {
+              type: 'array',
+              items: { $ref: '#/components/schemas/CursoTurmaProva' },
+            },
+            regrasAvaliacao: {
+              nullable: true,
+              allOf: [{ $ref: '#/components/schemas/CursoTurmaRegrasAvaliacao' }],
+            },
+          },
+        },
+        CursoPublicoDetalhado: {
+          type: 'object',
+          properties: {
+            id: { type: 'integer' },
+            codigo: { type: 'string' },
+            nome: { type: 'string' },
+            descricao: { type: 'string', nullable: true },
+            cargaHoraria: { type: 'integer' },
+            statusPadrao: { $ref: '#/components/schemas/CursosStatusPadrao' },
+            instrutor: {
+              type: 'object',
+              nullable: true,
+              properties: {
+                id: { type: 'string', format: 'uuid' },
+                nome: { type: 'string' },
+              },
+            },
+            turmas: {
+              type: 'array',
+              items: { $ref: '#/components/schemas/TurmaPublicaDetalhada' },
+            },
+          },
+        },
+        CursoTurmaPublicResumo: {
+          type: 'object',
+          properties: {
+            id: { type: 'string', format: 'uuid' },
+            codigo: { type: 'string' },
+            nome: { type: 'string' },
+            status: { $ref: '#/components/schemas/CursoStatus' },
+            vagasTotais: { type: 'integer' },
+            vagasDisponiveis: { type: 'integer' },
+            dataInicio: { type: 'string', format: 'date-time', nullable: true },
+            dataFim: { type: 'string', format: 'date-time', nullable: true },
+            dataInscricaoInicio: { type: 'string', format: 'date-time', nullable: true },
+            dataInscricaoFim: { type: 'string', format: 'date-time', nullable: true },
           },
         },
         CursoTurmaEnrollmentInput: {

--- a/src/modules/cursos/controllers/avaliacao.controller.ts
+++ b/src/modules/cursos/controllers/avaliacao.controller.ts
@@ -1,0 +1,266 @@
+import { Request, Response } from 'express';
+import { ZodError } from 'zod';
+
+import { avaliacaoService } from '../services/avaliacao.service';
+import {
+  registrarRecuperacaoSchema,
+  updateRegrasAvaliacaoSchema,
+} from '../validators/avaliacao.schema';
+
+const parseCursoId = (raw: string) => {
+  const id = Number(raw);
+  if (!Number.isInteger(id) || id <= 0) {
+    return null;
+  }
+  return id;
+};
+
+const parseTurmaId = (raw: string) => {
+  if (typeof raw !== 'string' || raw.trim().length === 0) {
+    return null;
+  }
+  return raw;
+};
+
+export class AvaliacaoController {
+  static getRules = async (req: Request, res: Response) => {
+    const cursoId = parseCursoId(req.params.cursoId);
+    const turmaId = parseTurmaId(req.params.turmaId);
+
+    if (!cursoId || !turmaId) {
+      return res.status(400).json({
+        success: false,
+        code: 'VALIDATION_ERROR',
+        message: 'Identificadores de curso ou turma inválidos',
+      });
+    }
+
+    try {
+      const regras = await avaliacaoService.obterRegras(cursoId, turmaId);
+      res.json(regras);
+    } catch (error: any) {
+      if (error?.code === 'TURMA_NOT_FOUND') {
+        return res.status(404).json({
+          success: false,
+          code: 'TURMA_NOT_FOUND',
+          message: 'Turma não encontrada para o curso informado',
+        });
+      }
+
+      res.status(500).json({
+        success: false,
+        code: 'AVALIACAO_RULES_ERROR',
+        message: 'Erro ao buscar regras de avaliação da turma',
+        error: error?.message,
+      });
+    }
+  };
+
+  static updateRules = async (req: Request, res: Response) => {
+    const cursoId = parseCursoId(req.params.cursoId);
+    const turmaId = parseTurmaId(req.params.turmaId);
+
+    if (!cursoId || !turmaId) {
+      return res.status(400).json({
+        success: false,
+        code: 'VALIDATION_ERROR',
+        message: 'Identificadores de curso ou turma inválidos',
+      });
+    }
+
+    try {
+      const data = updateRegrasAvaliacaoSchema.parse(req.body);
+      if (Object.keys(data).length === 0) {
+        return res.status(400).json({
+          success: false,
+          code: 'VALIDATION_ERROR',
+          message: 'Informe ao menos um campo para atualizar as regras de avaliação',
+        });
+      }
+
+      const regras = await avaliacaoService.atualizarRegras(cursoId, turmaId, {
+        mediaMinima: data.mediaMinima ?? undefined,
+        politicaRecuperacaoAtiva: data.politicaRecuperacaoAtiva ?? undefined,
+        modelosRecuperacao: data.modelosRecuperacao,
+        ordemAplicacaoRecuperacao: data.ordemAplicacaoRecuperacao,
+        notaMaximaRecuperacao: data.notaMaximaRecuperacao ?? undefined,
+        pesoProvaFinal: data.pesoProvaFinal ?? undefined,
+        observacoes: data.observacoes ?? undefined,
+      });
+
+      res.json(regras);
+    } catch (error: any) {
+      if (error instanceof ZodError) {
+        return res.status(400).json({
+          success: false,
+          code: 'VALIDATION_ERROR',
+          message: 'Dados inválidos para atualização das regras de avaliação',
+          issues: error.flatten().fieldErrors,
+        });
+      }
+
+      if (error?.code === 'TURMA_NOT_FOUND') {
+        return res.status(404).json({
+          success: false,
+          code: 'TURMA_NOT_FOUND',
+          message: 'Turma não encontrada para o curso informado',
+        });
+      }
+
+      res.status(500).json({
+        success: false,
+        code: 'AVALIACAO_RULES_UPDATE_ERROR',
+        message: 'Erro ao atualizar regras de avaliação da turma',
+        error: error?.message,
+      });
+    }
+  };
+
+  static registrarRecuperacao = async (req: Request, res: Response) => {
+    const cursoId = parseCursoId(req.params.cursoId);
+    const turmaId = parseTurmaId(req.params.turmaId);
+
+    if (!cursoId || !turmaId) {
+      return res.status(400).json({
+        success: false,
+        code: 'VALIDATION_ERROR',
+        message: 'Identificadores de curso ou turma inválidos',
+      });
+    }
+
+    try {
+      const data = registrarRecuperacaoSchema.parse(req.body);
+      const recuperacao = await avaliacaoService.registrarRecuperacao(cursoId, turmaId, data);
+      res.status(201).json(recuperacao);
+    } catch (error: any) {
+      if (error instanceof ZodError) {
+        return res.status(400).json({
+          success: false,
+          code: 'VALIDATION_ERROR',
+          message: 'Dados inválidos para registro de recuperação',
+          issues: error.flatten().fieldErrors,
+        });
+      }
+
+      if (error?.code === 'TURMA_NOT_FOUND') {
+        return res.status(404).json({
+          success: false,
+          code: 'TURMA_NOT_FOUND',
+          message: 'Turma não encontrada para o curso informado',
+        });
+      }
+
+      if (error?.code === 'MATRICULA_NOT_FOUND') {
+        return res.status(404).json({
+          success: false,
+          code: 'MATRICULA_NOT_FOUND',
+          message: 'Matrícula não encontrada para a turma informada',
+        });
+      }
+
+      if (error?.code === 'PROVA_NOT_FOUND') {
+        return res.status(404).json({
+          success: false,
+          code: 'PROVA_NOT_FOUND',
+          message: 'Prova não encontrada para a turma informada',
+        });
+      }
+
+      if (error?.code === 'ENVIO_NOT_FOUND') {
+        return res.status(404).json({
+          success: false,
+          code: 'ENVIO_NOT_FOUND',
+          message: 'Envio de prova não encontrado para a matrícula informada',
+        });
+      }
+
+      res.status(500).json({
+        success: false,
+        code: 'AVALIACAO_RECUPERACAO_ERROR',
+        message: 'Erro ao registrar recuperação da turma',
+        error: error?.message,
+      });
+    }
+  };
+
+  static getGrades = async (req: Request, res: Response) => {
+    const matriculaId = req.params.matriculaId;
+
+    if (!matriculaId) {
+      return res.status(400).json({
+        success: false,
+        code: 'VALIDATION_ERROR',
+        message: 'Identificador de matrícula inválido',
+      });
+    }
+
+    try {
+      const boletim = await avaliacaoService.calcularNotasMatricula(matriculaId, undefined, { permitirAdmin: true });
+      res.json(boletim);
+    } catch (error: any) {
+      if (error?.code === 'MATRICULA_NOT_FOUND') {
+        return res.status(404).json({
+          success: false,
+          code: 'MATRICULA_NOT_FOUND',
+          message: 'Matrícula não encontrada',
+        });
+      }
+
+      res.status(500).json({
+        success: false,
+        code: 'AVALIACAO_GRADE_ERROR',
+        message: 'Erro ao consultar notas da matrícula',
+        error: error?.message,
+      });
+    }
+  };
+
+  static getMyGrades = async (req: Request, res: Response) => {
+    const matriculaId = req.params.matriculaId;
+    const usuarioId = req.user?.id;
+
+    if (!matriculaId) {
+      return res.status(400).json({
+        success: false,
+        code: 'VALIDATION_ERROR',
+        message: 'Identificador de matrícula inválido',
+      });
+    }
+
+    if (!usuarioId) {
+      return res.status(401).json({
+        success: false,
+        code: 'UNAUTHORIZED',
+        message: 'Usuário não autenticado',
+      });
+    }
+
+    try {
+      const boletim = await avaliacaoService.calcularNotasMatricula(matriculaId, usuarioId);
+      res.json(boletim);
+    } catch (error: any) {
+      if (error?.code === 'MATRICULA_NOT_FOUND') {
+        return res.status(404).json({
+          success: false,
+          code: 'MATRICULA_NOT_FOUND',
+          message: 'Matrícula não encontrada',
+        });
+      }
+
+      if (error?.code === 'FORBIDDEN') {
+        return res.status(403).json({
+          success: false,
+          code: 'FORBIDDEN',
+          message: 'Você não tem permissão para visualizar as notas desta matrícula',
+        });
+      }
+
+      res.status(500).json({
+        success: false,
+        code: 'AVALIACAO_GRADE_ME_ERROR',
+        message: 'Erro ao consultar notas da matrícula do aluno',
+        error: error?.message,
+      });
+    }
+  };
+}

--- a/src/modules/cursos/controllers/cursos.controller.ts
+++ b/src/modules/cursos/controllers/cursos.controller.ts
@@ -77,6 +77,20 @@ export class CursosController {
     }
   };
 
+  static publicList = async (_req: Request, res: Response) => {
+    try {
+      const cursos = await cursosService.listPublic();
+      res.json({ data: cursos });
+    } catch (error: any) {
+      res.status(500).json({
+        success: false,
+        code: 'CURSOS_PUBLIC_LIST_ERROR',
+        message: 'Erro ao listar cursos públicos',
+        error: error?.message,
+      });
+    }
+  };
+
   static get = async (req: Request, res: Response) => {
     const id = parseCourseId(req.params.cursoId ?? req.params.id);
     if (!id) {
@@ -103,6 +117,37 @@ export class CursosController {
         success: false,
         code: 'CURSO_GET_ERROR',
         message: 'Erro ao buscar curso',
+        error: error?.message,
+      });
+    }
+  };
+
+  static publicGet = async (req: Request, res: Response) => {
+    const id = parseCourseId(req.params.cursoId ?? req.params.id);
+    if (!id) {
+      return res.status(400).json({
+        success: false,
+        code: 'VALIDATION_ERROR',
+        message: 'Identificador de curso inválido',
+      });
+    }
+
+    try {
+      const course = await cursosService.getPublicById(id);
+      if (!course) {
+        return res.status(404).json({
+          success: false,
+          code: 'CURSO_NOT_FOUND',
+          message: 'Curso não encontrado ou indisponível',
+        });
+      }
+
+      res.json(course);
+    } catch (error: any) {
+      res.status(500).json({
+        success: false,
+        code: 'CURSO_PUBLIC_GET_ERROR',
+        message: 'Erro ao buscar curso público',
         error: error?.message,
       });
     }

--- a/src/modules/cursos/controllers/modulos.controller.ts
+++ b/src/modules/cursos/controllers/modulos.controller.ts
@@ -1,15 +1,14 @@
 import { Request, Response } from 'express';
 import { ZodError } from 'zod';
 
-import { aulasService } from '../services/aulas.service';
-import { createAulaSchema, updateAulaSchema } from '../validators/aulas.schema';
+import { modulosService } from '../services/modulos.service';
+import { createModuloSchema, updateModuloSchema } from '../validators/modulos.schema';
 
 const parseCursoId = (raw: string) => {
   const id = Number(raw);
   if (!Number.isInteger(id) || id <= 0) {
     return null;
   }
-
   return id;
 };
 
@@ -17,19 +16,17 @@ const parseTurmaId = (raw: string) => {
   if (typeof raw !== 'string' || raw.trim().length === 0) {
     return null;
   }
-
   return raw;
 };
 
-const parseAulaId = (raw: string) => {
+const parseModuloId = (raw: string) => {
   if (typeof raw !== 'string' || raw.trim().length === 0) {
     return null;
   }
-
   return raw;
 };
 
-export class AulasController {
+export class ModulosController {
   static list = async (req: Request, res: Response) => {
     const cursoId = parseCursoId(req.params.cursoId);
     const turmaId = parseTurmaId(req.params.turmaId);
@@ -43,8 +40,8 @@ export class AulasController {
     }
 
     try {
-      const aulas = await aulasService.list(cursoId, turmaId);
-      res.json({ data: aulas });
+      const modulos = await modulosService.list(cursoId, turmaId);
+      res.json({ data: modulos });
     } catch (error: any) {
       if (error?.code === 'TURMA_NOT_FOUND') {
         return res.status(404).json({
@@ -56,8 +53,8 @@ export class AulasController {
 
       res.status(500).json({
         success: false,
-        code: 'AULAS_LIST_ERROR',
-        message: 'Erro ao listar aulas da turma',
+        code: 'MODULOS_LIST_ERROR',
+        message: 'Erro ao listar módulos da turma',
         error: error?.message,
       });
     }
@@ -66,32 +63,32 @@ export class AulasController {
   static get = async (req: Request, res: Response) => {
     const cursoId = parseCursoId(req.params.cursoId);
     const turmaId = parseTurmaId(req.params.turmaId);
-    const aulaId = parseAulaId(req.params.aulaId);
+    const moduloId = parseModuloId(req.params.moduloId);
 
-    if (!cursoId || !turmaId || !aulaId) {
+    if (!cursoId || !turmaId || !moduloId) {
       return res.status(400).json({
         success: false,
         code: 'VALIDATION_ERROR',
-        message: 'Identificadores de curso, turma ou aula inválidos',
+        message: 'Identificadores de curso, turma ou módulo inválidos',
       });
     }
 
     try {
-      const aula = await aulasService.get(cursoId, turmaId, aulaId);
-      res.json(aula);
+      const modulo = await modulosService.get(cursoId, turmaId, moduloId);
+      res.json(modulo);
     } catch (error: any) {
-      if (error?.code === 'AULA_NOT_FOUND' || error?.code === 'TURMA_NOT_FOUND') {
+      if (error?.code === 'MODULO_NOT_FOUND' || error?.code === 'TURMA_NOT_FOUND') {
         return res.status(404).json({
           success: false,
-          code: 'AULA_NOT_FOUND',
-          message: 'Aula não encontrada para a turma informada',
+          code: 'MODULO_NOT_FOUND',
+          message: 'Módulo não encontrado para a turma informada',
         });
       }
 
       res.status(500).json({
         success: false,
-        code: 'AULA_GET_ERROR',
-        message: 'Erro ao buscar aula da turma',
+        code: 'MODULO_GET_ERROR',
+        message: 'Erro ao buscar módulo da turma',
         error: error?.message,
       });
     }
@@ -110,15 +107,15 @@ export class AulasController {
     }
 
     try {
-      const data = createAulaSchema.parse(req.body);
-      const aula = await aulasService.create(cursoId, turmaId, data);
-      res.status(201).json(aula);
+      const data = createModuloSchema.parse(req.body);
+      const modulo = await modulosService.create(cursoId, turmaId, data);
+      res.status(201).json(modulo);
     } catch (error: any) {
       if (error instanceof ZodError) {
         return res.status(400).json({
           success: false,
           code: 'VALIDATION_ERROR',
-          message: 'Dados inválidos para criação da aula',
+          message: 'Dados inválidos para criação do módulo',
           issues: error.flatten().fieldErrors,
         });
       }
@@ -131,18 +128,10 @@ export class AulasController {
         });
       }
 
-      if (error?.code === 'MODULO_NOT_FOUND') {
-        return res.status(404).json({
-          success: false,
-          code: 'MODULO_NOT_FOUND',
-          message: 'Módulo não encontrado para a turma informada',
-        });
-      }
-
       res.status(500).json({
         success: false,
-        code: 'AULA_CREATE_ERROR',
-        message: 'Erro ao criar aula para a turma',
+        code: 'MODULO_CREATE_ERROR',
+        message: 'Erro ao criar módulo para a turma',
         error: error?.message,
       });
     }
@@ -151,48 +140,40 @@ export class AulasController {
   static update = async (req: Request, res: Response) => {
     const cursoId = parseCursoId(req.params.cursoId);
     const turmaId = parseTurmaId(req.params.turmaId);
-    const aulaId = parseAulaId(req.params.aulaId);
+    const moduloId = parseModuloId(req.params.moduloId);
 
-    if (!cursoId || !turmaId || !aulaId) {
+    if (!cursoId || !turmaId || !moduloId) {
       return res.status(400).json({
         success: false,
         code: 'VALIDATION_ERROR',
-        message: 'Identificadores de curso, turma ou aula inválidos',
+        message: 'Identificadores de curso, turma ou módulo inválidos',
       });
     }
 
     try {
-      const data = updateAulaSchema.parse(req.body);
+      const data = updateModuloSchema.parse(req.body);
 
       if (Object.keys(data).length === 0) {
         return res.status(400).json({
           success: false,
           code: 'VALIDATION_ERROR',
-          message: 'Informe ao menos um campo para atualização da aula',
+          message: 'Informe ao menos um campo para atualização do módulo',
         });
       }
 
-      const aula = await aulasService.update(cursoId, turmaId, aulaId, data);
-      res.json(aula);
+      const modulo = await modulosService.update(cursoId, turmaId, moduloId, data);
+      res.json(modulo);
     } catch (error: any) {
       if (error instanceof ZodError) {
         return res.status(400).json({
           success: false,
           code: 'VALIDATION_ERROR',
-          message: 'Dados inválidos para atualização da aula',
+          message: 'Dados inválidos para atualização do módulo',
           issues: error.flatten().fieldErrors,
         });
       }
 
-      if (error?.code === 'AULA_NOT_FOUND' || error?.code === 'TURMA_NOT_FOUND') {
-        return res.status(404).json({
-          success: false,
-          code: 'AULA_NOT_FOUND',
-          message: 'Aula não encontrada para a turma informada',
-        });
-      }
-
-      if (error?.code === 'MODULO_NOT_FOUND') {
+      if (error?.code === 'MODULO_NOT_FOUND' || error?.code === 'TURMA_NOT_FOUND') {
         return res.status(404).json({
           success: false,
           code: 'MODULO_NOT_FOUND',
@@ -202,8 +183,8 @@ export class AulasController {
 
       res.status(500).json({
         success: false,
-        code: 'AULA_UPDATE_ERROR',
-        message: 'Erro ao atualizar aula da turma',
+        code: 'MODULO_UPDATE_ERROR',
+        message: 'Erro ao atualizar módulo da turma',
         error: error?.message,
       });
     }
@@ -212,32 +193,32 @@ export class AulasController {
   static delete = async (req: Request, res: Response) => {
     const cursoId = parseCursoId(req.params.cursoId);
     const turmaId = parseTurmaId(req.params.turmaId);
-    const aulaId = parseAulaId(req.params.aulaId);
+    const moduloId = parseModuloId(req.params.moduloId);
 
-    if (!cursoId || !turmaId || !aulaId) {
+    if (!cursoId || !turmaId || !moduloId) {
       return res.status(400).json({
         success: false,
         code: 'VALIDATION_ERROR',
-        message: 'Identificadores de curso, turma ou aula inválidos',
+        message: 'Identificadores de curso, turma ou módulo inválidos',
       });
     }
 
     try {
-      await aulasService.remove(cursoId, turmaId, aulaId);
-      res.json({ success: true });
+      const result = await modulosService.remove(cursoId, turmaId, moduloId);
+      res.json(result);
     } catch (error: any) {
-      if (error?.code === 'AULA_NOT_FOUND' || error?.code === 'TURMA_NOT_FOUND') {
+      if (error?.code === 'MODULO_NOT_FOUND' || error?.code === 'TURMA_NOT_FOUND') {
         return res.status(404).json({
           success: false,
-          code: 'AULA_NOT_FOUND',
-          message: 'Aula não encontrada para a turma informada',
+          code: 'MODULO_NOT_FOUND',
+          message: 'Módulo não encontrado para a turma informada',
         });
       }
 
       res.status(500).json({
         success: false,
-        code: 'AULA_DELETE_ERROR',
-        message: 'Erro ao remover aula da turma',
+        code: 'MODULO_DELETE_ERROR',
+        message: 'Erro ao remover módulo da turma',
         error: error?.message,
       });
     }

--- a/src/modules/cursos/controllers/provas.controller.ts
+++ b/src/modules/cursos/controllers/provas.controller.ts
@@ -1,15 +1,14 @@
 import { Request, Response } from 'express';
 import { ZodError } from 'zod';
 
-import { aulasService } from '../services/aulas.service';
-import { createAulaSchema, updateAulaSchema } from '../validators/aulas.schema';
+import { provasService } from '../services/provas.service';
+import { createProvaSchema, registrarNotaSchema, updateProvaSchema } from '../validators/provas.schema';
 
 const parseCursoId = (raw: string) => {
   const id = Number(raw);
   if (!Number.isInteger(id) || id <= 0) {
     return null;
   }
-
   return id;
 };
 
@@ -17,19 +16,17 @@ const parseTurmaId = (raw: string) => {
   if (typeof raw !== 'string' || raw.trim().length === 0) {
     return null;
   }
-
   return raw;
 };
 
-const parseAulaId = (raw: string) => {
+const parseProvaId = (raw: string) => {
   if (typeof raw !== 'string' || raw.trim().length === 0) {
     return null;
   }
-
   return raw;
 };
 
-export class AulasController {
+export class ProvasController {
   static list = async (req: Request, res: Response) => {
     const cursoId = parseCursoId(req.params.cursoId);
     const turmaId = parseTurmaId(req.params.turmaId);
@@ -43,8 +40,8 @@ export class AulasController {
     }
 
     try {
-      const aulas = await aulasService.list(cursoId, turmaId);
-      res.json({ data: aulas });
+      const provas = await provasService.list(cursoId, turmaId);
+      res.json({ data: provas });
     } catch (error: any) {
       if (error?.code === 'TURMA_NOT_FOUND') {
         return res.status(404).json({
@@ -56,8 +53,8 @@ export class AulasController {
 
       res.status(500).json({
         success: false,
-        code: 'AULAS_LIST_ERROR',
-        message: 'Erro ao listar aulas da turma',
+        code: 'PROVAS_LIST_ERROR',
+        message: 'Erro ao listar provas da turma',
         error: error?.message,
       });
     }
@@ -66,32 +63,32 @@ export class AulasController {
   static get = async (req: Request, res: Response) => {
     const cursoId = parseCursoId(req.params.cursoId);
     const turmaId = parseTurmaId(req.params.turmaId);
-    const aulaId = parseAulaId(req.params.aulaId);
+    const provaId = parseProvaId(req.params.provaId);
 
-    if (!cursoId || !turmaId || !aulaId) {
+    if (!cursoId || !turmaId || !provaId) {
       return res.status(400).json({
         success: false,
         code: 'VALIDATION_ERROR',
-        message: 'Identificadores de curso, turma ou aula inválidos',
+        message: 'Identificadores de curso, turma ou prova inválidos',
       });
     }
 
     try {
-      const aula = await aulasService.get(cursoId, turmaId, aulaId);
-      res.json(aula);
+      const prova = await provasService.get(cursoId, turmaId, provaId);
+      res.json(prova);
     } catch (error: any) {
-      if (error?.code === 'AULA_NOT_FOUND' || error?.code === 'TURMA_NOT_FOUND') {
+      if (error?.code === 'PROVA_NOT_FOUND' || error?.code === 'TURMA_NOT_FOUND') {
         return res.status(404).json({
           success: false,
-          code: 'AULA_NOT_FOUND',
-          message: 'Aula não encontrada para a turma informada',
+          code: 'PROVA_NOT_FOUND',
+          message: 'Prova não encontrada para a turma informada',
         });
       }
 
       res.status(500).json({
         success: false,
-        code: 'AULA_GET_ERROR',
-        message: 'Erro ao buscar aula da turma',
+        code: 'PROVA_GET_ERROR',
+        message: 'Erro ao buscar prova da turma',
         error: error?.message,
       });
     }
@@ -110,15 +107,15 @@ export class AulasController {
     }
 
     try {
-      const data = createAulaSchema.parse(req.body);
-      const aula = await aulasService.create(cursoId, turmaId, data);
-      res.status(201).json(aula);
+      const data = createProvaSchema.parse(req.body);
+      const prova = await provasService.create(cursoId, turmaId, data);
+      res.status(201).json(prova);
     } catch (error: any) {
       if (error instanceof ZodError) {
         return res.status(400).json({
           success: false,
           code: 'VALIDATION_ERROR',
-          message: 'Dados inválidos para criação da aula',
+          message: 'Dados inválidos para criação da prova',
           issues: error.flatten().fieldErrors,
         });
       }
@@ -141,8 +138,8 @@ export class AulasController {
 
       res.status(500).json({
         success: false,
-        code: 'AULA_CREATE_ERROR',
-        message: 'Erro ao criar aula para a turma',
+        code: 'PROVA_CREATE_ERROR',
+        message: 'Erro ao criar prova para a turma',
         error: error?.message,
       });
     }
@@ -151,44 +148,44 @@ export class AulasController {
   static update = async (req: Request, res: Response) => {
     const cursoId = parseCursoId(req.params.cursoId);
     const turmaId = parseTurmaId(req.params.turmaId);
-    const aulaId = parseAulaId(req.params.aulaId);
+    const provaId = parseProvaId(req.params.provaId);
 
-    if (!cursoId || !turmaId || !aulaId) {
+    if (!cursoId || !turmaId || !provaId) {
       return res.status(400).json({
         success: false,
         code: 'VALIDATION_ERROR',
-        message: 'Identificadores de curso, turma ou aula inválidos',
+        message: 'Identificadores de curso, turma ou prova inválidos',
       });
     }
 
     try {
-      const data = updateAulaSchema.parse(req.body);
+      const data = updateProvaSchema.parse(req.body);
 
       if (Object.keys(data).length === 0) {
         return res.status(400).json({
           success: false,
           code: 'VALIDATION_ERROR',
-          message: 'Informe ao menos um campo para atualização da aula',
+          message: 'Informe ao menos um campo para atualização da prova',
         });
       }
 
-      const aula = await aulasService.update(cursoId, turmaId, aulaId, data);
-      res.json(aula);
+      const prova = await provasService.update(cursoId, turmaId, provaId, data);
+      res.json(prova);
     } catch (error: any) {
       if (error instanceof ZodError) {
         return res.status(400).json({
           success: false,
           code: 'VALIDATION_ERROR',
-          message: 'Dados inválidos para atualização da aula',
+          message: 'Dados inválidos para atualização da prova',
           issues: error.flatten().fieldErrors,
         });
       }
 
-      if (error?.code === 'AULA_NOT_FOUND' || error?.code === 'TURMA_NOT_FOUND') {
+      if (error?.code === 'PROVA_NOT_FOUND' || error?.code === 'TURMA_NOT_FOUND') {
         return res.status(404).json({
           success: false,
-          code: 'AULA_NOT_FOUND',
-          message: 'Aula não encontrada para a turma informada',
+          code: 'PROVA_NOT_FOUND',
+          message: 'Prova não encontrada para a turma informada',
         });
       }
 
@@ -202,8 +199,8 @@ export class AulasController {
 
       res.status(500).json({
         success: false,
-        code: 'AULA_UPDATE_ERROR',
-        message: 'Erro ao atualizar aula da turma',
+        code: 'PROVA_UPDATE_ERROR',
+        message: 'Erro ao atualizar prova da turma',
         error: error?.message,
       });
     }
@@ -212,32 +209,87 @@ export class AulasController {
   static delete = async (req: Request, res: Response) => {
     const cursoId = parseCursoId(req.params.cursoId);
     const turmaId = parseTurmaId(req.params.turmaId);
-    const aulaId = parseAulaId(req.params.aulaId);
+    const provaId = parseProvaId(req.params.provaId);
 
-    if (!cursoId || !turmaId || !aulaId) {
+    if (!cursoId || !turmaId || !provaId) {
       return res.status(400).json({
         success: false,
         code: 'VALIDATION_ERROR',
-        message: 'Identificadores de curso, turma ou aula inválidos',
+        message: 'Identificadores de curso, turma ou prova inválidos',
       });
     }
 
     try {
-      await aulasService.remove(cursoId, turmaId, aulaId);
-      res.json({ success: true });
+      const result = await provasService.remove(cursoId, turmaId, provaId);
+      res.json(result);
     } catch (error: any) {
-      if (error?.code === 'AULA_NOT_FOUND' || error?.code === 'TURMA_NOT_FOUND') {
+      if (error?.code === 'PROVA_NOT_FOUND' || error?.code === 'TURMA_NOT_FOUND') {
         return res.status(404).json({
           success: false,
-          code: 'AULA_NOT_FOUND',
-          message: 'Aula não encontrada para a turma informada',
+          code: 'PROVA_NOT_FOUND',
+          message: 'Prova não encontrada para a turma informada',
         });
       }
 
       res.status(500).json({
         success: false,
-        code: 'AULA_DELETE_ERROR',
-        message: 'Erro ao remover aula da turma',
+        code: 'PROVA_DELETE_ERROR',
+        message: 'Erro ao remover prova da turma',
+        error: error?.message,
+      });
+    }
+  };
+
+  static registrarNota = async (req: Request, res: Response) => {
+    const cursoId = parseCursoId(req.params.cursoId);
+    const turmaId = parseTurmaId(req.params.turmaId);
+    const provaId = parseProvaId(req.params.provaId);
+
+    if (!cursoId || !turmaId || !provaId) {
+      return res.status(400).json({
+        success: false,
+        code: 'VALIDATION_ERROR',
+        message: 'Identificadores de curso, turma ou prova inválidos',
+      });
+    }
+
+    try {
+      const data = registrarNotaSchema.parse(req.body);
+      const prova = await provasService.registrarNota(cursoId, turmaId, provaId, {
+        ...data,
+        realizadoEm: data.realizadoEm ?? undefined,
+      });
+      res.status(200).json(prova);
+    } catch (error: any) {
+      if (error instanceof ZodError) {
+        return res.status(400).json({
+          success: false,
+          code: 'VALIDATION_ERROR',
+          message: 'Dados inválidos para registro de nota',
+          issues: error.flatten().fieldErrors,
+        });
+      }
+
+      if (error?.code === 'PROVA_NOT_FOUND' || error?.code === 'TURMA_NOT_FOUND') {
+        return res.status(404).json({
+          success: false,
+          code: 'PROVA_NOT_FOUND',
+          message: 'Prova não encontrada para a turma informada',
+        });
+      }
+
+      if (error?.code === 'MATRICULA_NOT_FOUND') {
+        return res.status(404).json({
+          success: false,
+          code: 'MATRICULA_NOT_FOUND',
+          message: 'Matrícula não encontrada para a turma informada',
+        });
+      }
+
+      res.status(500).json({
+        success: false,
+        code: 'PROVA_REGISTRAR_NOTA_ERROR',
+        message: 'Erro ao registrar nota da prova',
         error: error?.message,
       });
     }

--- a/src/modules/cursos/controllers/turmas.controller.ts
+++ b/src/modules/cursos/controllers/turmas.controller.ts
@@ -2,6 +2,7 @@ import { Request, Response } from 'express';
 import { ZodError } from 'zod';
 
 import { turmasService } from '../services/turmas.service';
+import { cursosService } from '../services/cursos.service';
 import {
   createTurmaSchema,
   turmaEnrollmentSchema,
@@ -85,6 +86,38 @@ export class TurmasController {
         success: false,
         code: 'TURMA_GET_ERROR',
         message: 'Erro ao buscar turma do curso',
+        error: error?.message,
+      });
+    }
+  };
+
+  static publicGet = async (req: Request, res: Response) => {
+    const turmaId = parseTurmaId(req.params.turmaId);
+
+    if (!turmaId) {
+      return res.status(400).json({
+        success: false,
+        code: 'VALIDATION_ERROR',
+        message: 'Identificador de turma inválido',
+      });
+    }
+
+    try {
+      const turma = await cursosService.getPublicTurma(turmaId);
+      if (!turma) {
+        return res.status(404).json({
+          success: false,
+          code: 'TURMA_NOT_FOUND',
+          message: 'Turma não encontrada ou indisponível',
+        });
+      }
+
+      res.json(turma);
+    } catch (error: any) {
+      res.status(500).json({
+        success: false,
+        code: 'TURMA_PUBLIC_GET_ERROR',
+        message: 'Erro ao buscar turma pública',
         error: error?.message,
       });
     }

--- a/src/modules/cursos/routes/index.ts
+++ b/src/modules/cursos/routes/index.ts
@@ -7,6 +7,9 @@ import { supabaseAuthMiddleware } from '@/modules/usuarios/auth';
 import { CursosController } from '../controllers/cursos.controller';
 import { AulasController } from '../controllers/aulas.controller';
 import { TurmasController } from '../controllers/turmas.controller';
+import { ModulosController } from '../controllers/modulos.controller';
+import { ProvasController } from '../controllers/provas.controller';
+import { AvaliacaoController } from '../controllers/avaliacao.controller';
 
 const router = Router();
 
@@ -108,6 +111,75 @@ router.get('/', publicCache, CursosController.list);
  *               $ref: '#/components/schemas/ErrorResponse'
  */
 router.get('/:cursoId', publicCache, CursosController.get);
+
+/**
+ * @openapi
+ * /api/v1/cursos/publico/cursos:
+ *   get:
+ *     summary: Listar cursos publicados para vitrine pública
+ *     tags: [Cursos - Público]
+ *     responses:
+ *       200:
+ *         description: Lista de cursos disponíveis publicamente
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 data:
+ *                   type: array
+ *                   items:
+ *                     $ref: '#/components/schemas/CursoPublico'
+ *       500:
+ *         description: Erro ao listar cursos públicos
+ */
+router.get('/publico/cursos', publicCache, CursosController.publicList);
+
+/**
+ * @openapi
+ * /api/v1/cursos/publico/cursos/{cursoId}:
+ *   get:
+ *     summary: Detalhar curso publicado
+ *     tags: [Cursos - Público]
+ *     parameters:
+ *       - in: path
+ *         name: cursoId
+ *         required: true
+ *         schema: { type: integer, minimum: 1 }
+ *     responses:
+ *       200:
+ *         description: Detalhes do curso com turmas e módulos
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/CursoPublicoDetalhado'
+ *       404:
+ *         description: Curso não encontrado ou indisponível
+ */
+router.get('/publico/cursos/:cursoId', publicCache, CursosController.publicGet);
+
+/**
+ * @openapi
+ * /api/v1/cursos/publico/turmas/{turmaId}:
+ *   get:
+ *     summary: Detalhar turma publicada
+ *     tags: [Cursos - Público]
+ *     parameters:
+ *       - in: path
+ *         name: turmaId
+ *         required: true
+ *         schema: { type: string, format: uuid }
+ *     responses:
+ *       200:
+ *         description: Detalhes da turma com módulos, aulas e provas
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/TurmaPublicaDetalhada'
+ *       404:
+ *         description: Turma não encontrada ou indisponível
+ */
+router.get('/publico/turmas/:turmaId', publicCache, TurmasController.publicGet);
 
 /**
  * @openapi
@@ -612,6 +684,489 @@ router.delete(
   '/:cursoId/turmas/:turmaId/aulas/:aulaId',
   supabaseAuthMiddleware([Roles.ADMIN, Roles.MODERADOR, Roles.PEDAGOGICO, Roles.PROFESSOR]),
   AulasController.delete,
+);
+
+/**
+ * @openapi
+ * /api/v1/cursos/{cursoId}/turmas/{turmaId}/modulos:
+ *   get:
+ *     summary: Listar módulos da turma
+ *     tags: ['Cursos - Módulos']
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: cursoId
+ *         required: true
+ *         schema: { type: integer, minimum: 1 }
+ *       - in: path
+ *         name: turmaId
+ *         required: true
+ *         schema: { type: string, format: uuid }
+ *     responses:
+ *       200:
+ *         description: Lista de módulos da turma
+ *       404:
+ *         description: Turma não encontrada
+ */
+router.get(
+  '/:cursoId/turmas/:turmaId/modulos',
+  supabaseAuthMiddleware([Roles.ADMIN, Roles.MODERADOR, Roles.PEDAGOGICO, Roles.PROFESSOR]),
+  ModulosController.list,
+);
+
+/**
+ * @openapi
+ * /api/v1/cursos/{cursoId}/turmas/{turmaId}/modulos/{moduloId}:
+ *   get:
+ *     summary: Detalhar módulo da turma
+ *     tags: ['Cursos - Módulos']
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: cursoId
+ *         required: true
+ *         schema: { type: integer, minimum: 1 }
+ *       - in: path
+ *         name: turmaId
+ *         required: true
+ *         schema: { type: string, format: uuid }
+ *       - in: path
+ *         name: moduloId
+ *         required: true
+ *         schema: { type: string, format: uuid }
+ *     responses:
+ *       200:
+ *         description: Dados do módulo
+ *       404:
+ *         description: Módulo não encontrado
+ */
+router.get(
+  '/:cursoId/turmas/:turmaId/modulos/:moduloId',
+  supabaseAuthMiddleware([Roles.ADMIN, Roles.MODERADOR, Roles.PEDAGOGICO, Roles.PROFESSOR]),
+  ModulosController.get,
+);
+
+/**
+ * @openapi
+ * /api/v1/cursos/{cursoId}/turmas/{turmaId}/modulos:
+ *   post:
+ *     summary: Criar módulo na turma
+ *     tags: ['Cursos - Módulos']
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: cursoId
+ *         required: true
+ *         schema: { type: integer, minimum: 1 }
+ *       - in: path
+ *         name: turmaId
+ *         required: true
+ *         schema: { type: string, format: uuid }
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/CursoTurmaModuloCreateInput'
+ *     responses:
+ *       201:
+ *         description: Módulo criado
+ */
+router.post(
+  '/:cursoId/turmas/:turmaId/modulos',
+  supabaseAuthMiddleware([Roles.ADMIN, Roles.MODERADOR, Roles.PEDAGOGICO, Roles.PROFESSOR]),
+  ModulosController.create,
+);
+
+/**
+ * @openapi
+ * /api/v1/cursos/{cursoId}/turmas/{turmaId}/modulos/{moduloId}:
+ *   put:
+ *     summary: Atualizar módulo da turma
+ *     tags: ['Cursos - Módulos']
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: cursoId
+ *         required: true
+ *         schema: { type: integer, minimum: 1 }
+ *       - in: path
+ *         name: turmaId
+ *         required: true
+ *         schema: { type: string, format: uuid }
+ *       - in: path
+ *         name: moduloId
+ *         required: true
+ *         schema: { type: string, format: uuid }
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/CursoTurmaModuloUpdateInput'
+ *     responses:
+ *       200:
+ *         description: Módulo atualizado
+ */
+router.put(
+  '/:cursoId/turmas/:turmaId/modulos/:moduloId',
+  supabaseAuthMiddleware([Roles.ADMIN, Roles.MODERADOR, Roles.PEDAGOGICO, Roles.PROFESSOR]),
+  ModulosController.update,
+);
+
+/**
+ * @openapi
+ * /api/v1/cursos/{cursoId}/turmas/{turmaId}/modulos/{moduloId}:
+ *   delete:
+ *     summary: Remover módulo da turma
+ *     tags: ['Cursos - Módulos']
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: cursoId
+ *         required: true
+ *         schema: { type: integer, minimum: 1 }
+ *       - in: path
+ *         name: turmaId
+ *         required: true
+ *         schema: { type: string, format: uuid }
+ *       - in: path
+ *         name: moduloId
+ *         required: true
+ *         schema: { type: string, format: uuid }
+ *     responses:
+ *       200:
+ *         description: Módulo removido
+ */
+router.delete(
+  '/:cursoId/turmas/:turmaId/modulos/:moduloId',
+  supabaseAuthMiddleware([Roles.ADMIN, Roles.MODERADOR, Roles.PEDAGOGICO, Roles.PROFESSOR]),
+  ModulosController.delete,
+);
+
+/**
+ * @openapi
+ * /api/v1/cursos/{cursoId}/turmas/{turmaId}/provas:
+ *   get:
+ *     summary: Listar provas da turma
+ *     tags: ['Cursos - Provas']
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: cursoId
+ *         required: true
+ *         schema: { type: integer, minimum: 1 }
+ *       - in: path
+ *         name: turmaId
+ *         required: true
+ *         schema: { type: string, format: uuid }
+ *     responses:
+ *       200:
+ *         description: Lista de provas atreladas à turma
+ */
+router.get(
+  '/:cursoId/turmas/:turmaId/provas',
+  supabaseAuthMiddleware([Roles.ADMIN, Roles.MODERADOR, Roles.PEDAGOGICO, Roles.PROFESSOR]),
+  ProvasController.list,
+);
+
+/**
+ * @openapi
+ * /api/v1/cursos/{cursoId}/turmas/{turmaId}/provas/{provaId}:
+ *   get:
+ *     summary: Detalhar prova da turma
+ *     tags: ['Cursos - Provas']
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: cursoId
+ *         required: true
+ *         schema: { type: integer, minimum: 1 }
+ *       - in: path
+ *         name: turmaId
+ *         required: true
+ *         schema: { type: string, format: uuid }
+ *       - in: path
+ *         name: provaId
+ *         required: true
+ *         schema: { type: string, format: uuid }
+ *     responses:
+ *       200:
+ *         description: Dados da prova
+ */
+router.get(
+  '/:cursoId/turmas/:turmaId/provas/:provaId',
+  supabaseAuthMiddleware([Roles.ADMIN, Roles.MODERADOR, Roles.PEDAGOGICO, Roles.PROFESSOR]),
+  ProvasController.get,
+);
+
+/**
+ * @openapi
+ * /api/v1/cursos/{cursoId}/turmas/{turmaId}/provas:
+ *   post:
+ *     summary: Criar prova para a turma
+ *     tags: ['Cursos - Provas']
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: cursoId
+ *         required: true
+ *         schema: { type: integer, minimum: 1 }
+ *       - in: path
+ *         name: turmaId
+ *         required: true
+ *         schema: { type: string, format: uuid }
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/CursoTurmaProvaCreateInput'
+ *     responses:
+ *       201:
+ *         description: Prova criada
+ */
+router.post(
+  '/:cursoId/turmas/:turmaId/provas',
+  supabaseAuthMiddleware([Roles.ADMIN, Roles.MODERADOR, Roles.PEDAGOGICO, Roles.PROFESSOR]),
+  ProvasController.create,
+);
+
+/**
+ * @openapi
+ * /api/v1/cursos/{cursoId}/turmas/{turmaId}/provas/{provaId}:
+ *   put:
+ *     summary: Atualizar prova da turma
+ *     tags: ['Cursos - Provas']
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: cursoId
+ *         required: true
+ *         schema: { type: integer, minimum: 1 }
+ *       - in: path
+ *         name: turmaId
+ *         required: true
+ *         schema: { type: string, format: uuid }
+ *       - in: path
+ *         name: provaId
+ *         required: true
+ *         schema: { type: string, format: uuid }
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/CursoTurmaProvaUpdateInput'
+ *     responses:
+ *       200:
+ *         description: Prova atualizada
+ */
+router.put(
+  '/:cursoId/turmas/:turmaId/provas/:provaId',
+  supabaseAuthMiddleware([Roles.ADMIN, Roles.MODERADOR, Roles.PEDAGOGICO, Roles.PROFESSOR]),
+  ProvasController.update,
+);
+
+/**
+ * @openapi
+ * /api/v1/cursos/{cursoId}/turmas/{turmaId}/provas/{provaId}:
+ *   delete:
+ *     summary: Remover prova da turma
+ *     tags: ['Cursos - Provas']
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: cursoId
+ *         required: true
+ *         schema: { type: integer, minimum: 1 }
+ *       - in: path
+ *         name: turmaId
+ *         required: true
+ *         schema: { type: string, format: uuid }
+ *       - in: path
+ *         name: provaId
+ *         required: true
+ *         schema: { type: string, format: uuid }
+ *     responses:
+ *       200:
+ *         description: Prova removida
+ */
+router.delete(
+  '/:cursoId/turmas/:turmaId/provas/:provaId',
+  supabaseAuthMiddleware([Roles.ADMIN, Roles.MODERADOR, Roles.PEDAGOGICO, Roles.PROFESSOR]),
+  ProvasController.delete,
+);
+
+/**
+ * @openapi
+ * /api/v1/cursos/{cursoId}/turmas/{turmaId}/provas/{provaId}/notas:
+ *   put:
+ *     summary: Registrar ou atualizar nota de prova
+ *     tags: ['Cursos - Provas']
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: cursoId
+ *         required: true
+ *         schema: { type: integer, minimum: 1 }
+ *       - in: path
+ *         name: turmaId
+ *         required: true
+ *         schema: { type: string, format: uuid }
+ *       - in: path
+ *         name: provaId
+ *         required: true
+ *         schema: { type: string, format: uuid }
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/CursoTurmaProvaNotaInput'
+ *     responses:
+ *       200:
+ *         description: Nota registrada com sucesso
+ */
+router.put(
+  '/:cursoId/turmas/:turmaId/provas/:provaId/notas',
+  supabaseAuthMiddleware([Roles.ADMIN, Roles.MODERADOR, Roles.PEDAGOGICO, Roles.PROFESSOR]),
+  ProvasController.registrarNota,
+);
+
+/**
+ * @openapi
+ * /api/v1/cursos/{cursoId}/turmas/{turmaId}/regras-avaliacao:
+ *   get:
+ *     summary: Obter regras de avaliação da turma
+ *     tags: ['Cursos - Avaliação']
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: cursoId
+ *         required: true
+ *         schema: { type: integer, minimum: 1 }
+ *       - in: path
+ *         name: turmaId
+ *         required: true
+ *         schema: { type: string, format: uuid }
+ */
+router.get(
+  '/:cursoId/turmas/:turmaId/regras-avaliacao',
+  supabaseAuthMiddleware([Roles.ADMIN, Roles.MODERADOR, Roles.PEDAGOGICO, Roles.PROFESSOR]),
+  AvaliacaoController.getRules,
+);
+
+/**
+ * @openapi
+ * /api/v1/cursos/{cursoId}/turmas/{turmaId}/regras-avaliacao:
+ *   put:
+ *     summary: Atualizar regras de avaliação da turma
+ *     tags: ['Cursos - Avaliação']
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: cursoId
+ *         required: true
+ *         schema: { type: integer, minimum: 1 }
+ *       - in: path
+ *         name: turmaId
+ *         required: true
+ *         schema: { type: string, format: uuid }
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/CursoTurmaRegrasAvaliacaoInput'
+ */
+router.put(
+  '/:cursoId/turmas/:turmaId/regras-avaliacao',
+  supabaseAuthMiddleware([Roles.ADMIN, Roles.MODERADOR, Roles.PEDAGOGICO, Roles.PROFESSOR]),
+  AvaliacaoController.updateRules,
+);
+
+/**
+ * @openapi
+ * /api/v1/cursos/{cursoId}/turmas/{turmaId}/recuperacoes:
+ *   post:
+ *     summary: Registrar tentativa de recuperação
+ *     tags: ['Cursos - Avaliação']
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: cursoId
+ *         required: true
+ *         schema: { type: integer, minimum: 1 }
+ *       - in: path
+ *         name: turmaId
+ *         required: true
+ *         schema: { type: string, format: uuid }
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/CursoTurmaRecuperacaoInput'
+ */
+router.post(
+  '/:cursoId/turmas/:turmaId/recuperacoes',
+  supabaseAuthMiddleware([Roles.ADMIN, Roles.MODERADOR, Roles.PEDAGOGICO, Roles.PROFESSOR]),
+  AvaliacaoController.registrarRecuperacao,
+);
+
+/**
+ * @openapi
+ * /api/v1/cursos/matriculas/{matriculaId}/notas:
+ *   get:
+ *     summary: Consultar notas consolidadas de uma matrícula (admin)
+ *     tags: ['Cursos - Avaliação']
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: matriculaId
+ *         required: true
+ *         schema: { type: string, format: uuid }
+ */
+router.get(
+  '/matriculas/:matriculaId/notas',
+  supabaseAuthMiddleware([Roles.ADMIN, Roles.MODERADOR, Roles.PEDAGOGICO]),
+  AvaliacaoController.getGrades,
+);
+
+/**
+ * @openapi
+ * /api/v1/cursos/me/matriculas/{matriculaId}/notas:
+ *   get:
+ *     summary: Consultar notas consolidadas do aluno autenticado
+ *     tags: ['Cursos - Avaliação']
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: matriculaId
+ *         required: true
+ *         schema: { type: string, format: uuid }
+ */
+router.get(
+  '/me/matriculas/:matriculaId/notas',
+  supabaseAuthMiddleware([Roles.ALUNO_CANDIDATO]),
+  AvaliacaoController.getMyGrades,
 );
 
 export { router as cursosRoutes };

--- a/src/modules/cursos/services/aulas.mapper.ts
+++ b/src/modules/cursos/services/aulas.mapper.ts
@@ -31,6 +31,7 @@ export const mapMaterial = (material: AulaWithMateriais['materiais'][number]) =>
 export const mapAula = (aula: AulaWithMateriais) => ({
   id: aula.id,
   turmaId: aula.turmaId,
+  moduloId: aula.moduloId ?? null,
   nome: aula.nome,
   descricao: aula.descricao,
   ordem: aula.ordem,

--- a/src/modules/cursos/services/avaliacao.service.ts
+++ b/src/modules/cursos/services/avaliacao.service.ts
@@ -1,0 +1,447 @@
+import {
+  CursosSituacaoFinal,
+  CursosModelosRecuperacao,
+  Prisma,
+} from '@prisma/client';
+
+import { prisma } from '@/config/prisma';
+import { logger } from '@/utils/logger';
+
+import {
+  ResultadoAplicacaoRecuperacao,
+  applyRecoveryModels,
+  computeFinalResult,
+  computeInitialAverage,
+  CursosFinalStatus,
+  CursosModelosDeRecuperacao,
+  CursosRegrasDeProvas,
+  CursosReferenciasDeProvas,
+  traduzirModelosPrisma,
+} from '../utils/avaliacao';
+
+const avaliacaoLogger = logger.child({ module: 'CursosAvaliacaoService' });
+
+type PrismaClientOrTx = Prisma.TransactionClient | typeof prisma;
+
+const defaultRegras: CursosRegrasDeProvas = {
+  mediaMinima: 7,
+  politicaRecuperacao: {
+    habilitada: false,
+    modelos: [],
+  },
+};
+
+const round = (valor: Prisma.Decimal | number | null | undefined, precision = 2) => {
+  if (valor === null || valor === undefined) {
+    return null;
+  }
+  const numero = typeof valor === 'number' ? valor : valor.toNumber();
+  const factor = 10 ** precision;
+  return Math.round(numero * factor) / factor;
+};
+
+const mapStatusFinal = (status: CursosSituacaoFinal | null | undefined): CursosFinalStatus => {
+  switch (status) {
+    case CursosSituacaoFinal.APROVADO:
+      return CursosFinalStatus.APROVADO;
+    case CursosSituacaoFinal.REPROVADO:
+      return CursosFinalStatus.REPROVADO;
+    case CursosSituacaoFinal.EM_ANALISE:
+    default:
+      return CursosFinalStatus.EM_ANALISE;
+  }
+};
+
+const mapModeloToPrisma = (modelo: CursosModelosDeRecuperacao | null | undefined) => {
+  if (!modelo) return undefined;
+  switch (modelo) {
+    case CursosModelosDeRecuperacao.SUBSTITUI_MENOR:
+      return CursosModelosRecuperacao.SUBSTITUI_MENOR;
+    case CursosModelosDeRecuperacao.MEDIA_MINIMA_DIRETA:
+      return CursosModelosRecuperacao.MEDIA_MINIMA_DIRETA;
+    case CursosModelosDeRecuperacao.PROVA_FINAL_UNICA:
+      return CursosModelosRecuperacao.PROVA_FINAL_UNICA;
+    case CursosModelosDeRecuperacao.NOTA_MAXIMA_LIMITADA:
+      return CursosModelosRecuperacao.NOTA_MAXIMA_LIMITADA;
+    default:
+      return undefined;
+  }
+};
+
+const mapRegrasFromDb = (
+  regras:
+    | (Prisma.CursosTurmasRegrasAvaliacaoGetPayload<{ select: typeof regrasSelect }> & {
+        modelosRecuperacao: CursosModelosRecuperacao[];
+        ordemAplicacaoRecuperacao: CursosModelosRecuperacao[];
+      })
+    | null
+    | undefined,
+): CursosRegrasDeProvas => {
+  if (!regras) {
+    return defaultRegras;
+  }
+
+  return {
+    mediaMinima: round(regras.mediaMinima, 1) ?? defaultRegras.mediaMinima,
+    politicaRecuperacao: {
+      habilitada: regras.politicaRecuperacaoAtiva,
+      modelos: traduzirModelosPrisma(regras.modelosRecuperacao),
+      ordemAplicacao: traduzirModelosPrisma(regras.ordemAplicacaoRecuperacao),
+      notaMaxima: round(regras.notaMaximaRecuperacao, 1),
+      pesoProvaFinal: round(regras.pesoProvaFinal, 2),
+    },
+  };
+};
+
+const regrasSelect = {
+  id: true,
+  mediaMinima: true,
+  politicaRecuperacaoAtiva: true,
+  modelosRecuperacao: true,
+  ordemAplicacaoRecuperacao: true,
+  notaMaximaRecuperacao: true,
+  pesoProvaFinal: true,
+  observacoes: true,
+} as const;
+
+const ensureTurmaBelongsToCurso = async (
+  client: PrismaClientOrTx,
+  cursoId: number,
+  turmaId: string,
+): Promise<void> => {
+  const turma = await client.cursosTurmas.findFirst({
+    where: { id: turmaId, cursoId },
+    select: { id: true },
+  });
+
+  if (!turma) {
+    const error = new Error('Turma não encontrada para o curso informado');
+    (error as any).code = 'TURMA_NOT_FOUND';
+    throw error;
+  }
+};
+
+const ensureMatriculaBelongsToTurma = async (
+  client: PrismaClientOrTx,
+  turmaId: string,
+  matriculaId: string,
+): Promise<void> => {
+  const matricula = await client.cursosTurmasMatriculas.findFirst({
+    where: { id: matriculaId, turmaId },
+    select: { id: true },
+  });
+
+  if (!matricula) {
+    const error = new Error('Matrícula não encontrada para a turma informada');
+    (error as any).code = 'MATRICULA_NOT_FOUND';
+    throw error;
+  }
+};
+
+const mapProvaToReferencia = (
+  prova: Prisma.CursosTurmasProvasGetPayload<{ include: { envios: true } }>,
+  matriculaId: string,
+): CursosReferenciasDeProvas => {
+  const envio = prova.envios.find((item) => item.matriculaId === matriculaId) ?? null;
+  return {
+    id: prova.id,
+    etiqueta: prova.etiqueta,
+    peso: round(prova.peso, 2) ?? 0,
+    nota: envio?.nota ? round(envio.nota, 1) : null,
+  };
+};
+
+const buildRecuperacaoResponse = (
+  recuperacao: Prisma.CursosTurmasRecuperacoesGetPayload<{
+    include: {
+      prova: { select: { id: true, etiqueta: true } };
+    };
+  }> | null,
+  resultadoRecuperacao: ResultadoAplicacaoRecuperacao | null,
+) => {
+  if (!recuperacao) {
+    return null;
+  }
+
+  return {
+    id: recuperacao.id,
+    notaRegistrada: recuperacao.notaFinal ? round(recuperacao.notaFinal, 1) : recuperacao.notaRecuperacao ? round(recuperacao.notaRecuperacao, 1) : null,
+    notaRecuperacao: resultadoRecuperacao?.notaRecuperacao ?? (recuperacao.notaRecuperacao ? round(recuperacao.notaRecuperacao, 1) : null),
+    status: mapStatusFinal(recuperacao.statusFinal),
+    prova: recuperacao.prova ? { id: recuperacao.prova.id, etiqueta: recuperacao.prova.etiqueta } : null,
+    modeloAplicado: recuperacao.modeloAplicado ? traduzirModelosPrisma([recuperacao.modeloAplicado])[0] : null,
+    detalhes: (recuperacao.detalhes as Record<string, unknown> | null) ?? undefined,
+    observacoes: recuperacao.observacoes ?? undefined,
+    aplicadoEm: recuperacao.aplicadoEm?.toISOString() ?? null,
+    modelos: resultadoRecuperacao?.modelos ?? undefined,
+  };
+};
+
+export const avaliacaoService = {
+  async obterRegras(cursoId: number, turmaId: string) {
+    await ensureTurmaBelongsToCurso(prisma, cursoId, turmaId);
+
+    const regras = await prisma.cursosTurmasRegrasAvaliacao.findUnique({
+      where: { turmaId },
+      select: regrasSelect,
+    });
+
+    return mapRegrasFromDb(regras as any);
+  },
+
+  async atualizarRegras(
+    cursoId: number,
+    turmaId: string,
+    data: Partial<{
+      mediaMinima: number | null;
+      politicaRecuperacaoAtiva: boolean;
+      modelosRecuperacao: CursosModelosDeRecuperacao[];
+      ordemAplicacaoRecuperacao: CursosModelosDeRecuperacao[];
+      notaMaximaRecuperacao: number | null;
+      pesoProvaFinal: number | null;
+      observacoes?: string | null;
+    }> & { modelosRecuperacao?: CursosModelosDeRecuperacao[] },
+  ) {
+    return prisma.$transaction(async (tx) => {
+      await ensureTurmaBelongsToCurso(tx, cursoId, turmaId);
+
+      const modelos = data.modelosRecuperacao?.map(mapModeloToPrisma).filter(Boolean) as CursosModelosRecuperacao[] | undefined;
+      const ordem = data.ordemAplicacaoRecuperacao?.map(mapModeloToPrisma).filter(Boolean) as CursosModelosRecuperacao[] | undefined;
+
+      const regras = await tx.cursosTurmasRegrasAvaliacao.upsert({
+        where: { turmaId },
+        update: {
+          mediaMinima: data.mediaMinima !== undefined ? new Prisma.Decimal(data.mediaMinima) : undefined,
+          politicaRecuperacaoAtiva: data.politicaRecuperacaoAtiva ?? undefined,
+          modelosRecuperacao: modelos ?? undefined,
+          ordemAplicacaoRecuperacao: ordem ?? undefined,
+          notaMaximaRecuperacao:
+            data.notaMaximaRecuperacao !== undefined ? new Prisma.Decimal(data.notaMaximaRecuperacao) : undefined,
+          pesoProvaFinal:
+            data.pesoProvaFinal !== undefined ? new Prisma.Decimal(data.pesoProvaFinal) : undefined,
+          observacoes: data.observacoes ?? undefined,
+        },
+        create: {
+          turmaId,
+          mediaMinima: new Prisma.Decimal(data.mediaMinima ?? defaultRegras.mediaMinima),
+          politicaRecuperacaoAtiva: data.politicaRecuperacaoAtiva ?? false,
+          modelosRecuperacao: modelos ?? [],
+          ordemAplicacaoRecuperacao: ordem ?? [],
+          notaMaximaRecuperacao:
+            data.notaMaximaRecuperacao !== undefined && data.notaMaximaRecuperacao !== null
+              ? new Prisma.Decimal(data.notaMaximaRecuperacao)
+              : null,
+          pesoProvaFinal:
+            data.pesoProvaFinal !== undefined && data.pesoProvaFinal !== null
+              ? new Prisma.Decimal(data.pesoProvaFinal)
+              : null,
+          observacoes: data.observacoes ?? null,
+        },
+        select: regrasSelect,
+      });
+
+      avaliacaoLogger.info({ turmaId }, 'Regras de avaliação atualizadas');
+
+      return mapRegrasFromDb(regras as any);
+    });
+  },
+
+  async registrarRecuperacao(
+    cursoId: number,
+    turmaId: string,
+    data: {
+      matriculaId: string;
+      provaId?: string | null;
+      envioId?: string | null;
+      notaRecuperacao?: number | null;
+      notaFinal?: number | null;
+      mediaCalculada?: number | null;
+      modeloAplicado?: CursosModelosDeRecuperacao | null;
+      detalhes?: Record<string, unknown> | null;
+      observacoes?: string | null;
+      aplicadoEm?: Date | null;
+    },
+  ) {
+    return prisma.$transaction(async (tx) => {
+      await ensureTurmaBelongsToCurso(tx, cursoId, turmaId);
+      await ensureMatriculaBelongsToTurma(tx, turmaId, data.matriculaId);
+
+      if (data.provaId) {
+        await ensureProvaBelongsToTurma(tx, cursoId, turmaId, data.provaId);
+      }
+
+      if (data.envioId) {
+        const envio = await tx.cursosTurmasProvasEnvios.findFirst({
+          where: { id: data.envioId, prova: { turmaId } },
+          select: { matriculaId: true },
+        });
+        if (!envio || envio.matriculaId !== data.matriculaId) {
+          const error = new Error('Envio de prova não encontrado para a matrícula informada');
+          (error as any).code = 'ENVIO_NOT_FOUND';
+          throw error;
+        }
+      }
+
+      const recuperacao = await tx.cursosTurmasRecuperacoes.create({
+        data: {
+          turmaId,
+          matriculaId: data.matriculaId,
+          provaId: data.provaId ?? null,
+          envioId: data.envioId ?? null,
+          notaRecuperacao:
+            data.notaRecuperacao !== undefined && data.notaRecuperacao !== null
+              ? new Prisma.Decimal(data.notaRecuperacao)
+              : null,
+          notaFinal:
+            data.notaFinal !== undefined && data.notaFinal !== null
+              ? new Prisma.Decimal(data.notaFinal)
+              : null,
+          mediaCalculada:
+            data.mediaCalculada !== undefined && data.mediaCalculada !== null
+              ? new Prisma.Decimal(data.mediaCalculada)
+              : null,
+          modeloAplicado: mapModeloToPrisma(data.modeloAplicado) ?? null,
+          statusFinal: CursosSituacaoFinal.EM_ANALISE,
+          detalhes: data.detalhes ?? null,
+          observacoes: data.observacoes ?? null,
+          aplicadoEm: data.aplicadoEm ?? new Date(),
+          regraId: (
+            await tx.cursosTurmasRegrasAvaliacao.findUnique({ where: { turmaId }, select: { id: true } })
+          )?.id ?? null,
+        },
+        include: {
+          prova: { select: { id: true, etiqueta: true } },
+        },
+      });
+
+      avaliacaoLogger.info({ turmaId, recuperacaoId: recuperacao.id }, 'Recuperação registrada');
+
+      return recuperacao;
+    });
+  },
+
+  async calcularNotasMatricula(
+    matriculaId: string,
+    requesterId?: string,
+    { permitirAdmin = false }: { permitirAdmin?: boolean } = {},
+  ) {
+    const matricula = await prisma.cursosTurmasMatriculas.findUnique({
+      where: { id: matriculaId },
+      include: {
+        aluno: { select: { id: true, nomeCompleto: true, email: true } },
+        turma: {
+          include: {
+            curso: { select: { id: true, nome: true } },
+            provas: {
+              orderBy: [
+                { ordem: 'asc' },
+                { criadoEm: 'asc' },
+              ],
+              include: {
+                envios: {
+                  where: { matriculaId },
+                  orderBy: { atualizadoEm: 'desc' },
+                },
+              },
+            },
+            regrasAvaliacao: { select: regrasSelect },
+          },
+        },
+        recuperacoes: {
+          orderBy: { criadoEm: 'desc' },
+          take: 1,
+          include: {
+            prova: { select: { id: true, etiqueta: true } },
+          },
+        },
+      },
+    });
+
+    if (!matricula) {
+      const error = new Error('Matrícula não encontrada');
+      (error as any).code = 'MATRICULA_NOT_FOUND';
+      throw error;
+    }
+
+    if (requesterId && requesterId !== matricula.alunoId && !permitirAdmin) {
+      const error = new Error('Acesso negado');
+      (error as any).code = 'FORBIDDEN';
+      throw error;
+    }
+
+    const regras = mapRegrasFromDb(matricula.turma.regrasAvaliacao as any);
+    const provasAtivas = matricula.turma.provas.filter((prova) => prova.ativo !== false);
+    const referencias: CursosReferenciasDeProvas[] = provasAtivas.map((prova) =>
+      mapProvaToReferencia(prova as any, matriculaId),
+    );
+
+    const mediaInicial = computeInitialAverage(referencias);
+    const ultimaRecuperacao = matricula.recuperacoes[0] ?? null;
+    const notaRecuperacao = ultimaRecuperacao
+      ? ultimaRecuperacao.notaFinal
+        ? round(ultimaRecuperacao.notaFinal, 1)
+        : ultimaRecuperacao.notaRecuperacao
+          ? round(ultimaRecuperacao.notaRecuperacao, 1)
+          : null
+      : null;
+
+    const resultadoRecuperacao = ultimaRecuperacao
+      ? applyRecoveryModels(referencias, regras, notaRecuperacao)
+      : null;
+
+    const resultadoFinal = computeFinalResult({
+      mediaInicial,
+      regras,
+      recuperacao: resultadoRecuperacao,
+    });
+
+    return {
+      matricula: {
+        id: matricula.id,
+        aluno: {
+          id: matricula.aluno.id,
+          nome: matricula.aluno.nomeCompleto,
+          email: matricula.aluno.email,
+        },
+      },
+      curso: {
+        id: matricula.turma.curso.id,
+        nome: matricula.turma.curso.nome,
+      },
+      turma: {
+        id: matricula.turmaId,
+        nome: matricula.turma.nome,
+        codigo: matricula.turma.codigo,
+      },
+      regras,
+      provas: {
+        referencias,
+        mediaInicial: resultadoFinal.mediaInicial,
+        statusInicial: resultadoFinal.statusInicial,
+      },
+      recuperacao: buildRecuperacaoResponse(ultimaRecuperacao, resultadoRecuperacao),
+      resultadoFinal: {
+        media: resultadoFinal.mediaFinal,
+        status: resultadoFinal.statusFinal,
+      },
+    };
+  },
+};
+
+const ensureProvaBelongsToTurma = async (
+  client: PrismaClientOrTx,
+  cursoId: number,
+  turmaId: string,
+  provaId: string,
+): Promise<void> => {
+  const prova = await client.cursosTurmasProvas.findFirst({
+    where: { id: provaId, turmaId, turma: { cursoId } },
+    select: { id: true },
+  });
+
+  if (!prova) {
+    const error = new Error('Prova não encontrada para a turma informada');
+    (error as any).code = 'PROVA_NOT_FOUND';
+    throw error;
+  }
+};

--- a/src/modules/cursos/services/modulos.mapper.ts
+++ b/src/modules/cursos/services/modulos.mapper.ts
@@ -1,0 +1,38 @@
+import { Prisma } from '@prisma/client';
+
+import { aulaWithMateriaisInclude, mapAula } from './aulas.mapper';
+import { mapProva, provaDefaultInclude } from './provas.mapper';
+
+export const moduloDetailedInclude = {
+  include: {
+    aulas: {
+      ...aulaWithMateriaisInclude.include,
+      orderBy: [
+        { ordem: 'asc' as const },
+        { criadoEm: 'asc' as const },
+      ],
+    },
+    provas: {
+      ...provaDefaultInclude.include,
+      orderBy: [
+        { ordem: 'asc' as const },
+        { criadoEm: 'asc' as const },
+      ],
+    },
+  },
+} as const;
+
+export type ModuloWithRelations = Prisma.CursosTurmasModulosGetPayload<typeof moduloDetailedInclude>;
+
+export const mapModulo = (modulo: ModuloWithRelations) => ({
+  id: modulo.id,
+  turmaId: modulo.turmaId,
+  nome: modulo.nome,
+  descricao: modulo.descricao ?? null,
+  obrigatorio: modulo.obrigatorio,
+  ordem: modulo.ordem,
+  criadoEm: modulo.criadoEm.toISOString(),
+  atualizadoEm: modulo.atualizadoEm.toISOString(),
+  aulas: modulo.aulas?.map(mapAula) ?? [],
+  provas: modulo.provas?.map(mapProva) ?? [],
+});

--- a/src/modules/cursos/services/modulos.service.ts
+++ b/src/modules/cursos/services/modulos.service.ts
@@ -1,0 +1,156 @@
+import { Prisma } from '@prisma/client';
+
+import { prisma } from '@/config/prisma';
+import { logger } from '@/utils/logger';
+
+import { moduloDetailedInclude, mapModulo } from './modulos.mapper';
+
+type PrismaClientOrTx = Prisma.TransactionClient | typeof prisma;
+
+const modulosLogger = logger.child({ module: 'CursosModulosService' });
+
+const ensureTurmaBelongsToCurso = async (
+  client: PrismaClientOrTx,
+  cursoId: number,
+  turmaId: string,
+): Promise<void> => {
+  const turma = await client.cursosTurmas.findFirst({
+    where: { id: turmaId, cursoId },
+    select: { id: true },
+  });
+
+  if (!turma) {
+    const error = new Error('Turma não encontrada para o curso informado');
+    (error as any).code = 'TURMA_NOT_FOUND';
+    throw error;
+  }
+};
+
+const ensureModuloBelongsToTurma = async (
+  client: PrismaClientOrTx,
+  cursoId: number,
+  turmaId: string,
+  moduloId: string,
+): Promise<void> => {
+  const modulo = await client.cursosTurmasModulos.findFirst({
+    where: { id: moduloId, turmaId, turma: { cursoId } },
+    select: { id: true },
+  });
+
+  if (!modulo) {
+    const error = new Error('Módulo não encontrado para a turma informada');
+    (error as any).code = 'MODULO_NOT_FOUND';
+    throw error;
+  }
+};
+
+const fetchModulo = async (client: PrismaClientOrTx, moduloId: string) => {
+  const modulo = await client.cursosTurmasModulos.findUnique({
+    where: { id: moduloId },
+    ...moduloDetailedInclude,
+  });
+
+  if (!modulo) {
+    const error = new Error('Módulo não encontrado');
+    (error as any).code = 'MODULO_NOT_FOUND';
+    throw error;
+  }
+
+  return mapModulo(modulo);
+};
+
+export const modulosService = {
+  async list(cursoId: number, turmaId: string) {
+    await ensureTurmaBelongsToCurso(prisma, cursoId, turmaId);
+
+    const modulos = await prisma.cursosTurmasModulos.findMany({
+      where: { turmaId },
+      orderBy: [
+        { ordem: 'asc' },
+        { criadoEm: 'asc' },
+      ],
+      ...moduloDetailedInclude,
+    });
+
+    return modulos.map(mapModulo);
+  },
+
+  async get(cursoId: number, turmaId: string, moduloId: string) {
+    await ensureModuloBelongsToTurma(prisma, cursoId, turmaId, moduloId);
+
+    return fetchModulo(prisma, moduloId);
+  },
+
+  async create(
+    cursoId: number,
+    turmaId: string,
+    data: {
+      nome: string;
+      descricao?: string | null;
+      obrigatorio?: boolean;
+      ordem?: number | null;
+    },
+  ) {
+    return prisma.$transaction(async (tx) => {
+      await ensureTurmaBelongsToCurso(tx, cursoId, turmaId);
+
+      const ordem = data.ordem ?? (await tx.cursosTurmasModulos.count({ where: { turmaId } })) + 1;
+
+      const modulo = await tx.cursosTurmasModulos.create({
+        data: {
+          turmaId,
+          nome: data.nome,
+          descricao: data.descricao ?? null,
+          obrigatorio: data.obrigatorio ?? true,
+          ordem,
+        },
+      });
+
+      modulosLogger.info({ turmaId, moduloId: modulo.id }, 'Módulo criado com sucesso');
+
+      return fetchModulo(tx, modulo.id);
+    });
+  },
+
+  async update(
+    cursoId: number,
+    turmaId: string,
+    moduloId: string,
+    data: {
+      nome?: string;
+      descricao?: string | null;
+      obrigatorio?: boolean;
+      ordem?: number | null;
+    },
+  ) {
+    return prisma.$transaction(async (tx) => {
+      await ensureModuloBelongsToTurma(tx, cursoId, turmaId, moduloId);
+
+      await tx.cursosTurmasModulos.update({
+        where: { id: moduloId },
+        data: {
+          nome: data.nome ?? undefined,
+          descricao: data.descricao ?? undefined,
+          obrigatorio: data.obrigatorio ?? undefined,
+          ordem: data.ordem ?? undefined,
+        },
+      });
+
+      modulosLogger.info({ turmaId, moduloId }, 'Módulo atualizado com sucesso');
+
+      return fetchModulo(tx, moduloId);
+    });
+  },
+
+  async remove(cursoId: number, turmaId: string, moduloId: string) {
+    return prisma.$transaction(async (tx) => {
+      await ensureModuloBelongsToTurma(tx, cursoId, turmaId, moduloId);
+
+      await tx.cursosTurmasModulos.delete({ where: { id: moduloId } });
+
+      modulosLogger.info({ turmaId, moduloId }, 'Módulo removido com sucesso');
+
+      return { success: true } as const;
+    });
+  },
+};

--- a/src/modules/cursos/services/provas.mapper.ts
+++ b/src/modules/cursos/services/provas.mapper.ts
@@ -1,0 +1,82 @@
+import { Prisma } from '@prisma/client';
+
+export const provaDefaultInclude = {
+  include: {
+    modulo: {
+      select: {
+        id: true,
+        nome: true,
+      },
+    },
+  },
+} as const;
+
+export const provaWithEnviosInclude = {
+  include: {
+    modulo: {
+      select: {
+        id: true,
+        nome: true,
+      },
+    },
+    envios: {
+      include: {
+        matricula: {
+          select: {
+            id: true,
+            alunoId: true,
+          },
+        },
+      },
+      orderBy: [
+        { criadoEm: 'desc' as const },
+      ],
+    },
+  },
+} as const;
+
+export type ProvaWithModulo = Prisma.CursosTurmasProvasGetPayload<typeof provaDefaultInclude>;
+export type ProvaWithEnvios = Prisma.CursosTurmasProvasGetPayload<typeof provaWithEnviosInclude>;
+
+const normalizeDecimal = (value: Prisma.Decimal | number | null | undefined) => {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  return Number(value);
+};
+
+export const mapProva = (prova: ProvaWithModulo | ProvaWithEnvios) => ({
+  id: prova.id,
+  turmaId: prova.turmaId,
+  moduloId: prova.moduloId ?? null,
+  titulo: prova.titulo,
+  etiqueta: prova.etiqueta,
+  descricao: prova.descricao ?? null,
+  peso: normalizeDecimal(prova.peso) ?? 0,
+  ativo: prova.ativo,
+  localizacao: prova.localizacao,
+  ordem: prova.ordem,
+  criadoEm: prova.criadoEm.toISOString(),
+  atualizadoEm: prova.atualizadoEm.toISOString(),
+  modulo: prova.modulo
+    ? {
+        id: prova.modulo.id,
+        nome: prova.modulo.nome,
+      }
+    : null,
+  envios: 'envios' in prova && Array.isArray(prova.envios)
+    ? prova.envios.map((envio) => ({
+        id: envio.id,
+        provaId: envio.provaId,
+        matriculaId: envio.matriculaId,
+        alunoId: envio.matricula.alunoId,
+        nota: normalizeDecimal(envio.nota),
+        pesoTotal: normalizeDecimal(envio.pesoTotal),
+        realizadoEm: envio.realizadoEm?.toISOString() ?? null,
+        observacoes: envio.observacoes ?? null,
+        criadoEm: envio.criadoEm.toISOString(),
+        atualizadoEm: envio.atualizadoEm.toISOString(),
+      }))
+    : undefined,
+});

--- a/src/modules/cursos/services/provas.service.ts
+++ b/src/modules/cursos/services/provas.service.ts
@@ -1,0 +1,263 @@
+import { Prisma, CursosLocalProva } from '@prisma/client';
+
+import { prisma } from '@/config/prisma';
+import { logger } from '@/utils/logger';
+
+import { mapProva, provaDefaultInclude, provaWithEnviosInclude } from './provas.mapper';
+
+type PrismaClientOrTx = Prisma.TransactionClient | typeof prisma;
+
+const provasLogger = logger.child({ module: 'CursosProvasService' });
+
+const ensureTurmaBelongsToCurso = async (
+  client: PrismaClientOrTx,
+  cursoId: number,
+  turmaId: string,
+): Promise<void> => {
+  const turma = await client.cursosTurmas.findFirst({
+    where: { id: turmaId, cursoId },
+    select: { id: true },
+  });
+
+  if (!turma) {
+    const error = new Error('Turma não encontrada para o curso informado');
+    (error as any).code = 'TURMA_NOT_FOUND';
+    throw error;
+  }
+};
+
+const ensureModuloBelongsToTurma = async (
+  client: PrismaClientOrTx,
+  turmaId: string,
+  moduloId: string,
+): Promise<void> => {
+  const modulo = await client.cursosTurmasModulos.findFirst({
+    where: { id: moduloId, turmaId },
+    select: { id: true },
+  });
+
+  if (!modulo) {
+    const error = new Error('Módulo não encontrado para a turma informada');
+    (error as any).code = 'MODULO_NOT_FOUND';
+    throw error;
+  }
+};
+
+const ensureProvaBelongsToTurma = async (
+  client: PrismaClientOrTx,
+  cursoId: number,
+  turmaId: string,
+  provaId: string,
+): Promise<void> => {
+  const prova = await client.cursosTurmasProvas.findFirst({
+    where: { id: provaId, turmaId, turma: { cursoId } },
+    select: { id: true },
+  });
+
+  if (!prova) {
+    const error = new Error('Prova não encontrada para a turma informada');
+    (error as any).code = 'PROVA_NOT_FOUND';
+    throw error;
+  }
+};
+
+const fetchProva = async (client: PrismaClientOrTx, provaId: string) => {
+  const prova = await client.cursosTurmasProvas.findUnique({
+    where: { id: provaId },
+    ...provaWithEnviosInclude,
+  });
+
+  if (!prova) {
+    const error = new Error('Prova não encontrada');
+    (error as any).code = 'PROVA_NOT_FOUND';
+    throw error;
+  }
+
+  return mapProva(prova);
+};
+
+const toDecimal = (value: number | null | undefined) => {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  return new Prisma.Decimal(value);
+};
+
+export const provasService = {
+  async list(cursoId: number, turmaId: string) {
+    await ensureTurmaBelongsToCurso(prisma, cursoId, turmaId);
+
+    const provas = await prisma.cursosTurmasProvas.findMany({
+      where: { turmaId },
+      orderBy: [
+        { ordem: 'asc' },
+        { criadoEm: 'asc' },
+      ],
+      ...provaWithEnviosInclude,
+    });
+
+    return provas.map(mapProva);
+  },
+
+  async get(cursoId: number, turmaId: string, provaId: string) {
+    await ensureProvaBelongsToTurma(prisma, cursoId, turmaId, provaId);
+
+    return fetchProva(prisma, provaId);
+  },
+
+  async create(
+    cursoId: number,
+    turmaId: string,
+    data: {
+      titulo: string;
+      etiqueta: string;
+      descricao?: string | null;
+      peso: number;
+      moduloId?: string | null;
+      ativo?: boolean;
+      ordem?: number | null;
+    },
+  ) {
+    return prisma.$transaction(async (tx) => {
+      await ensureTurmaBelongsToCurso(tx, cursoId, turmaId);
+
+      if (data.moduloId) {
+        await ensureModuloBelongsToTurma(tx, turmaId, data.moduloId);
+      }
+
+      const ordem = data.ordem ?? (await tx.cursosTurmasProvas.count({ where: { turmaId } })) + 1;
+
+      const prova = await tx.cursosTurmasProvas.create({
+        data: {
+          turmaId,
+          moduloId: data.moduloId ?? null,
+          titulo: data.titulo,
+          etiqueta: data.etiqueta,
+          descricao: data.descricao ?? null,
+          peso: new Prisma.Decimal(data.peso),
+          ativo: data.ativo ?? true,
+          ordem,
+          localizacao: data.moduloId ? CursosLocalProva.MODULO : CursosLocalProva.TURMA,
+        },
+        ...provaDefaultInclude,
+      });
+
+      provasLogger.info({ turmaId, provaId: prova.id }, 'Prova criada com sucesso');
+
+      return mapProva(prova);
+    });
+  },
+
+  async update(
+    cursoId: number,
+    turmaId: string,
+    provaId: string,
+    data: {
+      titulo?: string;
+      etiqueta?: string;
+      descricao?: string | null;
+      peso?: number;
+      moduloId?: string | null;
+      ativo?: boolean;
+      ordem?: number | null;
+    },
+  ) {
+    return prisma.$transaction(async (tx) => {
+      await ensureProvaBelongsToTurma(tx, cursoId, turmaId, provaId);
+
+      if (data.moduloId) {
+        await ensureModuloBelongsToTurma(tx, turmaId, data.moduloId);
+      }
+
+      await tx.cursosTurmasProvas.update({
+        where: { id: provaId },
+        data: {
+          titulo: data.titulo ?? undefined,
+          etiqueta: data.etiqueta ?? undefined,
+          descricao: data.descricao ?? undefined,
+          peso: data.peso !== undefined ? new Prisma.Decimal(data.peso) : undefined,
+          moduloId: data.moduloId ?? (data.moduloId === null ? null : undefined),
+          ativo: data.ativo ?? undefined,
+          ordem: data.ordem ?? undefined,
+          localizacao:
+            data.moduloId !== undefined
+              ? data.moduloId
+                ? CursosLocalProva.MODULO
+                : CursosLocalProva.TURMA
+              : undefined,
+        },
+      });
+
+      provasLogger.info({ turmaId, provaId }, 'Prova atualizada com sucesso');
+
+      return fetchProva(tx, provaId);
+    });
+  },
+
+  async remove(cursoId: number, turmaId: string, provaId: string) {
+    return prisma.$transaction(async (tx) => {
+      await ensureProvaBelongsToTurma(tx, cursoId, turmaId, provaId);
+
+      await tx.cursosTurmasProvas.delete({ where: { id: provaId } });
+
+      provasLogger.info({ turmaId, provaId }, 'Prova removida com sucesso');
+
+      return { success: true } as const;
+    });
+  },
+
+  async registrarNota(
+    cursoId: number,
+    turmaId: string,
+    provaId: string,
+    data: {
+      matriculaId: string;
+      nota: number;
+      pesoTotal?: number | null;
+      realizadoEm?: Date | null;
+      observacoes?: string | null;
+    },
+  ) {
+    return prisma.$transaction(async (tx) => {
+      await ensureProvaBelongsToTurma(tx, cursoId, turmaId, provaId);
+
+      const matricula = await tx.cursosTurmasMatriculas.findFirst({
+        where: { id: data.matriculaId, turmaId },
+        select: { id: true },
+      });
+
+      if (!matricula) {
+        const error = new Error('Matrícula não encontrada para a turma informada');
+        (error as any).code = 'MATRICULA_NOT_FOUND';
+        throw error;
+      }
+
+      const envio = await tx.cursosTurmasProvasEnvios.upsert({
+        where: {
+          provaId_matriculaId: {
+            provaId,
+            matriculaId: data.matriculaId,
+          },
+        },
+        update: {
+          nota: toDecimal(data.nota),
+          pesoTotal: toDecimal(data.pesoTotal ?? null) ?? undefined,
+          realizadoEm: data.realizadoEm ?? undefined,
+          observacoes: data.observacoes ?? undefined,
+        },
+        create: {
+          provaId,
+          matriculaId: data.matriculaId,
+          nota: toDecimal(data.nota),
+          pesoTotal: toDecimal(data.pesoTotal ?? null),
+          realizadoEm: data.realizadoEm ?? null,
+          observacoes: data.observacoes ?? null,
+        },
+      });
+
+      provasLogger.info({ turmaId, provaId, envioId: envio.id }, 'Nota de prova registrada/atualizada');
+
+      return fetchProva(tx, provaId);
+    });
+  },
+};

--- a/src/modules/cursos/utils/avaliacao.ts
+++ b/src/modules/cursos/utils/avaliacao.ts
@@ -1,0 +1,285 @@
+import { CursosModelosRecuperacao } from '@prisma/client';
+
+export enum CursosFinalStatus {
+  EM_ANALISE = 'Em análise',
+  APROVADO = 'Aprovado',
+  REPROVADO = 'Reprovado',
+}
+
+export enum CursosModelosDeRecuperacao {
+  SUBSTITUI_MENOR = 'substitui_menor',
+  MEDIA_MINIMA_DIRETA = 'media_minima_direta',
+  PROVA_FINAL_UNICA = 'prova_final_unica',
+  NOTA_MAXIMA_LIMITADA = 'nota_maxima_limitada',
+}
+
+export type CursosPoliticaDeRecuperacao = {
+  habilitada: boolean;
+  modelos: CursosModelosDeRecuperacao[];
+  ordemAplicacao?: CursosModelosDeRecuperacao[];
+  notaMaxima?: number | null;
+  pesoProvaFinal?: number | null;
+};
+
+export type CursosRegrasDeProvas = {
+  mediaMinima: number;
+  politicaRecuperacao: CursosPoliticaDeRecuperacao;
+};
+
+export type CursosReferenciasDeProvas = {
+  id: string;
+  etiqueta: string;
+  peso: number;
+  nota: number | null;
+};
+
+export type ResultadoModeloRecuperacao = {
+  aplicado: boolean;
+  novaMedia?: number | null;
+  notaConsiderada?: number | null;
+  status?: CursosFinalStatus;
+  detalhes?: string;
+};
+
+export type ResultadoAplicacaoRecuperacao = {
+  provas: CursosReferenciasDeProvas[];
+  media: number | null;
+  status: CursosFinalStatus;
+  notaRecuperacao?: number | null;
+  modelos: Partial<Record<CursosModelosDeRecuperacao, ResultadoModeloRecuperacao>>;
+};
+
+const round = (value: number, precision = 2) => {
+  const factor = 10 ** precision;
+  return Math.round(value * factor) / factor;
+};
+
+const normalizarPeso = (provas: CursosReferenciasDeProvas[]) => {
+  const pesos = provas.map((prova) => Math.max(prova.peso, 0));
+  const total = pesos.reduce((acc, peso) => acc + peso, 0);
+  return total > 0 ? total : 0;
+};
+
+export const computeInitialAverage = (provas: CursosReferenciasDeProvas[]): number | null => {
+  const provasValidas = provas.filter((prova) => prova.nota !== null && prova.peso > 0);
+  if (provasValidas.length === 0) {
+    return null;
+  }
+
+  const somaPesos = provasValidas.reduce((acc, prova) => acc + prova.peso, 0);
+  if (somaPesos === 0) {
+    return null;
+  }
+
+  const somaNotas = provasValidas.reduce((acc, prova) => acc + (prova.nota ?? 0) * prova.peso, 0);
+  return round(somaNotas / somaPesos, 2);
+};
+
+const mapModeloEnum = (modelo: CursosModelosRecuperacao): CursosModelosDeRecuperacao => {
+  switch (modelo) {
+    case CursosModelosRecuperacao.SUBSTITUI_MENOR:
+      return CursosModelosDeRecuperacao.SUBSTITUI_MENOR;
+    case CursosModelosRecuperacao.MEDIA_MINIMA_DIRETA:
+      return CursosModelosDeRecuperacao.MEDIA_MINIMA_DIRETA;
+    case CursosModelosRecuperacao.PROVA_FINAL_UNICA:
+      return CursosModelosDeRecuperacao.PROVA_FINAL_UNICA;
+    case CursosModelosRecuperacao.NOTA_MAXIMA_LIMITADA:
+      return CursosModelosDeRecuperacao.NOTA_MAXIMA_LIMITADA;
+    default:
+      return modelo as unknown as CursosModelosDeRecuperacao;
+  }
+};
+
+export const traduzirModelosPrisma = (
+  modelos: CursosModelosRecuperacao[] | null | undefined,
+): CursosModelosDeRecuperacao[] => {
+  if (!modelos || modelos.length === 0) {
+    return [];
+  }
+  return modelos.map(mapModeloEnum);
+};
+
+export const applyRecoveryModels = (
+  provas: CursosReferenciasDeProvas[],
+  regras: CursosRegrasDeProvas,
+  notaRecuperacao: number | null,
+): ResultadoAplicacaoRecuperacao => {
+  const modelosAplicacao = regras.politicaRecuperacao.ordemAplicacao?.length
+    ? regras.politicaRecuperacao.ordemAplicacao
+    : regras.politicaRecuperacao.modelos;
+
+  const modelosResultado: ResultadoAplicacaoRecuperacao['modelos'] = {};
+  const provasOrdenadas = [...provas];
+  let mediaAtual = computeInitialAverage(provasOrdenadas);
+  let statusAtual = mediaAtual === null ? CursosFinalStatus.EM_ANALISE : CursosFinalStatus.REPROVADO;
+  let notaAtualRecuperacao = notaRecuperacao;
+
+  if (!regras.politicaRecuperacao.habilitada || notaRecuperacao === null) {
+    return {
+      provas: provasOrdenadas,
+      media: mediaAtual,
+      status: mediaAtual !== null && mediaAtual >= regras.mediaMinima ? CursosFinalStatus.APROVADO : statusAtual,
+      notaRecuperacao,
+      modelos: modelosResultado,
+    };
+  }
+
+  const somaPesos = normalizarPeso(provasOrdenadas);
+
+  for (const modelo of modelosAplicacao) {
+    switch (modelo) {
+      case CursosModelosDeRecuperacao.NOTA_MAXIMA_LIMITADA: {
+        if (notaAtualRecuperacao !== null && regras.politicaRecuperacao.notaMaxima !== null && regras.politicaRecuperacao.notaMaxima !== undefined) {
+          const limitada = Math.min(notaAtualRecuperacao, regras.politicaRecuperacao.notaMaxima);
+          modelosResultado[modelo] = {
+            aplicado: true,
+            notaConsiderada: round(limitada, 1),
+            detalhes: 'Nota de recuperação limitada pelo teto configurado',
+            status: statusAtual,
+          };
+          notaAtualRecuperacao = limitada;
+        } else {
+          modelosResultado[modelo] = { aplicado: false };
+        }
+        break;
+      }
+      case CursosModelosDeRecuperacao.SUBSTITUI_MENOR: {
+        if (notaAtualRecuperacao === null) {
+          modelosResultado[modelo] = { aplicado: false };
+          break;
+        }
+
+        const provasComNotas = provasOrdenadas.filter((prova) => prova.nota !== null);
+        if (provasComNotas.length === 0) {
+          modelosResultado[modelo] = { aplicado: false };
+          break;
+        }
+
+        let indiceMenor = 0;
+        let menorNota = provasComNotas[0].nota ?? 0;
+        for (let i = 1; i < provasComNotas.length; i += 1) {
+          const notaAtual = provasComNotas[i].nota ?? 0;
+          if (notaAtual < menorNota) {
+            menorNota = notaAtual;
+            indiceMenor = i;
+          }
+        }
+
+        const provaMenor = provasComNotas[indiceMenor];
+        if (notaAtualRecuperacao > (provaMenor.nota ?? 0)) {
+          const indiceGlobal = provasOrdenadas.findIndex((prova) => prova.id === provaMenor.id);
+          if (indiceGlobal >= 0) {
+            provasOrdenadas[indiceGlobal] = {
+              ...provasOrdenadas[indiceGlobal],
+              nota: round(notaAtualRecuperacao, 1),
+            };
+            mediaAtual = computeInitialAverage(provasOrdenadas);
+            statusAtual = mediaAtual !== null && mediaAtual >= regras.mediaMinima ? CursosFinalStatus.APROVADO : CursosFinalStatus.EM_ANALISE;
+            modelosResultado[modelo] = {
+              aplicado: true,
+              novaMedia: mediaAtual,
+              notaConsiderada: round(notaAtualRecuperacao, 1),
+              status: statusAtual,
+              detalhes: `Substituição da prova ${provaMenor.etiqueta}`,
+            };
+          }
+        } else {
+          modelosResultado[modelo] = {
+            aplicado: false,
+            detalhes: 'Nota de recuperação não superou a menor nota existente',
+          };
+        }
+        break;
+      }
+      case CursosModelosDeRecuperacao.MEDIA_MINIMA_DIRETA: {
+        if (notaAtualRecuperacao === null) {
+          modelosResultado[modelo] = { aplicado: false };
+          break;
+        }
+
+        if (notaAtualRecuperacao >= regras.mediaMinima) {
+          mediaAtual = Math.max(mediaAtual ?? 0, notaAtualRecuperacao);
+          statusAtual = CursosFinalStatus.APROVADO;
+          modelosResultado[modelo] = {
+            aplicado: true,
+            novaMedia: round(mediaAtual, 2),
+            notaConsiderada: round(notaAtualRecuperacao, 1),
+            status: statusAtual,
+            detalhes: 'Nota de recuperação atingiu a média mínima para aprovação direta',
+          };
+        } else {
+          modelosResultado[modelo] = {
+            aplicado: false,
+            detalhes: 'Nota de recuperação abaixo da média mínima configurada',
+          };
+        }
+        break;
+      }
+      case CursosModelosDeRecuperacao.PROVA_FINAL_UNICA: {
+        if (notaAtualRecuperacao === null) {
+          modelosResultado[modelo] = { aplicado: false };
+          break;
+        }
+
+        if (regras.politicaRecuperacao.pesoProvaFinal && regras.politicaRecuperacao.pesoProvaFinal > 0 && somaPesos > 0) {
+          const pesoFinal = regras.politicaRecuperacao.pesoProvaFinal;
+          const mediaAnterior = mediaAtual ?? computeInitialAverage(provasOrdenadas) ?? 0;
+          const mediaCombinada = (mediaAnterior * somaPesos + notaAtualRecuperacao * pesoFinal) / (somaPesos + pesoFinal);
+          mediaAtual = round(mediaCombinada, 2);
+        } else {
+          mediaAtual = round(notaAtualRecuperacao, 2);
+        }
+
+        statusAtual = mediaAtual >= regras.mediaMinima ? CursosFinalStatus.APROVADO : CursosFinalStatus.EM_ANALISE;
+        modelosResultado[modelo] = {
+          aplicado: true,
+          novaMedia: mediaAtual,
+          notaConsiderada: round(notaAtualRecuperacao, 1),
+          status: statusAtual,
+          detalhes: 'Prova final aplicada como nota predominante',
+        };
+        break;
+      }
+      default:
+        modelosResultado[modelo] = { aplicado: false };
+    }
+  }
+
+  return {
+    provas: provasOrdenadas,
+    media: mediaAtual,
+    status: statusAtual,
+    notaRecuperacao: notaAtualRecuperacao,
+    modelos: modelosResultado,
+  };
+};
+
+export const computeFinalResult = ({
+  mediaInicial,
+  regras,
+  recuperacao,
+}: {
+  mediaInicial: number | null;
+  regras: CursosRegrasDeProvas;
+  recuperacao?: ResultadoAplicacaoRecuperacao | null;
+}) => {
+  const statusInicial = mediaInicial === null
+    ? CursosFinalStatus.EM_ANALISE
+    : mediaInicial >= regras.mediaMinima
+      ? CursosFinalStatus.APROVADO
+      : CursosFinalStatus.REPROVADO;
+
+  const mediaFinal = recuperacao?.media ?? mediaInicial;
+  const statusFinal = mediaFinal === null
+    ? CursosFinalStatus.EM_ANALISE
+    : mediaFinal >= regras.mediaMinima
+      ? CursosFinalStatus.APROVADO
+      : CursosFinalStatus.REPROVADO;
+
+  return {
+    mediaInicial: mediaInicial !== null ? round(mediaInicial, 2) : null,
+    statusInicial,
+    mediaFinal: mediaFinal !== null ? round(mediaFinal, 2) : null,
+    statusFinal,
+  };
+};

--- a/src/modules/cursos/validators/aulas.schema.ts
+++ b/src/modules/cursos/validators/aulas.schema.ts
@@ -36,6 +36,10 @@ const materialSchema = z.object({
 });
 
 const aulaBaseSchema = z.object({
+  moduloId: z
+    .string({ invalid_type_error: 'Identificador do módulo deve ser um texto' })
+    .uuid('Identificador de módulo inválido')
+    .nullish(),
   nome: z.string().trim().min(3).max(255),
   descricao: z
     .string({ invalid_type_error: 'Descrição deve ser um texto' })

--- a/src/modules/cursos/validators/avaliacao.schema.ts
+++ b/src/modules/cursos/validators/avaliacao.schema.ts
@@ -1,0 +1,60 @@
+import { CursosModelosRecuperacao } from '@prisma/client';
+import { z } from 'zod';
+
+const decimalNotaSchema = z
+  .number({ invalid_type_error: 'Valor deve ser um número' })
+  .min(0, 'Valor mínimo é 0')
+  .max(10, 'Valor máximo é 10');
+
+const pesoSchema = z
+  .number({ invalid_type_error: 'Peso deve ser um número' })
+  .gt(0, 'Peso deve ser maior que zero')
+  .max(1000, 'Peso deve ser menor ou igual a 1000');
+
+export const updateRegrasAvaliacaoSchema = z.object({
+  mediaMinima: decimalNotaSchema.optional(),
+  politicaRecuperacaoAtiva: z.boolean().optional(),
+  modelosRecuperacao: z.array(z.nativeEnum(CursosModelosRecuperacao)).optional(),
+  ordemAplicacaoRecuperacao: z.array(z.nativeEnum(CursosModelosRecuperacao)).optional(),
+  notaMaximaRecuperacao: decimalNotaSchema.nullish(),
+  pesoProvaFinal: pesoSchema.nullish(),
+  observacoes: z
+    .string({ invalid_type_error: 'Observações devem ser um texto' })
+    .trim()
+    .max(500)
+    .nullish(),
+});
+
+const uuidSchema = z.string().uuid('Identificador inválido');
+
+export const registrarRecuperacaoSchema = z.object({
+  matriculaId: uuidSchema,
+  provaId: uuidSchema.nullish(),
+  envioId: uuidSchema.nullish(),
+  notaRecuperacao: decimalNotaSchema.nullish(),
+  notaFinal: decimalNotaSchema.nullish(),
+  mediaCalculada: z
+    .number({ invalid_type_error: 'Média deve ser um número' })
+    .min(0)
+    .max(10)
+    .nullish(),
+  modeloAplicado: z.nativeEnum(CursosModelosRecuperacao).nullish(),
+  detalhes: z.record(z.any()).nullish(),
+  observacoes: z
+    .string({ invalid_type_error: 'Observações devem ser um texto' })
+    .trim()
+    .max(500)
+    .nullish(),
+  aplicadoEm: z
+    .preprocess((value) => {
+      if (value === undefined || value === null || value === '') {
+        return undefined;
+      }
+      if (value instanceof Date) {
+        return value;
+      }
+      const parsed = new Date(String(value));
+      return Number.isNaN(parsed.getTime()) ? value : parsed;
+    }, z.date({ invalid_type_error: 'Data inválida' }))
+    .optional(),
+});

--- a/src/modules/cursos/validators/modulos.schema.ts
+++ b/src/modules/cursos/validators/modulos.schema.ts
@@ -1,0 +1,21 @@
+import { z } from 'zod';
+
+const ordemSchema = z
+  .number({ invalid_type_error: 'Ordem deve ser um número' })
+  .int('Ordem deve ser um número inteiro')
+  .min(0, 'Ordem deve ser maior ou igual a zero');
+
+const moduloBaseSchema = z.object({
+  nome: z.string().trim().min(3, 'Informe um nome com ao menos 3 caracteres').max(255),
+  descricao: z
+    .string({ invalid_type_error: 'Descrição deve ser um texto' })
+    .trim()
+    .max(2000, 'Descrição deve ter no máximo 2000 caracteres')
+    .nullish(),
+  obrigatorio: z.boolean().optional(),
+  ordem: ordemSchema.optional(),
+});
+
+export const createModuloSchema = moduloBaseSchema;
+
+export const updateModuloSchema = moduloBaseSchema.partial();

--- a/src/modules/cursos/validators/provas.schema.ts
+++ b/src/modules/cursos/validators/provas.schema.ts
@@ -1,0 +1,60 @@
+import { z } from 'zod';
+
+const ordemSchema = z
+  .number({ invalid_type_error: 'Ordem deve ser um número' })
+  .int('Ordem deve ser inteiro')
+  .min(0, 'Ordem deve ser maior ou igual a zero');
+
+const pesoSchema = z
+  .number({ invalid_type_error: 'Peso deve ser um número' })
+  .gt(0, 'Peso deve ser maior que zero')
+  .max(1000, 'Peso deve ser menor ou igual a 1000');
+
+const dataSchema = z
+  .preprocess((value) => {
+    if (value === undefined || value === null || value === '') {
+      return undefined;
+    }
+    if (value instanceof Date) {
+      return value;
+    }
+    const parsed = new Date(String(value));
+    return Number.isNaN(parsed.getTime()) ? value : parsed;
+  }, z.date({ invalid_type_error: 'Data inválida' }))
+  .optional();
+
+const provaBaseSchema = z.object({
+  titulo: z.string().trim().min(3).max(255),
+  etiqueta: z.string().trim().min(1).max(30),
+  descricao: z
+    .string({ invalid_type_error: 'Descrição deve ser um texto' })
+    .trim()
+    .max(2000)
+    .nullish(),
+  peso: pesoSchema,
+  moduloId: z
+    .string({ invalid_type_error: 'Identificador do módulo deve ser um texto' })
+    .uuid('Identificador de módulo inválido')
+    .nullish(),
+  ativo: z.boolean().optional(),
+  ordem: ordemSchema.optional(),
+});
+
+export const createProvaSchema = provaBaseSchema;
+
+export const updateProvaSchema = provaBaseSchema.partial({ peso: true });
+
+export const registrarNotaSchema = z.object({
+  matriculaId: z.string().uuid('Identificador da matrícula inválido'),
+  nota: z
+    .number({ invalid_type_error: 'Nota deve ser um número' })
+    .min(0, 'Nota mínima é 0')
+    .max(10, 'Nota máxima é 10'),
+  pesoTotal: pesoSchema.nullish(),
+  realizadoEm: dataSchema,
+  observacoes: z
+    .string({ invalid_type_error: 'Observações devem ser um texto' })
+    .trim()
+    .max(1000)
+    .nullish(),
+});


### PR DESCRIPTION
## Summary
- acrescenta modelagem Prisma para módulos, provas, regras de avaliação e recuperações das turmas
- adiciona serviços, controladores e rotas para CRUD de módulos/provas, regras de avaliação e vitrine pública
- implementa utilitários de cálculo de médias/recuperações e atualiza a documentação Swagger com os novos esquemas

## Testing
- pnpm lint
- pnpm test
- pnpm prisma:generate

------
https://chatgpt.com/codex/tasks/task_e_68d185615f308332b045f82163801c96