### PR TITLE
fix: update cursos services for prisma 6

### DIFF
--- a/src/modules/cursos/services/aulas.mapper.ts
+++ b/src/modules/cursos/services/aulas.mapper.ts
@@ -1,6 +1,6 @@
 import { Prisma } from '@prisma/client';
 
-export const aulaWithMateriaisInclude = {
+export const aulaWithMateriaisInclude = Prisma.validator<Prisma.CursosTurmasAulasDefaultArgs>()({
   include: {
     materiais: {
       orderBy: [
@@ -9,7 +9,7 @@ export const aulaWithMateriaisInclude = {
       ],
     },
   },
-} as const;
+});
 
 export type AulaWithMateriais = Prisma.CursosTurmasAulasGetPayload<typeof aulaWithMateriaisInclude>;
 

--- a/src/modules/cursos/services/avaliacao.service.ts
+++ b/src/modules/cursos/services/avaliacao.service.ts
@@ -211,14 +211,25 @@ export const avaliacaoService = {
       const regras = await tx.cursosTurmasRegrasAvaliacao.upsert({
         where: { turmaId },
         update: {
-          mediaMinima: data.mediaMinima !== undefined ? new Prisma.Decimal(data.mediaMinima) : undefined,
+          mediaMinima:
+            data.mediaMinima !== undefined && data.mediaMinima !== null
+              ? new Prisma.Decimal(data.mediaMinima)
+              : undefined,
           politicaRecuperacaoAtiva: data.politicaRecuperacaoAtiva ?? undefined,
           modelosRecuperacao: modelos ?? undefined,
           ordemAplicacaoRecuperacao: ordem ?? undefined,
           notaMaximaRecuperacao:
-            data.notaMaximaRecuperacao !== undefined ? new Prisma.Decimal(data.notaMaximaRecuperacao) : undefined,
+            data.notaMaximaRecuperacao !== undefined
+              ? data.notaMaximaRecuperacao !== null
+                ? new Prisma.Decimal(data.notaMaximaRecuperacao)
+                : null
+              : undefined,
           pesoProvaFinal:
-            data.pesoProvaFinal !== undefined ? new Prisma.Decimal(data.pesoProvaFinal) : undefined,
+            data.pesoProvaFinal !== undefined
+              ? data.pesoProvaFinal !== null
+                ? new Prisma.Decimal(data.pesoProvaFinal)
+                : null
+              : undefined,
           observacoes: data.observacoes ?? undefined,
         },
         create: {
@@ -302,7 +313,12 @@ export const avaliacaoService = {
               : null,
           modeloAplicado: mapModeloToPrisma(data.modeloAplicado) ?? null,
           statusFinal: CursosSituacaoFinal.EM_ANALISE,
-          detalhes: data.detalhes ?? null,
+          detalhes:
+            data.detalhes !== undefined
+              ? data.detalhes
+                ? (data.detalhes as Prisma.JsonObject)
+                : Prisma.JsonNull
+              : Prisma.JsonNull,
           observacoes: data.observacoes ?? null,
           aplicadoEm: data.aplicadoEm ?? new Date(),
           regraId: (

--- a/src/modules/cursos/services/modulos.mapper.ts
+++ b/src/modules/cursos/services/modulos.mapper.ts
@@ -1,30 +1,35 @@
 import { Prisma } from '@prisma/client';
 
-import { aulaWithMateriaisInclude, mapAula } from './aulas.mapper';
-import { mapProva, provaDefaultInclude } from './provas.mapper';
+import { AulaWithMateriais, aulaWithMateriaisInclude, mapAula } from './aulas.mapper';
+import { ProvaWithModulo, mapProva, provaDefaultInclude } from './provas.mapper';
 
-export const moduloDetailedInclude = {
-  include: {
-    aulas: {
-      ...aulaWithMateriaisInclude.include,
-      orderBy: [
-        { ordem: 'asc' as const },
-        { criadoEm: 'asc' as const },
-      ],
+export const moduloDetailedInclude =
+  Prisma.validator<Prisma.CursosTurmasModulosDefaultArgs>()({
+    include: {
+      aulas: {
+        ...aulaWithMateriaisInclude.include,
+        orderBy: [
+          { ordem: 'asc' },
+          { criadoEm: 'asc' },
+        ],
+      },
+      provas: {
+        ...provaDefaultInclude.include,
+        orderBy: [
+          { ordem: 'asc' },
+          { criadoEm: 'asc' },
+        ],
+      },
     },
-    provas: {
-      ...provaDefaultInclude.include,
-      orderBy: [
-        { ordem: 'asc' as const },
-        { criadoEm: 'asc' as const },
-      ],
-    },
-  },
-} as const;
+  });
 
 export type ModuloWithRelations = Prisma.CursosTurmasModulosGetPayload<typeof moduloDetailedInclude>;
 
-export const mapModulo = (modulo: ModuloWithRelations) => ({
+export const mapModulo = (modulo: ModuloWithRelations) => {
+  const aulas = (modulo.aulas ?? []) as unknown as AulaWithMateriais[];
+  const provas = (modulo.provas ?? []) as unknown as ProvaWithModulo[];
+
+  return {
   id: modulo.id,
   turmaId: modulo.turmaId,
   nome: modulo.nome,
@@ -33,6 +38,7 @@ export const mapModulo = (modulo: ModuloWithRelations) => ({
   ordem: modulo.ordem,
   criadoEm: modulo.criadoEm.toISOString(),
   atualizadoEm: modulo.atualizadoEm.toISOString(),
-  aulas: modulo.aulas?.map(mapAula) ?? [],
-  provas: modulo.provas?.map(mapProva) ?? [],
-});
+  aulas: aulas.map(mapAula),
+  provas: provas.map(mapProva),
+};
+};

--- a/src/modules/cursos/services/provas.mapper.ts
+++ b/src/modules/cursos/services/provas.mapper.ts
@@ -1,6 +1,6 @@
 import { Prisma } from '@prisma/client';
 
-export const provaDefaultInclude = {
+export const provaDefaultInclude = Prisma.validator<Prisma.CursosTurmasProvasDefaultArgs>()({
   include: {
     modulo: {
       select: {
@@ -9,9 +9,9 @@ export const provaDefaultInclude = {
       },
     },
   },
-} as const;
+});
 
-export const provaWithEnviosInclude = {
+export const provaWithEnviosInclude = Prisma.validator<Prisma.CursosTurmasProvasDefaultArgs>()({
   include: {
     modulo: {
       select: {
@@ -28,12 +28,10 @@ export const provaWithEnviosInclude = {
           },
         },
       },
-      orderBy: [
-        { criadoEm: 'desc' as const },
-      ],
+      orderBy: [{ criadoEm: 'desc' }],
     },
   },
-} as const;
+});
 
 export type ProvaWithModulo = Prisma.CursosTurmasProvasGetPayload<typeof provaDefaultInclude>;
 export type ProvaWithEnvios = Prisma.CursosTurmasProvasGetPayload<typeof provaWithEnviosInclude>;

--- a/src/modules/cursos/services/turmas.service.ts
+++ b/src/modules/cursos/services/turmas.service.ts
@@ -8,6 +8,8 @@ import {
   generateUniqueTurmaCode,
 } from '../utils/code-generator';
 import { aulaWithMateriaisInclude } from './aulas.mapper';
+import { moduloDetailedInclude } from './modulos.mapper';
+import { provaDefaultInclude } from './provas.mapper';
 import { cursosTurmasMapper } from './cursos.service';
 
 const turmasLogger = logger.child({ module: 'CursosTurmasService' });
@@ -25,7 +27,17 @@ const turmaSummarySelect = {
   dataInscricaoFim: true,
 } as const;
 
-const turmaDetailedInclude = {
+const regrasAvaliacaoSelect = {
+  mediaMinima: true,
+  politicaRecuperacaoAtiva: true,
+  modelosRecuperacao: true,
+  ordemAplicacaoRecuperacao: true,
+  notaMaximaRecuperacao: true,
+  pesoProvaFinal: true,
+  observacoes: true,
+} as const;
+
+const turmaDetailedInclude = Prisma.validator<Prisma.CursosTurmasDefaultArgs>()({
   include: {
     curso: {
       select: {
@@ -55,8 +67,23 @@ const turmaDetailedInclude = {
       ],
       include: aulaWithMateriaisInclude.include,
     },
+    modulos: {
+      ...moduloDetailedInclude.include,
+      orderBy: [
+        { ordem: 'asc' },
+        { criadoEm: 'asc' },
+      ],
+    },
+    provas: {
+      ...provaDefaultInclude.include,
+      orderBy: [
+        { ordem: 'asc' },
+        { criadoEm: 'asc' },
+      ],
+    },
+    regrasAvaliacao: { select: regrasAvaliacaoSelect },
   },
-} as const;
+});
 
 const ensureCursoExists = async (cursoId: number) => {
   const curso = await prisma.cursos.findUnique({ where: { id: cursoId }, select: { id: true } });


### PR DESCRIPTION
## Summary
- Ajusta os includes compartilhados de aulas, módulos e provas para usar `Prisma.validator`, garantindo tipagens mutáveis.
- Revê os serviços de cursos/turmas para alinhar mapeamentos, casts e payloads com as mudanças do Prisma 6, incluindo a tradução de enums no controller de avaliação.
- Fortalece o serviço e utilitários de avaliação, além do schema Zod, para tratar decimais/JSON e validações parciais com segurança.

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d18fbf91988332acd9831b6898f201