### PR TITLE
feat: extend agenda event types

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -159,6 +159,7 @@ model CursosTurmas {
   aulas                CursosTurmasAulas[]
   modulos              CursosTurmasModulos[]
   provas               CursosTurmasProvas[]
+  agenda               CursosTurmasAgenda[]
   notas                CursosNotas[]
   frequencias          CursosFrequenciaAlunos[]
   regrasAvaliacao      CursosTurmasRegrasAvaliacao?
@@ -203,6 +204,7 @@ model CursosTurmasAulas {
   modulo    CursosTurmasModulos?       @relation(fields: [moduloId], references: [id], onDelete: SetNull)
   materiais CursosTurmasAulasMateriais[]
   frequencias CursosFrequenciaAlunos[]
+  agenda     CursosTurmasAgenda[]
 
   @@index([turmaId])
   @@index([moduloId])
@@ -265,11 +267,35 @@ model CursosTurmasProvas {
   envios     CursosTurmasProvasEnvios[]
   recuperacoes CursosTurmasRecuperacoes[]
   notas      CursosNotas[]
+  agenda     CursosTurmasAgenda[]
 
   @@unique([turmaId, etiqueta])
   @@index([turmaId])
   @@index([moduloId])
   @@index([turmaId, ativo])
+}
+
+model CursosTurmasAgenda {
+  id          String           @id @default(uuid())
+  turmaId     String
+  tipo        CursosAgendaTipo
+  titulo      String           @db.VarChar(255)
+  descricao   String?          @db.VarChar(1000)
+  inicio      DateTime
+  fim         DateTime?
+  aulaId      String?
+  provaId     String?
+  criadoEm    DateTime         @default(now())
+  atualizadoEm DateTime        @updatedAt
+
+  turma CursosTurmas         @relation(fields: [turmaId], references: [id], onDelete: Cascade)
+  aula  CursosTurmasAulas?   @relation(fields: [aulaId], references: [id], onDelete: SetNull)
+  prova CursosTurmasProvas?  @relation(fields: [provaId], references: [id], onDelete: SetNull)
+
+  @@index([turmaId, inicio])
+  @@index([tipo])
+  @@index([aulaId])
+  @@index([provaId])
 }
 
 model CursosTurmasProvasEnvios {
@@ -422,6 +448,20 @@ enum CursosFrequenciaStatus {
 enum CursosLocalProva {
   TURMA
   MODULO
+}
+
+enum CursosAgendaTipo {
+  AULA
+  PROVA
+  EVENTO
+  ATIVIDADE
+  TRABALHO
+  PROJETO
+  SEMINARIO
+  SIMULADO
+  REUNIAO
+  RECESSO
+  FERIADO
 }
 
 enum CursosStatusPadrao {

--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -918,6 +918,164 @@ const options: Options = {
           description: 'Situação da presença do aluno em aula ou período',
           example: 'PRESENTE',
         },
+        CursosAgendaTipo: {
+          type: 'string',
+          enum: [
+            'AULA',
+            'PROVA',
+            'EVENTO',
+            'ATIVIDADE',
+            'TRABALHO',
+            'PROJETO',
+            'SEMINARIO',
+            'SIMULADO',
+            'REUNIAO',
+            'RECESSO',
+            'FERIADO',
+          ],
+          description: 'Tipo de evento registrado na agenda da turma',
+          example: 'AULA',
+        },
+        CursoAgendaEvento: {
+          type: 'object',
+          properties: {
+            id: { type: 'string', format: 'uuid' },
+            turmaId: { type: 'string', format: 'uuid' },
+            tipo: { $ref: '#/components/schemas/CursosAgendaTipo' },
+            titulo: { type: 'string', example: 'Aula inaugural' },
+            descricao: {
+              type: 'string',
+              nullable: true,
+              example: 'Aula de abertura com apresentação da metodologia do curso.',
+            },
+            inicio: { type: 'string', format: 'date-time', example: '2025-03-10T18:30:00.000Z' },
+            fim: { type: 'string', format: 'date-time', nullable: true },
+            criadoEm: { type: 'string', format: 'date-time' },
+            atualizadoEm: { type: 'string', format: 'date-time' },
+            turma: {
+              type: 'object',
+              nullable: true,
+              properties: {
+                id: { type: 'string', format: 'uuid' },
+                nome: { type: 'string', example: 'Turma 2025/1 - Noite' },
+                codigo: { type: 'string', example: 'TURMA001' },
+                cursoId: { type: 'integer', example: 1 },
+                curso: {
+                  type: 'object',
+                  nullable: true,
+                  properties: {
+                    id: { type: 'integer', example: 10 },
+                    nome: { type: 'string', example: 'Formação Fullstack' },
+                  },
+                },
+              },
+            },
+            referencia: {
+              nullable: true,
+              anyOf: [
+                {
+                  type: 'object',
+                  properties: {
+                    tipo: { type: 'string', enum: ['AULA'] },
+                    id: { type: 'string', format: 'uuid' },
+                    nome: { type: 'string', example: 'Aula 01 - Fundamentos' },
+                    moduloId: { type: 'string', format: 'uuid', nullable: true },
+                    ordem: { type: 'integer', example: 1 },
+                  },
+                  required: ['tipo', 'id', 'nome', 'ordem'],
+                },
+                {
+                  type: 'object',
+                  properties: {
+                    tipo: { type: 'string', enum: ['PROVA'] },
+                    id: { type: 'string', format: 'uuid' },
+                    titulo: { type: 'string', example: 'Prova 1 - Frontend' },
+                    etiqueta: { type: 'string', example: 'P1' },
+                    moduloId: { type: 'string', format: 'uuid', nullable: true },
+                  },
+                  required: ['tipo', 'id', 'titulo', 'etiqueta'],
+                },
+              ],
+            },
+          },
+        },
+        CursoAgendaEventoAluno: {
+          allOf: [
+            { $ref: '#/components/schemas/CursoAgendaEvento' },
+            {
+              type: 'object',
+              properties: {
+                matriculaId: {
+                  type: 'string',
+                  format: 'uuid',
+                  nullable: true,
+                  description: 'Identificador da matrícula do aluno na turma relacionada ao evento',
+                },
+              },
+            },
+          ],
+        },
+        CursoAgendaCreateInput: {
+          type: 'object',
+          required: ['tipo', 'titulo', 'inicio'],
+          properties: {
+            tipo: { $ref: '#/components/schemas/CursosAgendaTipo' },
+            titulo: {
+              type: 'string',
+              example: 'Prova final',
+              minLength: 3,
+              maxLength: 255,
+            },
+            descricao: {
+              type: 'string',
+              nullable: true,
+              example: 'Prova presencial realizada na sede da escola.',
+            },
+            inicio: { type: 'string', format: 'date-time', example: '2025-07-20T13:00:00.000Z' },
+            fim: { type: 'string', format: 'date-time', nullable: true },
+            aulaId: {
+              type: 'string',
+              format: 'uuid',
+              nullable: true,
+              description: 'Obrigatório quando tipo for AULA',
+            },
+            provaId: {
+              type: 'string',
+              format: 'uuid',
+              nullable: true,
+              description: 'Obrigatório quando tipo for PROVA',
+            },
+          },
+        },
+        CursoAgendaUpdateInput: {
+          type: 'object',
+          properties: {
+            tipo: { $ref: '#/components/schemas/CursosAgendaTipo' },
+            titulo: {
+              type: 'string',
+              example: 'Aula prática de projeto',
+              minLength: 3,
+              maxLength: 255,
+            },
+            descricao: {
+              type: 'string',
+              nullable: true,
+              example: 'Workshop com mentoria individual.',
+            },
+            inicio: { type: 'string', format: 'date-time' },
+            fim: { type: 'string', format: 'date-time', nullable: true },
+            aulaId: {
+              type: 'string',
+              format: 'uuid',
+              nullable: true,
+            },
+            provaId: {
+              type: 'string',
+              format: 'uuid',
+              nullable: true,
+            },
+          },
+        },
         CursoFrequencia: {
           type: 'object',
           properties: {

--- a/src/modules/cursos/controllers/agenda.controller.ts
+++ b/src/modules/cursos/controllers/agenda.controller.ts
@@ -1,0 +1,450 @@
+import { Request, Response } from 'express';
+import { CursosAgendaTipo } from '@prisma/client';
+import { ZodError } from 'zod';
+
+import { agendaService } from '../services/agenda.service';
+import { createAgendaSchema, updateAgendaSchema } from '../validators/agenda.schema';
+
+const parseCursoId = (raw: string) => {
+  const id = Number(raw);
+  if (!Number.isInteger(id) || id <= 0) {
+    return null;
+  }
+  return id;
+};
+
+const parseTurmaId = (raw: string) => {
+  if (typeof raw !== 'string' || raw.trim().length === 0) {
+    return null;
+  }
+  return raw;
+};
+
+const parseAgendaId = (raw: string) => {
+  if (typeof raw !== 'string' || raw.trim().length === 0) {
+    return null;
+  }
+  return raw;
+};
+
+const parseAgendaTipo = (raw: unknown): CursosAgendaTipo | undefined | null => {
+  if (raw === undefined || raw === null || raw === '') {
+    return undefined;
+  }
+
+  if (typeof raw !== 'string') {
+    return null;
+  }
+
+  const normalized = raw.toUpperCase();
+  const allowed = Object.values(CursosAgendaTipo);
+  return allowed.includes(normalized as CursosAgendaTipo)
+    ? (normalized as CursosAgendaTipo)
+    : null;
+};
+
+const parseDateQuery = (raw: unknown) => {
+  if (raw === undefined || raw === null || raw === '') {
+    return undefined;
+  }
+
+  const date = new Date(String(raw));
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+
+  return date;
+};
+
+const parseBooleanQuery = (raw: unknown): boolean | undefined | null => {
+  if (raw === undefined || raw === null || raw === '') {
+    return undefined;
+  }
+
+  if (typeof raw === 'boolean') {
+    return raw;
+  }
+
+  if (typeof raw === 'string') {
+    const normalized = raw.trim().toLowerCase();
+    if (['true', '1', 'yes', 'sim'].includes(normalized)) {
+      return true;
+    }
+    if (['false', '0', 'no', 'nao', 'não'].includes(normalized)) {
+      return false;
+    }
+  }
+
+  return null;
+};
+
+const parseTurmaQuery = (raw: unknown) => {
+  if (raw === undefined || raw === null || raw === '') {
+    return undefined;
+  }
+
+  if (typeof raw !== 'string' || raw.trim().length === 0) {
+    return null;
+  }
+
+  return raw;
+};
+
+export class AgendaController {
+  static list = async (req: Request, res: Response) => {
+    const cursoId = parseCursoId(req.params.cursoId);
+    const turmaId = parseTurmaId(req.params.turmaId);
+
+    if (!cursoId || !turmaId) {
+      return res.status(400).json({
+        success: false,
+        code: 'VALIDATION_ERROR',
+        message: 'Identificadores de curso ou turma inválidos',
+      });
+    }
+
+    const tipo = parseAgendaTipo(req.query.tipo);
+    if (tipo === null) {
+      return res.status(400).json({
+        success: false,
+        code: 'VALIDATION_ERROR',
+        message: 'Tipo de evento inválido',
+      });
+    }
+
+    const dataInicio = parseDateQuery(req.query.dataInicio);
+    const dataFim = parseDateQuery(req.query.dataFim);
+    const apenasFuturos = parseBooleanQuery(req.query.apenasFuturos);
+
+    if (dataInicio === null || dataFim === null) {
+      return res.status(400).json({
+        success: false,
+        code: 'VALIDATION_ERROR',
+        message: 'Período informado é inválido',
+      });
+    }
+
+    if (apenasFuturos === null) {
+      return res.status(400).json({
+        success: false,
+        code: 'VALIDATION_ERROR',
+        message: 'Parâmetro apenasFuturos inválido',
+      });
+    }
+
+    try {
+      const eventos = await agendaService.list(cursoId, turmaId, {
+        tipo: tipo ?? undefined,
+        dataInicio,
+        dataFim,
+        apenasFuturos: apenasFuturos ?? undefined,
+      });
+
+      res.json({ data: eventos });
+    } catch (error: any) {
+      if (error?.code === 'TURMA_NOT_FOUND') {
+        return res.status(404).json({
+          success: false,
+          code: 'TURMA_NOT_FOUND',
+          message: 'Turma não encontrada para o curso informado',
+        });
+      }
+
+      res.status(500).json({
+        success: false,
+        code: 'AGENDA_LIST_ERROR',
+        message: 'Erro ao listar eventos da turma',
+        error: error?.message,
+      });
+    }
+  };
+
+  static get = async (req: Request, res: Response) => {
+    const cursoId = parseCursoId(req.params.cursoId);
+    const turmaId = parseTurmaId(req.params.turmaId);
+    const agendaId = parseAgendaId(req.params.agendaId);
+
+    if (!cursoId || !turmaId || !agendaId) {
+      return res.status(400).json({
+        success: false,
+        code: 'VALIDATION_ERROR',
+        message: 'Identificadores de curso, turma ou evento inválidos',
+      });
+    }
+
+    try {
+      const evento = await agendaService.get(cursoId, turmaId, agendaId);
+      res.json(evento);
+    } catch (error: any) {
+      if (error?.code === 'AGENDA_NOT_FOUND' || error?.code === 'TURMA_NOT_FOUND') {
+        return res.status(404).json({
+          success: false,
+          code: 'AGENDA_NOT_FOUND',
+          message: 'Evento não encontrado para a turma informada',
+        });
+      }
+
+      res.status(500).json({
+        success: false,
+        code: 'AGENDA_GET_ERROR',
+        message: 'Erro ao buscar evento da turma',
+        error: error?.message,
+      });
+    }
+  };
+
+  static create = async (req: Request, res: Response) => {
+    const cursoId = parseCursoId(req.params.cursoId);
+    const turmaId = parseTurmaId(req.params.turmaId);
+
+    if (!cursoId || !turmaId) {
+      return res.status(400).json({
+        success: false,
+        code: 'VALIDATION_ERROR',
+        message: 'Identificadores de curso ou turma inválidos',
+      });
+    }
+
+    try {
+      const data = createAgendaSchema.parse(req.body);
+      const evento = await agendaService.create(cursoId, turmaId, data);
+      res.status(201).json(evento);
+    } catch (error: any) {
+      if (error instanceof ZodError) {
+        return res.status(400).json({
+          success: false,
+          code: 'VALIDATION_ERROR',
+          message: 'Dados inválidos para criação do evento',
+          issues: error.flatten().fieldErrors,
+        });
+      }
+
+      if (error?.code === 'TURMA_NOT_FOUND') {
+        return res.status(404).json({
+          success: false,
+          code: 'TURMA_NOT_FOUND',
+          message: 'Turma não encontrada para o curso informado',
+        });
+      }
+
+      if (error?.code === 'AULA_NOT_FOUND') {
+        return res.status(404).json({
+          success: false,
+          code: 'AULA_NOT_FOUND',
+          message: 'Aula não encontrada para a turma informada',
+        });
+      }
+
+      if (error?.code === 'PROVA_NOT_FOUND') {
+        return res.status(404).json({
+          success: false,
+          code: 'PROVA_NOT_FOUND',
+          message: 'Prova não encontrada para a turma informada',
+        });
+      }
+
+      if (error?.code === 'VALIDATION_ERROR') {
+        return res.status(400).json({
+          success: false,
+          code: 'VALIDATION_ERROR',
+          message: error.message,
+        });
+      }
+
+      res.status(500).json({
+        success: false,
+        code: 'AGENDA_CREATE_ERROR',
+        message: 'Erro ao criar evento para a turma',
+        error: error?.message,
+      });
+    }
+  };
+
+  static update = async (req: Request, res: Response) => {
+    const cursoId = parseCursoId(req.params.cursoId);
+    const turmaId = parseTurmaId(req.params.turmaId);
+    const agendaId = parseAgendaId(req.params.agendaId);
+
+    if (!cursoId || !turmaId || !agendaId) {
+      return res.status(400).json({
+        success: false,
+        code: 'VALIDATION_ERROR',
+        message: 'Identificadores de curso, turma ou evento inválidos',
+      });
+    }
+
+    try {
+      const data = updateAgendaSchema.parse(req.body);
+
+      if (Object.values(data).every((value) => value === undefined)) {
+        return res.status(400).json({
+          success: false,
+          code: 'VALIDATION_ERROR',
+          message: 'Informe ao menos um campo para atualização do evento',
+        });
+      }
+
+      const evento = await agendaService.update(cursoId, turmaId, agendaId, data);
+      res.json(evento);
+    } catch (error: any) {
+      if (error instanceof ZodError) {
+        return res.status(400).json({
+          success: false,
+          code: 'VALIDATION_ERROR',
+          message: 'Dados inválidos para atualização do evento',
+          issues: error.flatten().fieldErrors,
+        });
+      }
+
+      if (error?.code === 'AGENDA_NOT_FOUND' || error?.code === 'TURMA_NOT_FOUND') {
+        return res.status(404).json({
+          success: false,
+          code: 'AGENDA_NOT_FOUND',
+          message: 'Evento não encontrado para a turma informada',
+        });
+      }
+
+      if (error?.code === 'AULA_NOT_FOUND') {
+        return res.status(404).json({
+          success: false,
+          code: 'AULA_NOT_FOUND',
+          message: 'Aula não encontrada para a turma informada',
+        });
+      }
+
+      if (error?.code === 'PROVA_NOT_FOUND') {
+        return res.status(404).json({
+          success: false,
+          code: 'PROVA_NOT_FOUND',
+          message: 'Prova não encontrada para a turma informada',
+        });
+      }
+
+      if (error?.code === 'VALIDATION_ERROR') {
+        return res.status(400).json({
+          success: false,
+          code: 'VALIDATION_ERROR',
+          message: error.message,
+        });
+      }
+
+      res.status(500).json({
+        success: false,
+        code: 'AGENDA_UPDATE_ERROR',
+        message: 'Erro ao atualizar evento da turma',
+        error: error?.message,
+      });
+    }
+  };
+
+  static delete = async (req: Request, res: Response) => {
+    const cursoId = parseCursoId(req.params.cursoId);
+    const turmaId = parseTurmaId(req.params.turmaId);
+    const agendaId = parseAgendaId(req.params.agendaId);
+
+    if (!cursoId || !turmaId || !agendaId) {
+      return res.status(400).json({
+        success: false,
+        code: 'VALIDATION_ERROR',
+        message: 'Identificadores de curso, turma ou evento inválidos',
+      });
+    }
+
+    try {
+      await agendaService.delete(cursoId, turmaId, agendaId);
+      res.status(204).send();
+    } catch (error: any) {
+      if (error?.code === 'AGENDA_NOT_FOUND' || error?.code === 'TURMA_NOT_FOUND') {
+        return res.status(404).json({
+          success: false,
+          code: 'AGENDA_NOT_FOUND',
+          message: 'Evento não encontrado para a turma informada',
+        });
+      }
+
+      res.status(500).json({
+        success: false,
+        code: 'AGENDA_DELETE_ERROR',
+        message: 'Erro ao remover evento da turma',
+        error: error?.message,
+      });
+    }
+  };
+
+  static listMy = async (req: Request, res: Response) => {
+    const userId = req.user?.id;
+
+    if (!userId) {
+      return res.status(401).json({
+        success: false,
+        code: 'UNAUTHORIZED',
+        message: 'Usuário não autenticado',
+      });
+    }
+
+    const tipo = parseAgendaTipo(req.query.tipo);
+    if (tipo === null) {
+      return res.status(400).json({
+        success: false,
+        code: 'VALIDATION_ERROR',
+        message: 'Tipo de evento inválido',
+      });
+    }
+
+    const dataInicio = parseDateQuery(req.query.dataInicio);
+    const dataFim = parseDateQuery(req.query.dataFim);
+    const apenasFuturos = parseBooleanQuery(req.query.apenasFuturos);
+    const turmaId = parseTurmaQuery(req.query.turmaId);
+
+    if (dataInicio === null || dataFim === null) {
+      return res.status(400).json({
+        success: false,
+        code: 'VALIDATION_ERROR',
+        message: 'Período informado é inválido',
+      });
+    }
+
+    if (apenasFuturos === null) {
+      return res.status(400).json({
+        success: false,
+        code: 'VALIDATION_ERROR',
+        message: 'Parâmetro apenasFuturos inválido',
+      });
+    }
+
+    if (turmaId === null) {
+      return res.status(400).json({
+        success: false,
+        code: 'VALIDATION_ERROR',
+        message: 'Identificador da turma inválido',
+      });
+    }
+
+    try {
+      const eventos = await agendaService.listMy(userId, {
+        tipo: tipo ?? undefined,
+        dataInicio,
+        dataFim,
+        apenasFuturos: apenasFuturos ?? undefined,
+        turmaId,
+      });
+
+      res.json({ data: eventos });
+    } catch (error: any) {
+      if (error?.code === 'MATRICULA_NOT_FOUND') {
+        return res.status(404).json({
+          success: false,
+          code: 'MATRICULA_NOT_FOUND',
+          message: 'Você não está matriculado na turma informada',
+        });
+      }
+
+      res.status(500).json({
+        success: false,
+        code: 'AGENDA_MY_LIST_ERROR',
+        message: 'Erro ao listar eventos do aluno',
+        error: error?.message,
+      });
+    }
+  };
+}

--- a/src/modules/cursos/routes/index.ts
+++ b/src/modules/cursos/routes/index.ts
@@ -12,6 +12,7 @@ import { ProvasController } from '../controllers/provas.controller';
 import { AvaliacaoController } from '../controllers/avaliacao.controller';
 import { NotasController } from '../controllers/notas.controller';
 import { FrequenciaController } from '../controllers/frequencia.controller';
+import { AgendaController } from '../controllers/agenda.controller';
 
 const router = Router();
 
@@ -1410,6 +1411,241 @@ router.delete(
   supabaseAuthMiddleware([Roles.ADMIN, Roles.MODERADOR, Roles.PEDAGOGICO, Roles.PROFESSOR]),
   NotasController.delete,
 );
+
+/**
+ * @openapi
+ * /api/v1/cursos/{cursoId}/turmas/{turmaId}/agenda:
+ *   get:
+ *     summary: Listar eventos de agenda da turma
+ *     tags: ['Cursos - Agenda']
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: cursoId
+ *         required: true
+ *         schema: { type: integer, minimum: 1 }
+ *       - in: path
+ *         name: turmaId
+ *         required: true
+ *         schema: { type: string, format: uuid }
+ *       - in: query
+ *         name: tipo
+ *         schema: { $ref: '#/components/schemas/CursosAgendaTipo' }
+ *       - in: query
+ *         name: dataInicio
+ *         schema: { type: string, format: date-time }
+ *         description: Filtra eventos com início igual ou posterior à data informada
+ *       - in: query
+ *         name: dataFim
+ *         schema: { type: string, format: date-time }
+ *         description: Limita eventos com início até a data informada
+ *       - in: query
+ *         name: apenasFuturos
+ *         schema: { type: boolean }
+ *         description: Retorna apenas eventos com início futuro em relação à consulta
+ *     responses:
+ *       200:
+ *         description: Lista de eventos da turma
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 data:
+ *                   type: array
+ *                   items:
+ *                     $ref: '#/components/schemas/CursoAgendaEvento'
+ */
+router.get(
+  '/:cursoId/turmas/:turmaId/agenda',
+  supabaseAuthMiddleware([Roles.ADMIN, Roles.MODERADOR, Roles.PEDAGOGICO, Roles.PROFESSOR]),
+  AgendaController.list,
+);
+
+/**
+ * @openapi
+ * /api/v1/cursos/{cursoId}/turmas/{turmaId}/agenda/{agendaId}:
+ *   get:
+ *     summary: Obter evento específico da agenda da turma
+ *     tags: ['Cursos - Agenda']
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: cursoId
+ *         required: true
+ *         schema: { type: integer, minimum: 1 }
+ *       - in: path
+ *         name: turmaId
+ *         required: true
+ *         schema: { type: string, format: uuid }
+ *       - in: path
+ *         name: agendaId
+ *         required: true
+ *         schema: { type: string, format: uuid }
+ *     responses:
+ *       200:
+ *         description: Evento de agenda
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/CursoAgendaEvento'
+ */
+router.get(
+  '/:cursoId/turmas/:turmaId/agenda/:agendaId',
+  supabaseAuthMiddleware([Roles.ADMIN, Roles.MODERADOR, Roles.PEDAGOGICO, Roles.PROFESSOR]),
+  AgendaController.get,
+);
+
+/**
+ * @openapi
+ * /api/v1/cursos/{cursoId}/turmas/{turmaId}/agenda:
+ *   post:
+ *     summary: Criar evento na agenda da turma
+ *     tags: ['Cursos - Agenda']
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: cursoId
+ *         required: true
+ *         schema: { type: integer, minimum: 1 }
+ *       - in: path
+ *         name: turmaId
+ *         required: true
+ *         schema: { type: string, format: uuid }
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/CursoAgendaCreateInput'
+ *     responses:
+ *       201:
+ *         description: Evento criado com sucesso
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/CursoAgendaEvento'
+ */
+router.post(
+  '/:cursoId/turmas/:turmaId/agenda',
+  supabaseAuthMiddleware([Roles.ADMIN, Roles.MODERADOR, Roles.PEDAGOGICO, Roles.PROFESSOR]),
+  AgendaController.create,
+);
+
+/**
+ * @openapi
+ * /api/v1/cursos/{cursoId}/turmas/{turmaId}/agenda/{agendaId}:
+ *   put:
+ *     summary: Atualizar evento da agenda da turma
+ *     tags: ['Cursos - Agenda']
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: cursoId
+ *         required: true
+ *         schema: { type: integer, minimum: 1 }
+ *       - in: path
+ *         name: turmaId
+ *         required: true
+ *         schema: { type: string, format: uuid }
+ *       - in: path
+ *         name: agendaId
+ *         required: true
+ *         schema: { type: string, format: uuid }
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/CursoAgendaUpdateInput'
+ *     responses:
+ *       200:
+ *         description: Evento atualizado com sucesso
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/CursoAgendaEvento'
+ */
+router.put(
+  '/:cursoId/turmas/:turmaId/agenda/:agendaId',
+  supabaseAuthMiddleware([Roles.ADMIN, Roles.MODERADOR, Roles.PEDAGOGICO, Roles.PROFESSOR]),
+  AgendaController.update,
+);
+
+/**
+ * @openapi
+ * /api/v1/cursos/{cursoId}/turmas/{turmaId}/agenda/{agendaId}:
+ *   delete:
+ *     summary: Remover evento da agenda da turma
+ *     tags: ['Cursos - Agenda']
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: cursoId
+ *         required: true
+ *         schema: { type: integer, minimum: 1 }
+ *       - in: path
+ *         name: turmaId
+ *         required: true
+ *         schema: { type: string, format: uuid }
+ *       - in: path
+ *         name: agendaId
+ *         required: true
+ *         schema: { type: string, format: uuid }
+ *     responses:
+ *       204:
+ *         description: Evento removido com sucesso
+ */
+router.delete(
+  '/:cursoId/turmas/:turmaId/agenda/:agendaId',
+  supabaseAuthMiddleware([Roles.ADMIN, Roles.MODERADOR, Roles.PEDAGOGICO, Roles.PROFESSOR]),
+  AgendaController.delete,
+);
+
+/**
+ * @openapi
+ * /api/v1/cursos/me/agenda:
+ *   get:
+ *     summary: Consultar eventos das turmas em que o aluno está matriculado
+ *     tags: ['Cursos - Agenda']
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: tipo
+ *         schema: { $ref: '#/components/schemas/CursosAgendaTipo' }
+ *       - in: query
+ *         name: dataInicio
+ *         schema: { type: string, format: date-time }
+ *       - in: query
+ *         name: dataFim
+ *         schema: { type: string, format: date-time }
+ *       - in: query
+ *         name: apenasFuturos
+ *         schema: { type: boolean }
+ *       - in: query
+ *         name: turmaId
+ *         schema: { type: string, format: uuid }
+ *         description: Filtra eventos para uma turma específica do aluno
+ *     responses:
+ *       200:
+ *         description: Eventos das turmas do aluno autenticado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 data:
+ *                   type: array
+ *                   items:
+ *                     $ref: '#/components/schemas/CursoAgendaEventoAluno'
+ */
+router.get('/me/agenda', supabaseAuthMiddleware([Roles.ALUNO_CANDIDATO]), AgendaController.listMy);
 
 /**
  * @openapi

--- a/src/modules/cursos/services/agenda.mapper.ts
+++ b/src/modules/cursos/services/agenda.mapper.ts
@@ -1,0 +1,81 @@
+import { Prisma } from '@prisma/client';
+
+export const agendaWithRelations = Prisma.validator<Prisma.CursosTurmasAgendaDefaultArgs>()({
+  include: {
+    turma: {
+      select: {
+        id: true,
+        nome: true,
+        codigo: true,
+        cursoId: true,
+        curso: {
+          select: {
+            id: true,
+            nome: true,
+          },
+        },
+      },
+    },
+    aula: {
+      select: {
+        id: true,
+        nome: true,
+        ordem: true,
+        moduloId: true,
+      },
+    },
+    prova: {
+      select: {
+        id: true,
+        titulo: true,
+        etiqueta: true,
+        moduloId: true,
+      },
+    },
+  },
+});
+
+export type AgendaWithRelations = Prisma.CursosTurmasAgendaGetPayload<typeof agendaWithRelations>;
+
+export const mapAgendaItem = (agenda: AgendaWithRelations) => ({
+  id: agenda.id,
+  turmaId: agenda.turmaId,
+  tipo: agenda.tipo,
+  titulo: agenda.titulo,
+  descricao: agenda.descricao ?? null,
+  inicio: agenda.inicio.toISOString(),
+  fim: agenda.fim?.toISOString() ?? null,
+  criadoEm: agenda.criadoEm.toISOString(),
+  atualizadoEm: agenda.atualizadoEm.toISOString(),
+  turma: agenda.turma
+    ? {
+        id: agenda.turma.id,
+        nome: agenda.turma.nome,
+        codigo: agenda.turma.codigo,
+        cursoId: agenda.turma.cursoId,
+        curso: agenda.turma.curso
+          ? {
+              id: agenda.turma.curso.id,
+              nome: agenda.turma.curso.nome,
+            }
+          : null,
+      }
+    : null,
+  referencia: agenda.aula
+    ? {
+        tipo: 'AULA' as const,
+        id: agenda.aula.id,
+        nome: agenda.aula.nome,
+        moduloId: agenda.aula.moduloId ?? null,
+        ordem: agenda.aula.ordem,
+      }
+    : agenda.prova
+      ? {
+          tipo: 'PROVA' as const,
+          id: agenda.prova.id,
+          titulo: agenda.prova.titulo,
+          etiqueta: agenda.prova.etiqueta,
+          moduloId: agenda.prova.moduloId ?? null,
+        }
+      : null,
+});

--- a/src/modules/cursos/services/agenda.service.ts
+++ b/src/modules/cursos/services/agenda.service.ts
@@ -1,0 +1,414 @@
+import { CursosAgendaTipo, Prisma } from '@prisma/client';
+
+import { prisma } from '@/config/prisma';
+import { logger } from '@/utils/logger';
+
+import { agendaWithRelations, mapAgendaItem } from './agenda.mapper';
+
+const agendaLogger = logger.child({ module: 'CursosAgendaService' });
+
+type PrismaClientOrTx = Prisma.TransactionClient | typeof prisma;
+
+const ensureTurmaBelongsToCurso = async (
+  client: PrismaClientOrTx,
+  cursoId: number,
+  turmaId: string,
+) => {
+  const turma = await client.cursosTurmas.findFirst({
+    where: { id: turmaId, cursoId },
+    select: { id: true },
+  });
+
+  if (!turma) {
+    const error = new Error('Turma não encontrada para o curso informado');
+    (error as any).code = 'TURMA_NOT_FOUND';
+    throw error;
+  }
+};
+
+const ensureAulaBelongsToTurma = async (
+  client: PrismaClientOrTx,
+  turmaId: string,
+  aulaId: string,
+) => {
+  const aula = await client.cursosTurmasAulas.findFirst({
+    where: { id: aulaId, turmaId },
+    select: { id: true },
+  });
+
+  if (!aula) {
+    const error = new Error('Aula não encontrada para a turma informada');
+    (error as any).code = 'AULA_NOT_FOUND';
+    throw error;
+  }
+};
+
+const ensureProvaBelongsToTurma = async (
+  client: PrismaClientOrTx,
+  turmaId: string,
+  provaId: string,
+) => {
+  const prova = await client.cursosTurmasProvas.findFirst({
+    where: { id: provaId, turmaId },
+    select: { id: true },
+  });
+
+  if (!prova) {
+    const error = new Error('Prova não encontrada para a turma informada');
+    (error as any).code = 'PROVA_NOT_FOUND';
+    throw error;
+  }
+};
+
+const ensureAgendaBelongsToTurma = async (
+  client: PrismaClientOrTx,
+  cursoId: number,
+  turmaId: string,
+  agendaId: string,
+) => {
+  const agenda = await client.cursosTurmasAgenda.findFirst({
+    where: { id: agendaId, turmaId, turma: { cursoId } },
+    select: {
+      id: true,
+      turmaId: true,
+      tipo: true,
+      titulo: true,
+      descricao: true,
+      inicio: true,
+      fim: true,
+      aulaId: true,
+      provaId: true,
+    },
+  });
+
+  if (!agenda) {
+    const error = new Error('Evento de agenda não encontrado para a turma informada');
+    (error as any).code = 'AGENDA_NOT_FOUND';
+    throw error;
+  }
+
+  return agenda;
+};
+
+const normalizeNullableString = (value: string | null | undefined) => {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (value === null) {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+};
+
+const validateDateRange = (inicio: Date, fim?: Date | null) => {
+  if (fim && fim.getTime() < inicio.getTime()) {
+    const error = new Error('Data de término não pode ser anterior à data de início');
+    (error as any).code = 'VALIDATION_ERROR';
+    throw error;
+  }
+};
+
+const ensureReferenceConsistency = async (
+  client: PrismaClientOrTx,
+  turmaId: string,
+  tipo: CursosAgendaTipo,
+  aulaId?: string | null,
+  provaId?: string | null,
+) => {
+  if (tipo === CursosAgendaTipo.AULA) {
+    if (!aulaId) {
+      const error = new Error('Aula é obrigatória para eventos do tipo AULA');
+      (error as any).code = 'VALIDATION_ERROR';
+      throw error;
+    }
+    await ensureAulaBelongsToTurma(client, turmaId, aulaId);
+    if (provaId) {
+      const error = new Error('Não é permitido vincular prova em eventos do tipo AULA');
+      (error as any).code = 'VALIDATION_ERROR';
+      throw error;
+    }
+    return;
+  }
+
+  if (tipo === CursosAgendaTipo.PROVA) {
+    if (!provaId) {
+      const error = new Error('Prova é obrigatória para eventos do tipo PROVA');
+      (error as any).code = 'VALIDATION_ERROR';
+      throw error;
+    }
+    await ensureProvaBelongsToTurma(client, turmaId, provaId);
+    if (aulaId) {
+      const error = new Error('Não é permitido vincular aula em eventos do tipo PROVA');
+      (error as any).code = 'VALIDATION_ERROR';
+      throw error;
+    }
+    return;
+  }
+
+  if (aulaId || provaId) {
+    const error = new Error(`Eventos do tipo ${tipo} não podem referenciar aulas ou provas`);
+    (error as any).code = 'VALIDATION_ERROR';
+    throw error;
+  }
+};
+
+const applyDateFilters = (
+  filters: {
+    dataInicio?: Date;
+    dataFim?: Date;
+    apenasFuturos?: boolean;
+  },
+) => {
+  let gte = filters.dataInicio;
+  if (filters.apenasFuturos) {
+    const now = new Date();
+    gte = gte ? (gte.getTime() > now.getTime() ? gte : now) : now;
+  }
+
+  const lte = filters.dataFim;
+
+  if (!gte && !lte) {
+    return undefined;
+  }
+
+  return {
+    gte: gte ?? undefined,
+    lte: lte ?? undefined,
+  } satisfies Prisma.DateTimeFilter;
+};
+
+export const agendaService = {
+  async list(
+    cursoId: number,
+    turmaId: string,
+    filters: {
+      tipo?: CursosAgendaTipo;
+      dataInicio?: Date;
+      dataFim?: Date;
+      apenasFuturos?: boolean;
+    } = {},
+  ) {
+    await ensureTurmaBelongsToCurso(prisma, cursoId, turmaId);
+
+    const where: Prisma.CursosTurmasAgendaWhereInput = {
+      turmaId,
+      turma: { cursoId },
+      tipo: filters.tipo ?? undefined,
+    };
+
+    const dataFilter = applyDateFilters(filters);
+    if (dataFilter) {
+      where.inicio = dataFilter;
+    }
+
+    const eventos = await prisma.cursosTurmasAgenda.findMany({
+      where,
+      orderBy: [
+        { inicio: 'asc' },
+        { criadoEm: 'asc' },
+      ],
+      ...agendaWithRelations,
+    });
+
+    return eventos.map(mapAgendaItem);
+  },
+
+  async get(cursoId: number, turmaId: string, agendaId: string) {
+    await ensureTurmaBelongsToCurso(prisma, cursoId, turmaId);
+
+    const evento = await prisma.cursosTurmasAgenda.findFirst({
+      where: { id: agendaId, turmaId, turma: { cursoId } },
+      ...agendaWithRelations,
+    });
+
+    if (!evento) {
+      const error = new Error('Evento de agenda não encontrado para a turma informada');
+      (error as any).code = 'AGENDA_NOT_FOUND';
+      throw error;
+    }
+
+    return mapAgendaItem(evento);
+  },
+
+  async create(
+    cursoId: number,
+    turmaId: string,
+    data: {
+      tipo: CursosAgendaTipo;
+      titulo: string;
+      descricao?: string | null;
+      inicio: Date;
+      fim?: Date | null;
+      aulaId?: string | null;
+      provaId?: string | null;
+    },
+  ) {
+    return prisma.$transaction(async (tx) => {
+      await ensureTurmaBelongsToCurso(tx, cursoId, turmaId);
+
+      const titulo = data.titulo.trim();
+      if (!titulo) {
+        const error = new Error('Título é obrigatório');
+        (error as any).code = 'VALIDATION_ERROR';
+        throw error;
+      }
+
+      validateDateRange(data.inicio, data.fim ?? null);
+      await ensureReferenceConsistency(tx, turmaId, data.tipo, data.aulaId ?? null, data.provaId ?? null);
+
+      const evento = await tx.cursosTurmasAgenda.create({
+        data: {
+          turmaId,
+          tipo: data.tipo,
+          titulo,
+          descricao: normalizeNullableString(data.descricao) ?? null,
+          inicio: data.inicio,
+          fim: data.fim ?? null,
+          aulaId: data.aulaId ?? null,
+          provaId: data.provaId ?? null,
+        },
+        ...agendaWithRelations,
+      });
+
+      agendaLogger.info({ turmaId, agendaId: evento.id }, 'Evento de agenda criado com sucesso');
+
+      return mapAgendaItem(evento);
+    });
+  },
+
+  async update(
+    cursoId: number,
+    turmaId: string,
+    agendaId: string,
+    data: {
+      tipo?: CursosAgendaTipo;
+      titulo?: string;
+      descricao?: string | null;
+      inicio?: Date;
+      fim?: Date | null;
+      aulaId?: string | null;
+      provaId?: string | null;
+    },
+  ) {
+    return prisma.$transaction(async (tx) => {
+      const agenda = await ensureAgendaBelongsToTurma(tx, cursoId, turmaId, agendaId);
+
+      const tipo = data.tipo ?? agenda.tipo;
+      const titulo = data.titulo !== undefined ? data.titulo.trim() : agenda.titulo;
+      const descricao =
+        data.descricao !== undefined ? normalizeNullableString(data.descricao) : agenda.descricao;
+      const inicio = data.inicio ?? agenda.inicio;
+      const fim = data.fim !== undefined ? data.fim : agenda.fim;
+      const aulaId = data.aulaId !== undefined ? data.aulaId : agenda.aulaId;
+      const provaId = data.provaId !== undefined ? data.provaId : agenda.provaId;
+
+      if (!titulo) {
+        const error = new Error('Título é obrigatório');
+        (error as any).code = 'VALIDATION_ERROR';
+        throw error;
+      }
+
+      validateDateRange(inicio, fim ?? null);
+      await ensureReferenceConsistency(tx, turmaId, tipo, aulaId ?? null, provaId ?? null);
+
+      await tx.cursosTurmasAgenda.update({
+        where: { id: agendaId },
+        data: {
+          tipo,
+          titulo,
+          descricao,
+          inicio,
+          fim: fim ?? null,
+          aulaId: aulaId ?? null,
+          provaId: provaId ?? null,
+        },
+      });
+
+      const atualizado = await tx.cursosTurmasAgenda.findUnique({
+        where: { id: agendaId },
+        ...agendaWithRelations,
+      });
+
+      if (!atualizado) {
+        const error = new Error('Evento de agenda não encontrado após atualização');
+        (error as any).code = 'AGENDA_NOT_FOUND';
+        throw error;
+      }
+
+      agendaLogger.info({ turmaId, agendaId }, 'Evento de agenda atualizado com sucesso');
+
+      return mapAgendaItem(atualizado);
+    });
+  },
+
+  async delete(cursoId: number, turmaId: string, agendaId: string) {
+    return prisma.$transaction(async (tx) => {
+      await ensureAgendaBelongsToTurma(tx, cursoId, turmaId, agendaId);
+
+      await tx.cursosTurmasAgenda.delete({ where: { id: agendaId } });
+
+      agendaLogger.info({ turmaId, agendaId }, 'Evento de agenda removido');
+    });
+  },
+
+  async listMy(
+    alunoId: string,
+    filters: {
+      tipo?: CursosAgendaTipo;
+      dataInicio?: Date;
+      dataFim?: Date;
+      apenasFuturos?: boolean;
+      turmaId?: string;
+    } = {},
+  ) {
+    const matriculas = await prisma.cursosTurmasMatriculas.findMany({
+      where: { alunoId },
+      select: {
+        id: true,
+        turmaId: true,
+      },
+    });
+
+    if (matriculas.length === 0) {
+      return [];
+    }
+
+    let turmaIds = matriculas.map((matricula) => matricula.turmaId);
+
+    if (filters.turmaId) {
+      if (!turmaIds.includes(filters.turmaId)) {
+        const error = new Error('Aluno não está matriculado na turma informada');
+        (error as any).code = 'MATRICULA_NOT_FOUND';
+        throw error;
+      }
+      turmaIds = [filters.turmaId];
+    }
+
+    const where: Prisma.CursosTurmasAgendaWhereInput = {
+      turmaId: { in: turmaIds },
+      tipo: filters.tipo ?? undefined,
+    };
+
+    const dataFilter = applyDateFilters(filters);
+    if (dataFilter) {
+      where.inicio = dataFilter;
+    }
+
+    const eventos = await prisma.cursosTurmasAgenda.findMany({
+      where,
+      orderBy: [
+        { inicio: 'asc' },
+        { criadoEm: 'asc' },
+      ],
+      ...agendaWithRelations,
+    });
+
+    const matriculaPorTurma = new Map(matriculas.map((matricula) => [matricula.turmaId, matricula.id]));
+
+    return eventos.map((evento) => ({
+      ...mapAgendaItem(evento),
+      matriculaId: matriculaPorTurma.get(evento.turmaId) ?? null,
+    }));
+  },
+};

--- a/src/modules/cursos/validators/agenda.schema.ts
+++ b/src/modules/cursos/validators/agenda.schema.ts
@@ -1,0 +1,158 @@
+import { CursosAgendaTipo } from '@prisma/client';
+import { z } from 'zod';
+
+const tituloSchema = z
+  .string({ invalid_type_error: 'Título deve ser um texto' })
+  .trim()
+  .min(3, 'Título deve ter ao menos 3 caracteres')
+  .max(255, 'Título deve ter no máximo 255 caracteres');
+
+const descricaoSchema = z
+  .string({ invalid_type_error: 'Descrição deve ser um texto' })
+  .trim()
+  .max(1000, 'Descrição deve ter no máximo 1000 caracteres')
+  .nullish();
+
+const aulaIdSchema = z
+  .string({ invalid_type_error: 'Identificador da aula deve ser um texto' })
+  .uuid('Identificador da aula inválido')
+  .nullish();
+
+const provaIdSchema = z
+  .string({ invalid_type_error: 'Identificador da prova deve ser um texto' })
+  .uuid('Identificador da prova inválido')
+  .nullish();
+
+const baseSchema = z.object({
+  tipo: z.nativeEnum(CursosAgendaTipo),
+  titulo: tituloSchema,
+  descricao: descricaoSchema,
+  inicio: z.coerce.date({ invalid_type_error: 'Informe uma data/hora válida para início' }),
+  fim: z.coerce
+    .date({ invalid_type_error: 'Informe uma data/hora válida para término' })
+    .optional(),
+  aulaId: aulaIdSchema,
+  provaId: provaIdSchema,
+});
+
+export const createAgendaSchema = baseSchema.superRefine((data, ctx) => {
+  if (data.fim && data.fim.getTime() < data.inicio.getTime()) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['fim'],
+      message: 'Data de término não pode ser anterior à data de início',
+    });
+  }
+
+  if (data.tipo === CursosAgendaTipo.AULA) {
+    if (!data.aulaId) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['aulaId'],
+        message: 'Informe a aula vinculada ao evento',
+      });
+    }
+    if (data.provaId) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['provaId'],
+        message: 'Eventos de aula não podem referenciar provas',
+      });
+    }
+    return;
+  }
+
+  if (data.tipo === CursosAgendaTipo.PROVA) {
+    if (!data.provaId) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['provaId'],
+        message: 'Informe a prova vinculada ao evento',
+      });
+    }
+    if (data.aulaId) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['aulaId'],
+        message: 'Eventos de prova não podem referenciar aulas',
+      });
+    }
+    return;
+  }
+
+  if (data.aulaId) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['aulaId'],
+      message: `Eventos do tipo ${data.tipo} não podem vincular aulas`,
+    });
+  }
+  if (data.provaId) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['provaId'],
+      message: `Eventos do tipo ${data.tipo} não podem vincular provas`,
+    });
+  }
+});
+
+export const updateAgendaSchema = z
+  .object({
+    tipo: z.nativeEnum(CursosAgendaTipo).optional(),
+    titulo: tituloSchema.optional(),
+    descricao: descricaoSchema.optional(),
+    inicio: z.coerce.date({ invalid_type_error: 'Informe uma data/hora válida para início' }).optional(),
+    fim: z.coerce.date({ invalid_type_error: 'Informe uma data/hora válida para término' }).optional(),
+    aulaId: aulaIdSchema.optional(),
+    provaId: provaIdSchema.optional(),
+  })
+  .superRefine((data, ctx) => {
+    if (data.inicio && data.fim && data.fim.getTime() < data.inicio.getTime()) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['fim'],
+        message: 'Data de término não pode ser anterior à data de início',
+      });
+    }
+
+    if (data.aulaId && data.provaId) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['provaId'],
+        message: 'Não é permitido vincular aula e prova ao mesmo evento',
+      });
+    }
+
+    if (data.tipo === CursosAgendaTipo.AULA && data.provaId && data.provaId !== null) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['provaId'],
+        message: 'Eventos de aula não podem referenciar provas',
+      });
+    }
+
+    if (data.tipo === CursosAgendaTipo.PROVA && data.aulaId && data.aulaId !== null) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['aulaId'],
+        message: 'Eventos de prova não podem referenciar aulas',
+      });
+    }
+
+    if (data.tipo && data.tipo !== CursosAgendaTipo.AULA && data.tipo !== CursosAgendaTipo.PROVA) {
+      if (data.aulaId && data.aulaId !== null) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['aulaId'],
+          message: `Eventos do tipo ${data.tipo} não podem vincular aulas`,
+        });
+      }
+      if (data.provaId && data.provaId !== null) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['provaId'],
+          message: `Eventos do tipo ${data.tipo} não podem vincular provas`,
+        });
+      }
+    }
+  });


### PR DESCRIPTION
## Summary
- extend `CursosAgendaTipo` with additional categories to detalhar eventos de turma
- ajustar validações e regras de consistência para permitir vínculos apenas em aulas e provas
- atualizar o schema do Swagger para refletir os novos tipos de agenda

## Testing
- pnpm prisma:generate
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d1fa29f7488332a60c611d3216c55d