### PR TITLE
feat: adicionar gestão de frequência de alunos

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -160,6 +160,7 @@ model CursosTurmas {
   modulos              CursosTurmasModulos[]
   provas               CursosTurmasProvas[]
   notas                CursosNotas[]
+  frequencias          CursosFrequenciaAlunos[]
   regrasAvaliacao      CursosTurmasRegrasAvaliacao?
   recuperacoes         CursosTurmasRecuperacoes[]
 
@@ -201,6 +202,7 @@ model CursosTurmasAulas {
   turma     CursosTurmas               @relation(fields: [turmaId], references: [id], onDelete: Cascade)
   modulo    CursosTurmasModulos?       @relation(fields: [moduloId], references: [id], onDelete: SetNull)
   materiais CursosTurmasAulasMateriais[]
+  frequencias CursosFrequenciaAlunos[]
 
   @@index([turmaId])
   @@index([moduloId])
@@ -238,6 +240,7 @@ model CursosTurmasMatriculas {
   envios CursosTurmasProvasEnvios[]
   recuperacoes CursosTurmasRecuperacoes[]
   notas CursosNotas[]
+  frequencias CursosFrequenciaAlunos[]
 
   @@unique([turmaId, alunoId])
   @@index([alunoId])
@@ -361,6 +364,29 @@ model CursosNotas {
   @@unique([matriculaId, provaId])
 }
 
+model CursosFrequenciaAlunos {
+  id             String                  @id @default(uuid())
+  turmaId        String
+  matriculaId    String
+  aulaId         String?
+  dataReferencia DateTime                @default(now())
+  status         CursosFrequenciaStatus  @default(PRESENTE)
+  justificativa  String?                 @db.VarChar(500)
+  observacoes    String?                 @db.VarChar(500)
+  criadoEm       DateTime                @default(now())
+  atualizadoEm   DateTime                @updatedAt
+
+  turma      CursosTurmas           @relation(fields: [turmaId], references: [id], onDelete: Cascade)
+  matricula  CursosTurmasMatriculas @relation(fields: [matriculaId], references: [id], onDelete: Cascade)
+  aula       CursosTurmasAulas?     @relation(fields: [aulaId], references: [id], onDelete: SetNull)
+
+  @@index([turmaId])
+  @@index([matriculaId])
+  @@index([aulaId])
+  @@index([dataReferencia])
+  @@unique([turmaId, matriculaId, aulaId, dataReferencia], map: "cursos_frequencia_unico")
+}
+
 enum CursosSituacaoFinal {
   EM_ANALISE
   APROVADO
@@ -384,6 +410,13 @@ enum CursosNotasTipo {
   SIMULADO
   BONUS
   OUTRO
+}
+
+enum CursosFrequenciaStatus {
+  PRESENTE
+  AUSENTE
+  JUSTIFICADO
+  ATRASADO
 }
 
 enum CursosLocalProva {

--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -152,6 +152,10 @@ const options: Options = {
         description: 'Lançamento e acompanhamento das notas dos alunos em provas e trabalhos',
       },
       {
+        name: 'Cursos - Frequências',
+        description: 'Registro e acompanhamento da presença dos alunos nas turmas e aulas',
+      },
+      {
         name: 'MercadoPago - Assinaturas',
         description: 'Assinaturas e cobranças recorrentes (Mercado Pago)',
       },
@@ -204,7 +208,10 @@ const options: Options = {
         name: 'Candidatos',
         tags: ['Candidatos', 'Candidatos - Áreas de Interesse'],
       },
-      { name: 'Cursos', tags: ['Cursos', 'Cursos - Turmas', 'Cursos - Aulas', 'Cursos - Notas'] },
+      {
+        name: 'Cursos',
+        tags: ['Cursos', 'Cursos - Turmas', 'Cursos - Aulas', 'Cursos - Notas', 'Cursos - Frequências'],
+      },
       { name: 'Pagamentos', tags: ['MercadoPago - Assinaturas'] },
     ],
     components: {
@@ -902,6 +909,148 @@ const options: Options = {
             notas: {
               type: 'array',
               items: { $ref: '#/components/schemas/CursoNota' },
+            },
+          },
+        },
+        CursosFrequenciaStatus: {
+          type: 'string',
+          enum: ['PRESENTE', 'AUSENTE', 'JUSTIFICADO', 'ATRASADO'],
+          description: 'Situação da presença do aluno em aula ou período',
+          example: 'PRESENTE',
+        },
+        CursoFrequencia: {
+          type: 'object',
+          properties: {
+            id: { type: 'string', format: 'uuid' },
+            turmaId: { type: 'string', format: 'uuid' },
+            matriculaId: { type: 'string', format: 'uuid' },
+            aulaId: { type: 'string', format: 'uuid', nullable: true },
+            dataReferencia: { type: 'string', format: 'date-time' },
+            status: { $ref: '#/components/schemas/CursosFrequenciaStatus' },
+            justificativa: {
+              type: 'string',
+              nullable: true,
+              example: 'Aluno apresentou atestado médico.',
+            },
+            observacoes: {
+              type: 'string',
+              nullable: true,
+              example: 'Aluno chegou com 10 minutos de atraso.',
+            },
+            criadoEm: { type: 'string', format: 'date-time' },
+            atualizadoEm: { type: 'string', format: 'date-time' },
+            aula: {
+              type: 'object',
+              nullable: true,
+              properties: {
+                id: { type: 'string', format: 'uuid' },
+                nome: { type: 'string', example: 'Aula 05 - Fundamentos de SQL' },
+                ordem: { type: 'integer', example: 5 },
+                moduloId: { type: 'string', format: 'uuid', nullable: true },
+                modulo: {
+                  type: 'object',
+                  nullable: true,
+                  properties: {
+                    id: { type: 'string', format: 'uuid' },
+                    nome: { type: 'string', example: 'Banco de Dados' },
+                  },
+                },
+              },
+            },
+            matricula: {
+              type: 'object',
+              nullable: true,
+              properties: {
+                id: { type: 'string', format: 'uuid' },
+                alunoId: { type: 'string', format: 'uuid' },
+                aluno: {
+                  type: 'object',
+                  nullable: true,
+                  properties: {
+                    id: { type: 'string', format: 'uuid' },
+                    nome: { type: 'string', example: 'João da Silva' },
+                    email: { type: 'string', format: 'email' },
+                  },
+                },
+              },
+            },
+          },
+        },
+        CursoFrequenciaCreateInput: {
+          type: 'object',
+          required: ['matriculaId', 'status'],
+          properties: {
+            matriculaId: { type: 'string', format: 'uuid' },
+            aulaId: { type: 'string', format: 'uuid', nullable: true },
+            dataReferencia: { type: 'string', format: 'date-time', nullable: true },
+            status: { $ref: '#/components/schemas/CursosFrequenciaStatus' },
+            justificativa: {
+              type: 'string',
+              nullable: true,
+              maxLength: 500,
+              example: 'Falta justificada com atestado.',
+            },
+            observacoes: {
+              type: 'string',
+              nullable: true,
+              maxLength: 500,
+              example: 'Aluno participou remotamente.',
+            },
+          },
+        },
+        CursoFrequenciaUpdateInput: {
+          type: 'object',
+          properties: {
+            aulaId: { type: 'string', format: 'uuid', nullable: true },
+            dataReferencia: { type: 'string', format: 'date-time', nullable: true },
+            status: { $ref: '#/components/schemas/CursosFrequenciaStatus' },
+            justificativa: {
+              type: 'string',
+              nullable: true,
+              maxLength: 500,
+            },
+            observacoes: {
+              type: 'string',
+              nullable: true,
+              maxLength: 500,
+            },
+          },
+        },
+        CursoFrequenciaResumoMatricula: {
+          type: 'object',
+          properties: {
+            matricula: {
+              type: 'object',
+              properties: {
+                id: { type: 'string', format: 'uuid' },
+                aluno: {
+                  type: 'object',
+                  properties: {
+                    id: { type: 'string', format: 'uuid' },
+                    nome: { type: 'string', example: 'Maria Souza' },
+                    email: { type: 'string', format: 'email' },
+                  },
+                },
+              },
+            },
+            curso: {
+              type: 'object',
+              properties: {
+                id: { type: 'integer', example: 1 },
+                nome: { type: 'string', example: 'Formação Fullstack' },
+              },
+            },
+            turma: {
+              type: 'object',
+              properties: {
+                id: { type: 'string', format: 'uuid' },
+                nome: { type: 'string', example: 'Turma 2025/1' },
+                codigo: { type: 'string', example: 'TURMA001' },
+              },
+            },
+            frequencias: {
+              type: 'array',
+              items: { $ref: '#/components/schemas/CursoFrequencia' },
             },
           },
         },

--- a/src/modules/cursos/controllers/frequencia.controller.ts
+++ b/src/modules/cursos/controllers/frequencia.controller.ts
@@ -1,0 +1,469 @@
+import { Request, Response } from 'express';
+import { CursosFrequenciaStatus } from '@prisma/client';
+import { ZodError } from 'zod';
+
+import { frequenciaService } from '../services/frequencia.service';
+import { createFrequenciaSchema, updateFrequenciaSchema } from '../validators/frequencia.schema';
+
+const parseCursoId = (raw: string) => {
+  const id = Number(raw);
+  if (!Number.isInteger(id) || id <= 0) {
+    return null;
+  }
+  return id;
+};
+
+const parseTurmaId = (raw: string) => {
+  if (typeof raw !== 'string' || raw.trim().length === 0) {
+    return null;
+  }
+  return raw;
+};
+
+const parseFrequenciaId = (raw: string) => {
+  if (typeof raw !== 'string' || raw.trim().length === 0) {
+    return null;
+  }
+  return raw;
+};
+
+const parseMatriculaId = (raw: unknown) => {
+  if (typeof raw !== 'string' || raw.trim().length === 0) {
+    return null;
+  }
+  return raw;
+};
+
+const parseAulaId = (raw: unknown) => {
+  if (raw === undefined || raw === null) {
+    return undefined;
+  }
+
+  if (typeof raw !== 'string' || raw.trim().length === 0) {
+    return null;
+  }
+
+  return raw;
+};
+
+const parseDateQuery = (raw: unknown) => {
+  if (raw === undefined || raw === null || raw === '') {
+    return undefined;
+  }
+
+  const date = new Date(String(raw));
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+
+  return date;
+};
+
+const parseStatusQuery = (raw: unknown): CursosFrequenciaStatus | undefined | null => {
+  if (raw === undefined || raw === null || raw === '') {
+    return undefined;
+  }
+
+  if (typeof raw !== 'string') {
+    return null;
+  }
+
+  const normalized = raw.toUpperCase();
+  const values = Object.values(CursosFrequenciaStatus);
+  return values.includes(normalized as CursosFrequenciaStatus)
+    ? (normalized as CursosFrequenciaStatus)
+    : null;
+};
+
+export class FrequenciaController {
+  static list = async (req: Request, res: Response) => {
+    const cursoId = parseCursoId(req.params.cursoId);
+    const turmaId = parseTurmaId(req.params.turmaId);
+
+    if (!cursoId || !turmaId) {
+      return res.status(400).json({
+        success: false,
+        code: 'VALIDATION_ERROR',
+        message: 'Identificadores de curso ou turma inválidos',
+      });
+    }
+
+    const matriculaId = parseMatriculaId(req.query.matriculaId);
+    if (matriculaId === null && req.query.matriculaId !== undefined) {
+      return res.status(400).json({
+        success: false,
+        code: 'VALIDATION_ERROR',
+        message: 'Identificador da matrícula inválido',
+      });
+    }
+
+    const aulaId = parseAulaId(req.query.aulaId);
+    if (aulaId === null) {
+      return res.status(400).json({
+        success: false,
+        code: 'VALIDATION_ERROR',
+        message: 'Identificador da aula inválido',
+      });
+    }
+
+    const status = parseStatusQuery(req.query.status);
+    if (status === null) {
+      return res.status(400).json({
+        success: false,
+        code: 'VALIDATION_ERROR',
+        message: 'Status de frequência inválido',
+      });
+    }
+
+    const dataInicio = parseDateQuery(req.query.dataInicio);
+    const dataFim = parseDateQuery(req.query.dataFim);
+
+    if (dataInicio === null || dataFim === null) {
+      return res.status(400).json({
+        success: false,
+        code: 'VALIDATION_ERROR',
+        message: 'Período informado é inválido',
+      });
+    }
+
+    try {
+      const frequencias = await frequenciaService.list(cursoId, turmaId, {
+        matriculaId: matriculaId ?? undefined,
+        aulaId,
+        status,
+        dataInicio,
+        dataFim,
+      });
+
+      res.json({ data: frequencias });
+    } catch (error: any) {
+      if (error?.code === 'TURMA_NOT_FOUND') {
+        return res.status(404).json({
+          success: false,
+          code: 'TURMA_NOT_FOUND',
+          message: 'Turma não encontrada para o curso informado',
+        });
+      }
+
+      if (error?.code === 'MATRICULA_NOT_FOUND') {
+        return res.status(404).json({
+          success: false,
+          code: 'MATRICULA_NOT_FOUND',
+          message: 'Matrícula não encontrada para a turma informada',
+        });
+      }
+
+      if (error?.code === 'AULA_NOT_FOUND') {
+        return res.status(404).json({
+          success: false,
+          code: 'AULA_NOT_FOUND',
+          message: 'Aula não encontrada para a turma informada',
+        });
+      }
+
+      res.status(500).json({
+        success: false,
+        code: 'FREQUENCIA_LIST_ERROR',
+        message: 'Erro ao listar registros de frequência da turma',
+        error: error?.message,
+      });
+    }
+  };
+
+  static get = async (req: Request, res: Response) => {
+    const cursoId = parseCursoId(req.params.cursoId);
+    const turmaId = parseTurmaId(req.params.turmaId);
+    const frequenciaId = parseFrequenciaId(req.params.frequenciaId);
+
+    if (!cursoId || !turmaId || !frequenciaId) {
+      return res.status(400).json({
+        success: false,
+        code: 'VALIDATION_ERROR',
+        message: 'Identificadores de curso, turma ou frequência inválidos',
+      });
+    }
+
+    try {
+      const frequencia = await frequenciaService.get(cursoId, turmaId, frequenciaId);
+      res.json(frequencia);
+    } catch (error: any) {
+      if (error?.code === 'FREQUENCIA_NOT_FOUND' || error?.code === 'TURMA_NOT_FOUND') {
+        return res.status(404).json({
+          success: false,
+          code: 'FREQUENCIA_NOT_FOUND',
+          message: 'Registro de frequência não encontrado para a turma informada',
+        });
+      }
+
+      res.status(500).json({
+        success: false,
+        code: 'FREQUENCIA_GET_ERROR',
+        message: 'Erro ao buscar registro de frequência da turma',
+        error: error?.message,
+      });
+    }
+  };
+
+  static create = async (req: Request, res: Response) => {
+    const cursoId = parseCursoId(req.params.cursoId);
+    const turmaId = parseTurmaId(req.params.turmaId);
+
+    if (!cursoId || !turmaId) {
+      return res.status(400).json({
+        success: false,
+        code: 'VALIDATION_ERROR',
+        message: 'Identificadores de curso ou turma inválidos',
+      });
+    }
+
+    try {
+      const data = createFrequenciaSchema.parse(req.body);
+      const frequencia = await frequenciaService.create(cursoId, turmaId, {
+        ...data,
+        aulaId: data.aulaId ?? null,
+        dataReferencia: data.dataReferencia ?? undefined,
+        justificativa: data.justificativa ?? null,
+        observacoes: data.observacoes ?? null,
+      });
+      res.status(201).json(frequencia);
+    } catch (error: any) {
+      if (error instanceof ZodError) {
+        return res.status(400).json({
+          success: false,
+          code: 'VALIDATION_ERROR',
+          message: 'Dados inválidos para criação do registro de frequência',
+          issues: error.flatten().fieldErrors,
+        });
+      }
+
+      if (error?.code === 'TURMA_NOT_FOUND') {
+        return res.status(404).json({
+          success: false,
+          code: 'TURMA_NOT_FOUND',
+          message: 'Turma não encontrada para o curso informado',
+        });
+      }
+
+      if (error?.code === 'MATRICULA_NOT_FOUND') {
+        return res.status(404).json({
+          success: false,
+          code: 'MATRICULA_NOT_FOUND',
+          message: 'Matrícula não encontrada para a turma informada',
+        });
+      }
+
+      if (error?.code === 'AULA_NOT_FOUND') {
+        return res.status(404).json({
+          success: false,
+          code: 'AULA_NOT_FOUND',
+          message: 'Aula não encontrada para a turma informada',
+        });
+      }
+
+      if (error?.code === 'DUPLICATE_FREQUENCIA') {
+        return res.status(409).json({
+          success: false,
+          code: 'DUPLICATE_FREQUENCIA',
+          message: 'Já existe uma frequência registrada para os parâmetros informados',
+        });
+      }
+
+      if (error?.code === 'VALIDATION_ERROR') {
+        return res.status(400).json({
+          success: false,
+          code: 'VALIDATION_ERROR',
+          message: error.message,
+        });
+      }
+
+      res.status(500).json({
+        success: false,
+        code: 'FREQUENCIA_CREATE_ERROR',
+        message: 'Erro ao registrar frequência para a turma',
+        error: error?.message,
+      });
+    }
+  };
+
+  static update = async (req: Request, res: Response) => {
+    const cursoId = parseCursoId(req.params.cursoId);
+    const turmaId = parseTurmaId(req.params.turmaId);
+    const frequenciaId = parseFrequenciaId(req.params.frequenciaId);
+
+    if (!cursoId || !turmaId || !frequenciaId) {
+      return res.status(400).json({
+        success: false,
+        code: 'VALIDATION_ERROR',
+        message: 'Identificadores de curso, turma ou frequência inválidos',
+      });
+    }
+
+    try {
+      const data = updateFrequenciaSchema.parse(req.body);
+      const frequencia = await frequenciaService.update(cursoId, turmaId, frequenciaId, {
+        aulaId: data.aulaId === undefined ? undefined : data.aulaId,
+        dataReferencia: data.dataReferencia ?? undefined,
+        status: data.status,
+        justificativa: data.justificativa === undefined ? undefined : data.justificativa,
+        observacoes: data.observacoes === undefined ? undefined : data.observacoes,
+      });
+      res.json(frequencia);
+    } catch (error: any) {
+      if (error instanceof ZodError) {
+        return res.status(400).json({
+          success: false,
+          code: 'VALIDATION_ERROR',
+          message: 'Dados inválidos para atualização do registro de frequência',
+          issues: error.flatten().fieldErrors,
+        });
+      }
+
+      if (error?.code === 'FREQUENCIA_NOT_FOUND' || error?.code === 'TURMA_NOT_FOUND') {
+        return res.status(404).json({
+          success: false,
+          code: 'FREQUENCIA_NOT_FOUND',
+          message: 'Registro de frequência não encontrado para a turma informada',
+        });
+      }
+
+      if (error?.code === 'AULA_NOT_FOUND') {
+        return res.status(404).json({
+          success: false,
+          code: 'AULA_NOT_FOUND',
+          message: 'Aula não encontrada para a turma informada',
+        });
+      }
+
+      if (error?.code === 'VALIDATION_ERROR') {
+        return res.status(400).json({
+          success: false,
+          code: 'VALIDATION_ERROR',
+          message: error.message,
+        });
+      }
+
+      res.status(500).json({
+        success: false,
+        code: 'FREQUENCIA_UPDATE_ERROR',
+        message: 'Erro ao atualizar registro de frequência da turma',
+        error: error?.message,
+      });
+    }
+  };
+
+  static delete = async (req: Request, res: Response) => {
+    const cursoId = parseCursoId(req.params.cursoId);
+    const turmaId = parseTurmaId(req.params.turmaId);
+    const frequenciaId = parseFrequenciaId(req.params.frequenciaId);
+
+    if (!cursoId || !turmaId || !frequenciaId) {
+      return res.status(400).json({
+        success: false,
+        code: 'VALIDATION_ERROR',
+        message: 'Identificadores de curso, turma ou frequência inválidos',
+      });
+    }
+
+    try {
+      const result = await frequenciaService.remove(cursoId, turmaId, frequenciaId);
+      res.json(result);
+    } catch (error: any) {
+      if (error?.code === 'FREQUENCIA_NOT_FOUND' || error?.code === 'TURMA_NOT_FOUND') {
+        return res.status(404).json({
+          success: false,
+          code: 'FREQUENCIA_NOT_FOUND',
+          message: 'Registro de frequência não encontrado para a turma informada',
+        });
+      }
+
+      res.status(500).json({
+        success: false,
+        code: 'FREQUENCIA_DELETE_ERROR',
+        message: 'Erro ao remover registro de frequência da turma',
+        error: error?.message,
+      });
+    }
+  };
+
+  static listByMatricula = async (req: Request, res: Response) => {
+    const matriculaId = parseMatriculaId(req.params.matriculaId);
+
+    if (!matriculaId) {
+      return res.status(400).json({
+        success: false,
+        code: 'VALIDATION_ERROR',
+        message: 'Identificador da matrícula inválido',
+      });
+    }
+
+    try {
+      const resultado = await frequenciaService.listByMatricula(matriculaId, undefined, { permitirAdmin: true });
+      res.json(resultado);
+    } catch (error: any) {
+      if (error?.code === 'MATRICULA_NOT_FOUND') {
+        return res.status(404).json({
+          success: false,
+          code: 'MATRICULA_NOT_FOUND',
+          message: 'Matrícula não encontrada',
+        });
+      }
+
+      res.status(500).json({
+        success: false,
+        code: 'FREQUENCIA_MATRICULA_ERROR',
+        message: 'Erro ao consultar frequência da matrícula',
+        error: error?.message,
+      });
+    }
+  };
+
+  static listMy = async (req: Request, res: Response) => {
+    const matriculaId = parseMatriculaId(req.params.matriculaId);
+
+    if (!matriculaId) {
+      return res.status(400).json({
+        success: false,
+        code: 'VALIDATION_ERROR',
+        message: 'Identificador da matrícula inválido',
+      });
+    }
+
+    const usuarioId = req.user?.id;
+
+    if (!usuarioId) {
+      return res.status(401).json({
+        success: false,
+        code: 'UNAUTHORIZED',
+        message: 'Usuário não autenticado',
+      });
+    }
+
+    try {
+      const resultado = await frequenciaService.listByMatricula(matriculaId, usuarioId);
+      res.json(resultado);
+    } catch (error: any) {
+      if (error?.code === 'MATRICULA_NOT_FOUND') {
+        return res.status(404).json({
+          success: false,
+          code: 'MATRICULA_NOT_FOUND',
+          message: 'Matrícula não encontrada',
+        });
+      }
+
+      if (error?.code === 'FORBIDDEN') {
+        return res.status(403).json({
+          success: false,
+          code: 'FORBIDDEN',
+          message: 'Você não tem permissão para visualizar a frequência desta matrícula',
+        });
+      }
+
+      res.status(500).json({
+        success: false,
+        code: 'FREQUENCIA_ME_MATRICULA_ERROR',
+        message: 'Erro ao consultar frequência da matrícula do aluno',
+        error: error?.message,
+      });
+    }
+  };
+}

--- a/src/modules/cursos/routes/index.ts
+++ b/src/modules/cursos/routes/index.ts
@@ -11,6 +11,7 @@ import { ModulosController } from '../controllers/modulos.controller';
 import { ProvasController } from '../controllers/provas.controller';
 import { AvaliacaoController } from '../controllers/avaliacao.controller';
 import { NotasController } from '../controllers/notas.controller';
+import { FrequenciaController } from '../controllers/frequencia.controller';
 
 const router = Router();
 
@@ -1011,6 +1012,216 @@ router.delete(
 
 /**
  * @openapi
+ * /api/v1/cursos/{cursoId}/turmas/{turmaId}/frequencias:
+ *   get:
+ *     summary: Listar registros de frequência da turma
+ *     tags: ['Cursos - Frequências']
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: cursoId
+ *         required: true
+ *         schema: { type: integer, minimum: 1 }
+ *       - in: path
+ *         name: turmaId
+ *         required: true
+ *         schema: { type: string, format: uuid }
+ *       - in: query
+ *         name: matriculaId
+ *         required: false
+ *         schema: { type: string, format: uuid }
+ *         description: Filtra registros de frequência de uma matrícula específica
+ *       - in: query
+ *         name: aulaId
+ *         required: false
+ *         schema: { type: string, format: uuid }
+ *         description: Filtra registros vinculados a uma aula específica
+ *       - in: query
+ *         name: status
+ *         required: false
+ *         schema: { $ref: '#/components/schemas/CursosFrequenciaStatus' }
+ *       - in: query
+ *         name: dataInicio
+ *         required: false
+ *         schema: { type: string, format: date-time }
+ *         description: Data inicial do período (inclusive)
+ *       - in: query
+ *         name: dataFim
+ *         required: false
+ *         schema: { type: string, format: date-time }
+ *         description: Data final do período (inclusive)
+ *     responses:
+ *       200:
+ *         description: Lista de registros de frequência
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 data:
+ *                   type: array
+ *                   items:
+ *                     $ref: '#/components/schemas/CursoFrequencia'
+ */
+router.get(
+  '/:cursoId/turmas/:turmaId/frequencias',
+  supabaseAuthMiddleware([Roles.ADMIN, Roles.MODERADOR, Roles.PEDAGOGICO, Roles.PROFESSOR]),
+  FrequenciaController.list,
+);
+
+/**
+ * @openapi
+ * /api/v1/cursos/{cursoId}/turmas/{turmaId}/frequencias:
+ *   post:
+ *     summary: Registrar frequência para a turma
+ *     tags: ['Cursos - Frequências']
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: cursoId
+ *         required: true
+ *         schema: { type: integer, minimum: 1 }
+ *       - in: path
+ *         name: turmaId
+ *         required: true
+ *         schema: { type: string, format: uuid }
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/CursoFrequenciaCreateInput'
+ *     responses:
+ *       201:
+ *         description: Frequência registrada com sucesso
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/CursoFrequencia'
+ */
+router.post(
+  '/:cursoId/turmas/:turmaId/frequencias',
+  supabaseAuthMiddleware([Roles.ADMIN, Roles.MODERADOR, Roles.PEDAGOGICO, Roles.PROFESSOR]),
+  FrequenciaController.create,
+);
+
+/**
+ * @openapi
+ * /api/v1/cursos/{cursoId}/turmas/{turmaId}/frequencias/{frequenciaId}:
+ *   get:
+ *     summary: Detalhar registro de frequência
+ *     tags: ['Cursos - Frequências']
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: cursoId
+ *         required: true
+ *         schema: { type: integer, minimum: 1 }
+ *       - in: path
+ *         name: turmaId
+ *         required: true
+ *         schema: { type: string, format: uuid }
+ *       - in: path
+ *         name: frequenciaId
+ *         required: true
+ *         schema: { type: string, format: uuid }
+ *     responses:
+ *       200:
+ *         description: Dados completos do registro de frequência
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/CursoFrequencia'
+ */
+router.get(
+  '/:cursoId/turmas/:turmaId/frequencias/:frequenciaId',
+  supabaseAuthMiddleware([Roles.ADMIN, Roles.MODERADOR, Roles.PEDAGOGICO, Roles.PROFESSOR]),
+  FrequenciaController.get,
+);
+
+/**
+ * @openapi
+ * /api/v1/cursos/{cursoId}/turmas/{turmaId}/frequencias/{frequenciaId}:
+ *   put:
+ *     summary: Atualizar registro de frequência
+ *     tags: ['Cursos - Frequências']
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: cursoId
+ *         required: true
+ *         schema: { type: integer, minimum: 1 }
+ *       - in: path
+ *         name: turmaId
+ *         required: true
+ *         schema: { type: string, format: uuid }
+ *       - in: path
+ *         name: frequenciaId
+ *         required: true
+ *         schema: { type: string, format: uuid }
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/CursoFrequenciaUpdateInput'
+ *     responses:
+ *       200:
+ *         description: Frequência atualizada com sucesso
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/CursoFrequencia'
+ */
+router.put(
+  '/:cursoId/turmas/:turmaId/frequencias/:frequenciaId',
+  supabaseAuthMiddleware([Roles.ADMIN, Roles.MODERADOR, Roles.PEDAGOGICO, Roles.PROFESSOR]),
+  FrequenciaController.update,
+);
+
+/**
+ * @openapi
+ * /api/v1/cursos/{cursoId}/turmas/{turmaId}/frequencias/{frequenciaId}:
+ *   delete:
+ *     summary: Remover registro de frequência
+ *     tags: ['Cursos - Frequências']
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: cursoId
+ *         required: true
+ *         schema: { type: integer, minimum: 1 }
+ *       - in: path
+ *         name: turmaId
+ *         required: true
+ *         schema: { type: string, format: uuid }
+ *       - in: path
+ *         name: frequenciaId
+ *         required: true
+ *         schema: { type: string, format: uuid }
+ *     responses:
+ *       200:
+ *         description: Frequência removida com sucesso
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success: { type: boolean, example: true }
+ */
+router.delete(
+  '/:cursoId/turmas/:turmaId/frequencias/:frequenciaId',
+  supabaseAuthMiddleware([Roles.ADMIN, Roles.MODERADOR, Roles.PEDAGOGICO, Roles.PROFESSOR]),
+  FrequenciaController.delete,
+);
+
+/**
+ * @openapi
  * /api/v1/cursos/{cursoId}/turmas/{turmaId}/notas:
  *   get:
  *     summary: Listar notas lançadas da turma
@@ -1198,6 +1409,60 @@ router.delete(
   '/:cursoId/turmas/:turmaId/notas/:notaId',
   supabaseAuthMiddleware([Roles.ADMIN, Roles.MODERADOR, Roles.PEDAGOGICO, Roles.PROFESSOR]),
   NotasController.delete,
+);
+
+/**
+ * @openapi
+ * /api/v1/cursos/matriculas/{matriculaId}/frequencias-detalhadas:
+ *   get:
+ *     summary: Consultar registros de frequência de uma matrícula (admin)
+ *     tags: ['Cursos - Frequências']
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: matriculaId
+ *         required: true
+ *         schema: { type: string, format: uuid }
+ *     responses:
+ *       200:
+ *         description: Frequência lançada e informações da matrícula
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/CursoFrequenciaResumoMatricula'
+ */
+router.get(
+  '/matriculas/:matriculaId/frequencias-detalhadas',
+  supabaseAuthMiddleware([Roles.ADMIN, Roles.MODERADOR, Roles.PEDAGOGICO, Roles.PROFESSOR]),
+  FrequenciaController.listByMatricula,
+);
+
+/**
+ * @openapi
+ * /api/v1/cursos/me/matriculas/{matriculaId}/frequencias-detalhadas:
+ *   get:
+ *     summary: Consultar registros de frequência do aluno autenticado
+ *     tags: ['Cursos - Frequências']
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: matriculaId
+ *         required: true
+ *         schema: { type: string, format: uuid }
+ *     responses:
+ *       200:
+ *         description: Frequência lançada associada à matrícula do aluno
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/CursoFrequenciaResumoMatricula'
+ */
+router.get(
+  '/me/matriculas/:matriculaId/frequencias-detalhadas',
+  supabaseAuthMiddleware([Roles.ALUNO_CANDIDATO]),
+  FrequenciaController.listMy,
 );
 
 /**

--- a/src/modules/cursos/services/frequencia.mapper.ts
+++ b/src/modules/cursos/services/frequencia.mapper.ts
@@ -1,0 +1,75 @@
+import { Prisma } from '@prisma/client';
+
+export const frequenciaWithRelations = Prisma.validator<Prisma.CursosFrequenciaAlunosDefaultArgs>()({
+  include: {
+    matricula: {
+      select: {
+        id: true,
+        alunoId: true,
+        aluno: {
+          select: {
+            id: true,
+            nomeCompleto: true,
+            email: true,
+          },
+        },
+      },
+    },
+    aula: {
+      select: {
+        id: true,
+        nome: true,
+        ordem: true,
+        moduloId: true,
+        modulo: {
+          select: {
+            id: true,
+            nome: true,
+          },
+        },
+      },
+    },
+  },
+});
+
+export type FrequenciaWithRelations = Prisma.CursosFrequenciaAlunosGetPayload<typeof frequenciaWithRelations>;
+
+export const mapFrequencia = (frequencia: FrequenciaWithRelations) => ({
+  id: frequencia.id,
+  turmaId: frequencia.turmaId,
+  matriculaId: frequencia.matriculaId,
+  aulaId: frequencia.aulaId,
+  dataReferencia: frequencia.dataReferencia.toISOString(),
+  status: frequencia.status,
+  justificativa: frequencia.justificativa ?? null,
+  observacoes: frequencia.observacoes ?? null,
+  criadoEm: frequencia.criadoEm.toISOString(),
+  atualizadoEm: frequencia.atualizadoEm.toISOString(),
+  aula: frequencia.aula
+    ? {
+        id: frequencia.aula.id,
+        nome: frequencia.aula.nome,
+        ordem: frequencia.aula.ordem,
+        moduloId: frequencia.aula.moduloId,
+        modulo: frequencia.aula.modulo
+          ? {
+              id: frequencia.aula.modulo.id,
+              nome: frequencia.aula.modulo.nome,
+            }
+          : null,
+      }
+    : null,
+  matricula: frequencia.matricula
+    ? {
+        id: frequencia.matricula.id,
+        alunoId: frequencia.matricula.alunoId,
+        aluno: frequencia.matricula.aluno
+          ? {
+              id: frequencia.matricula.aluno.id,
+              nome: frequencia.matricula.aluno.nomeCompleto,
+              email: frequencia.matricula.aluno.email,
+            }
+          : null,
+      }
+    : null,
+});

--- a/src/modules/cursos/services/frequencia.service.ts
+++ b/src/modules/cursos/services/frequencia.service.ts
@@ -1,0 +1,362 @@
+import { CursosFrequenciaStatus, Prisma } from '@prisma/client';
+
+import { prisma } from '@/config/prisma';
+import { logger } from '@/utils/logger';
+
+import {
+  FrequenciaWithRelations,
+  frequenciaWithRelations,
+  mapFrequencia,
+} from './frequencia.mapper';
+
+const frequenciasLogger = logger.child({ module: 'CursosFrequenciaService' });
+
+type PrismaClientOrTx = Prisma.TransactionClient | typeof prisma;
+
+const ensureTurmaBelongsToCurso = async (
+  client: PrismaClientOrTx,
+  cursoId: number,
+  turmaId: string,
+) => {
+  const turma = await client.cursosTurmas.findFirst({
+    where: { id: turmaId, cursoId },
+    select: { id: true },
+  });
+
+  if (!turma) {
+    const error = new Error('Turma não encontrada para o curso informado');
+    (error as any).code = 'TURMA_NOT_FOUND';
+    throw error;
+  }
+};
+
+const ensureMatriculaBelongsToTurma = async (
+  client: PrismaClientOrTx,
+  turmaId: string,
+  matriculaId: string,
+) => {
+  const matricula = await client.cursosTurmasMatriculas.findFirst({
+    where: { id: matriculaId, turmaId },
+    select: { id: true },
+  });
+
+  if (!matricula) {
+    const error = new Error('Matrícula não encontrada para a turma informada');
+    (error as any).code = 'MATRICULA_NOT_FOUND';
+    throw error;
+  }
+};
+
+const ensureAulaBelongsToTurma = async (
+  client: PrismaClientOrTx,
+  turmaId: string,
+  aulaId: string,
+) => {
+  const aula = await client.cursosTurmasAulas.findFirst({
+    where: { id: aulaId, turmaId },
+    select: { id: true },
+  });
+
+  if (!aula) {
+    const error = new Error('Aula não encontrada para a turma informada');
+    (error as any).code = 'AULA_NOT_FOUND';
+    throw error;
+  }
+};
+
+const ensureFrequenciaBelongsToTurma = async (
+  client: PrismaClientOrTx,
+  cursoId: number,
+  turmaId: string,
+  frequenciaId: string,
+) => {
+  const frequencia = await client.cursosFrequenciaAlunos.findFirst({
+    where: { id: frequenciaId, turmaId, turma: { cursoId } },
+    select: {
+      id: true,
+      turmaId: true,
+      matriculaId: true,
+      status: true,
+      aulaId: true,
+      justificativa: true,
+    },
+  });
+
+  if (!frequencia) {
+    const error = new Error('Registro de frequência não encontrado para a turma informada');
+    (error as any).code = 'FREQUENCIA_NOT_FOUND';
+    throw error;
+  }
+
+  return frequencia;
+};
+
+const normalizeNullable = (value: string | null | undefined) => {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (value === null) {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+};
+
+const ensureJustificativaWhenRequired = (
+  status: CursosFrequenciaStatus,
+  justificativa?: string | null,
+) => {
+  if (status === CursosFrequenciaStatus.JUSTIFICADO) {
+    const normalized = justificativa?.trim() ?? '';
+    if (!normalized) {
+      const error = new Error('Justificativa é obrigatória para registros justificados');
+      (error as any).code = 'VALIDATION_ERROR';
+      throw error;
+    }
+  }
+};
+
+export const frequenciaService = {
+  async list(
+    cursoId: number,
+    turmaId: string,
+    filters: {
+      matriculaId?: string;
+      aulaId?: string;
+      status?: CursosFrequenciaStatus;
+      dataInicio?: Date;
+      dataFim?: Date;
+    } = {},
+  ) {
+    await ensureTurmaBelongsToCurso(prisma, cursoId, turmaId);
+
+    if (filters.matriculaId) {
+      await ensureMatriculaBelongsToTurma(prisma, turmaId, filters.matriculaId);
+    }
+
+    if (filters.aulaId) {
+      await ensureAulaBelongsToTurma(prisma, turmaId, filters.aulaId);
+    }
+
+    const where: Prisma.CursosFrequenciaAlunosWhereInput = {
+      turmaId,
+      turma: { cursoId },
+      matriculaId: filters.matriculaId ?? undefined,
+      aulaId: filters.aulaId ?? undefined,
+      status: filters.status ?? undefined,
+    };
+
+    if (filters.dataInicio || filters.dataFim) {
+      where.dataReferencia = {
+        gte: filters.dataInicio ?? undefined,
+        lte: filters.dataFim ?? undefined,
+      };
+    }
+
+    const frequencias = await prisma.cursosFrequenciaAlunos.findMany({
+      where,
+      orderBy: [
+        { dataReferencia: 'desc' },
+        { criadoEm: 'desc' },
+      ],
+      ...frequenciaWithRelations,
+    });
+
+    return frequencias.map(mapFrequencia);
+  },
+
+  async get(cursoId: number, turmaId: string, frequenciaId: string) {
+    await ensureTurmaBelongsToCurso(prisma, cursoId, turmaId);
+
+    const frequencia = await prisma.cursosFrequenciaAlunos.findFirst({
+      where: { id: frequenciaId, turmaId, turma: { cursoId } },
+      ...frequenciaWithRelations,
+    });
+
+    if (!frequencia) {
+      const error = new Error('Registro de frequência não encontrado para a turma informada');
+      (error as any).code = 'FREQUENCIA_NOT_FOUND';
+      throw error;
+    }
+
+    return mapFrequencia(frequencia);
+  },
+
+  async create(
+    cursoId: number,
+    turmaId: string,
+    data: {
+      matriculaId: string;
+      aulaId?: string | null;
+      dataReferencia?: Date;
+      status: CursosFrequenciaStatus;
+      justificativa?: string | null;
+      observacoes?: string | null;
+    },
+  ) {
+    return prisma.$transaction(async (tx) => {
+      await ensureTurmaBelongsToCurso(tx, cursoId, turmaId);
+      await ensureMatriculaBelongsToTurma(tx, turmaId, data.matriculaId);
+
+      if (data.aulaId) {
+        await ensureAulaBelongsToTurma(tx, turmaId, data.aulaId);
+      }
+
+      ensureJustificativaWhenRequired(data.status, data.justificativa);
+
+      try {
+        const frequencia = (await tx.cursosFrequenciaAlunos.create({
+          data: {
+            turmaId,
+            matriculaId: data.matriculaId,
+            aulaId: data.aulaId ?? null,
+            dataReferencia: data.dataReferencia ?? new Date(),
+            status: data.status,
+            justificativa: normalizeNullable(data.justificativa),
+            observacoes: normalizeNullable(data.observacoes),
+          },
+          ...frequenciaWithRelations,
+        })) as FrequenciaWithRelations;
+
+        frequenciasLogger.info(
+          { turmaId, frequenciaId: frequencia.id },
+          'Frequência registrada para matrícula',
+        );
+
+        return mapFrequencia(frequencia);
+      } catch (error: any) {
+        if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002') {
+          const duplicated = new Error('Já existe uma frequência registrada para esta combinação');
+          (duplicated as any).code = 'DUPLICATE_FREQUENCIA';
+          throw duplicated;
+        }
+
+        throw error;
+      }
+    });
+  },
+
+  async update(
+    cursoId: number,
+    turmaId: string,
+    frequenciaId: string,
+    data: {
+      aulaId?: string | null;
+      dataReferencia?: Date | null;
+      status?: CursosFrequenciaStatus;
+      justificativa?: string | null;
+      observacoes?: string | null;
+    },
+  ) {
+    return prisma.$transaction(async (tx) => {
+      const frequenciaAtual = await ensureFrequenciaBelongsToTurma(tx, cursoId, turmaId, frequenciaId);
+
+      if (data.aulaId !== undefined && data.aulaId !== null) {
+        await ensureAulaBelongsToTurma(tx, turmaId, data.aulaId);
+      }
+
+      const statusFinal = data.status ?? frequenciaAtual.status;
+
+      const justificativaFinal =
+        data.justificativa !== undefined ? data.justificativa : frequenciaAtual.justificativa;
+
+      ensureJustificativaWhenRequired(statusFinal, justificativaFinal);
+
+      const frequencia = (await tx.cursosFrequenciaAlunos.update({
+        where: { id: frequenciaId },
+        data: {
+          aulaId:
+            data.aulaId !== undefined
+              ? data.aulaId
+                ? data.aulaId
+                : null
+              : undefined,
+          dataReferencia: data.dataReferencia ?? undefined,
+          status: data.status ?? undefined,
+          justificativa: normalizeNullable(data.justificativa),
+          observacoes: normalizeNullable(data.observacoes),
+        },
+        ...frequenciaWithRelations,
+      })) as FrequenciaWithRelations;
+
+      frequenciasLogger.info({ turmaId, frequenciaId }, 'Frequência atualizada');
+
+      return mapFrequencia(frequencia);
+    });
+  },
+
+  async remove(cursoId: number, turmaId: string, frequenciaId: string) {
+    return prisma.$transaction(async (tx) => {
+      await ensureFrequenciaBelongsToTurma(tx, cursoId, turmaId, frequenciaId);
+
+      await tx.cursosFrequenciaAlunos.delete({ where: { id: frequenciaId } });
+
+      frequenciasLogger.info({ turmaId, frequenciaId }, 'Frequência removida');
+
+      return { success: true } as const;
+    });
+  },
+
+  async listByMatricula(
+    matriculaId: string,
+    requesterId?: string,
+    { permitirAdmin = false }: { permitirAdmin?: boolean } = {},
+  ) {
+    const matricula = await prisma.cursosTurmasMatriculas.findUnique({
+      where: { id: matriculaId },
+      include: {
+        aluno: { select: { id: true, nomeCompleto: true, email: true } },
+        turma: {
+          select: {
+            id: true,
+            nome: true,
+            codigo: true,
+            curso: { select: { id: true, nome: true } },
+          },
+        },
+      },
+    });
+
+    if (!matricula) {
+      const error = new Error('Matrícula não encontrada');
+      (error as any).code = 'MATRICULA_NOT_FOUND';
+      throw error;
+    }
+
+    if (requesterId && matricula.alunoId !== requesterId && !permitirAdmin) {
+      const error = new Error('Acesso negado');
+      (error as any).code = 'FORBIDDEN';
+      throw error;
+    }
+
+    const frequencias = await prisma.cursosFrequenciaAlunos.findMany({
+      where: { matriculaId },
+      orderBy: [
+        { dataReferencia: 'desc' },
+        { criadoEm: 'desc' },
+      ],
+      ...frequenciaWithRelations,
+    });
+
+    return {
+      matricula: {
+        id: matricula.id,
+        aluno: {
+          id: matricula.aluno.id,
+          nome: matricula.aluno.nomeCompleto,
+          email: matricula.aluno.email,
+        },
+      },
+      curso: {
+        id: matricula.turma.curso.id,
+        nome: matricula.turma.curso.nome,
+      },
+      turma: {
+        id: matricula.turma.id,
+        nome: matricula.turma.nome,
+        codigo: matricula.turma.codigo,
+      },
+      frequencias: frequencias.map(mapFrequencia),
+    };
+  },
+};

--- a/src/modules/cursos/validators/frequencia.schema.ts
+++ b/src/modules/cursos/validators/frequencia.schema.ts
@@ -1,0 +1,78 @@
+import { z } from 'zod';
+
+const statusSchema = z.enum(['PRESENTE', 'AUSENTE', 'JUSTIFICADO', 'ATRASADO']);
+
+const dateSchema = z
+  .preprocess((value) => {
+    if (value === undefined || value === null || value === '') {
+      return undefined;
+    }
+    if (value instanceof Date) {
+      return value;
+    }
+    const parsed = new Date(String(value));
+    return Number.isNaN(parsed.getTime()) ? value : parsed;
+  }, z.date({ invalid_type_error: 'Data inválida' }))
+  .optional();
+
+const aulaIdSchema = z.string().uuid('Identificador da aula inválido').nullish();
+const matriculaIdSchema = z.string().uuid('Identificador da matrícula inválido');
+
+const justificativaSchema = z
+  .string({ invalid_type_error: 'Justificativa deve ser um texto' })
+  .trim()
+  .min(3, 'Justificativa deve conter ao menos 3 caracteres')
+  .max(500, 'Justificativa deve conter no máximo 500 caracteres')
+  .nullish();
+
+const observacoesSchema = z
+  .string({ invalid_type_error: 'Observações deve ser um texto' })
+  .trim()
+  .max(500, 'Observações deve conter no máximo 500 caracteres')
+  .nullish();
+
+export const createFrequenciaSchema = z
+  .object({
+    matriculaId: matriculaIdSchema,
+    aulaId: aulaIdSchema,
+    dataReferencia: dateSchema,
+    status: statusSchema,
+    justificativa: justificativaSchema,
+    observacoes: observacoesSchema,
+  })
+  .refine((data) => (data.status === 'JUSTIFICADO' ? !!data.justificativa?.trim() : true), {
+    path: ['justificativa'],
+    message: 'Justificativa é obrigatória para faltas justificadas',
+  });
+
+export const updateFrequenciaSchema = z
+  .object({
+    aulaId: aulaIdSchema.optional(),
+    dataReferencia: dateSchema,
+    status: statusSchema.optional(),
+    justificativa: justificativaSchema.optional(),
+    observacoes: observacoesSchema.optional(),
+  })
+  .refine((data) => Object.values(data).some((value) => value !== undefined), {
+    message: 'Informe ao menos um campo para atualização da frequência',
+  })
+  .refine(
+    (data) =>
+      data.status === 'JUSTIFICADO'
+        ? !!data.justificativa && data.justificativa.trim().length > 0
+        : true,
+    {
+      path: ['justificativa'],
+      message: 'Justificativa é obrigatória quando o status for JUSTIFICADO',
+    },
+  )
+  .refine(
+    (data) =>
+      data.justificativa === undefined || data.justificativa === null
+        ? true
+        : data.justificativa.trim().length > 0,
+    {
+      path: ['justificativa'],
+      message: 'Justificativa não pode ser vazia',
+    },
+  );


### PR DESCRIPTION
## Sumário
- adiciona modelagem `CursosFrequenciaAlunos` com enum dedicado no Prisma e referenciações em turmas, aulas e matrículas
- cria controller, service, mapper e validators para CRUD e relatórios de frequência por turma e matrícula
- documenta rotas e esquemas no Swagger, incluindo novos endpoints REST de frequência

## Testes
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68d1f63055748332816a45f4068e4057