### PR TITLE
fix: corrigir validações de notas e entrega de aulas

### DIFF
--- a/src/modules/cursos/services/aulas.service.ts
+++ b/src/modules/cursos/services/aulas.service.ts
@@ -190,7 +190,7 @@ const resolveDeliveryFieldsOnUpdate = (
           throw error;
         }
 
-        return { urlVideo, sala: null, urlMeet: null };
+        return { urlVideo: videoUrl, sala: null, urlMeet: null };
       }
 
       return {};

--- a/src/modules/cursos/validators/notas.schema.ts
+++ b/src/modules/cursos/validators/notas.schema.ts
@@ -14,7 +14,15 @@ const notaTipos = [
 
 const notaTipoSchema = z.enum(notaTipos);
 
-const tiposQueExigemTitulo = notaTipos.filter((tipo) => tipo !== 'PROVA');
+type NotaTipo = (typeof notaTipos)[number];
+type NotaTipoQueExigeTitulo = Exclude<NotaTipo, 'PROVA'>;
+
+const tiposQueExigemTitulo = notaTipos.filter(
+  (tipo): tipo is NotaTipoQueExigeTitulo => tipo !== 'PROVA',
+);
+
+const tipoExigeTitulo = (tipo: NotaTipo | undefined): tipo is NotaTipoQueExigeTitulo =>
+  !!tipo && tipo !== 'PROVA' && tiposQueExigemTitulo.includes(tipo as NotaTipoQueExigeTitulo);
 
 const decimalNotaSchema = z
   .number({ invalid_type_error: 'Nota deve ser um número' })
@@ -120,10 +128,10 @@ export const updateNotaSchema = z
     },
   )
   .refine(
-    (data) =>
-      data.tipo && tiposQueExigemTitulo.includes(data.tipo)
-        ? data.titulo === undefined || !!data.titulo?.trim()
-        : true,
+      (data) =>
+        tipoExigeTitulo(data.tipo)
+          ? data.titulo === undefined || !!data.titulo?.trim()
+          : true,
     {
       path: ['titulo'],
       message: 'Forneça um título válido ao alterar o tipo da nota',


### PR DESCRIPTION
## Summary
- corrige o retorno de campos de entrega ao atualizar aulas online
- ajusta a validação de título das notas para evitar valores nulos e reaproveitar dados de prova
- melhora o schema de atualização de notas com type guard para tipos que exigem título

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d1f0f175f48332a235c618371c76f8