### PR TITLE
feat: rastrear formato nos logs de certificados

### DIFF
--- a/prisma/migrations/20250205000000_add_cursos_certificados/migration.sql
+++ b/prisma/migrations/20250205000000_add_cursos_certificados/migration.sql
@@ -1,0 +1,63 @@
+-- CreateEnum
+CREATE TYPE "public"."CursosCertificadosLogAcao" AS ENUM ('EMISSAO', 'VISUALIZACAO');
+
+-- CreateTable
+CREATE TABLE "public"."CursosCertificadosEmitidos" (
+    "id" TEXT NOT NULL,
+    "matriculaId" TEXT NOT NULL,
+    "codigo" VARCHAR(20) NOT NULL,
+    "tipo" "public"."CursosCertificados" NOT NULL,
+    "formato" "public"."CursosCertificadosTipos" NOT NULL,
+    "cargaHoraria" INTEGER NOT NULL,
+    "assinaturaUrl" VARCHAR(2048),
+    "alunoNome" VARCHAR(255) NOT NULL,
+    "alunoCpf" VARCHAR(14),
+    "cursoNome" VARCHAR(255) NOT NULL,
+    "turmaNome" VARCHAR(255) NOT NULL,
+    "emitidoPorId" TEXT,
+    "emitidoEm" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "observacoes" VARCHAR(500),
+
+    CONSTRAINT "CursosCertificadosEmitidos_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."CursosCertificadosLogs" (
+    "id" TEXT NOT NULL,
+    "certificadoId" TEXT NOT NULL,
+    "acao" "public"."CursosCertificadosLogAcao" NOT NULL,
+    "detalhes" VARCHAR(500),
+    "criadoEm" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "CursosCertificadosLogs_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "CursosCertificadosEmitidos_codigo_key" ON "public"."CursosCertificadosEmitidos"("codigo");
+
+-- CreateIndex
+CREATE INDEX "CursosCertificadosEmitidos_matriculaId_idx" ON "public"."CursosCertificadosEmitidos"("matriculaId");
+
+-- CreateIndex
+CREATE INDEX "CursosCertificadosEmitidos_emitidoPorId_idx" ON "public"."CursosCertificadosEmitidos"("emitidoPorId");
+
+-- CreateIndex
+CREATE INDEX "CursosCertificadosEmitidos_emitidoEm_idx" ON "public"."CursosCertificadosEmitidos"("emitidoEm");
+
+-- CreateIndex
+CREATE INDEX "CursosCertificadosLogs_certificadoId_idx" ON "public"."CursosCertificadosLogs"("certificadoId");
+
+-- CreateIndex
+CREATE INDEX "CursosCertificadosLogs_acao_idx" ON "public"."CursosCertificadosLogs"("acao");
+
+-- CreateIndex
+CREATE INDEX "CursosCertificadosLogs_criadoEm_idx" ON "public"."CursosCertificadosLogs"("criadoEm");
+
+-- AddForeignKey
+ALTER TABLE "public"."CursosCertificadosEmitidos" ADD CONSTRAINT "CursosCertificadosEmitidos_matriculaId_fkey" FOREIGN KEY ("matriculaId") REFERENCES "public"."CursosTurmasMatriculas"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."CursosCertificadosEmitidos" ADD CONSTRAINT "CursosCertificadosEmitidos_emitidoPorId_fkey" FOREIGN KEY ("emitidoPorId") REFERENCES "public"."Usuarios"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."CursosCertificadosLogs" ADD CONSTRAINT "CursosCertificadosLogs_certificadoId_fkey" FOREIGN KEY ("certificadoId") REFERENCES "public"."CursosCertificadosEmitidos"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20250206000000_add_formato_to_certificados_logs/migration.sql
+++ b/prisma/migrations/20250206000000_add_formato_to_certificados_logs/migration.sql
@@ -1,0 +1,10 @@
+ALTER TABLE "public"."CursosCertificadosLogs"
+ADD COLUMN "formato" "public"."CursosCertificadosTipos" NOT NULL DEFAULT 'DIGITAL';
+
+UPDATE "public"."CursosCertificadosLogs" AS logs
+SET "formato" = certificados."formato"
+FROM "public"."CursosCertificadosEmitidos" AS certificados
+WHERE logs."certificadoId" = certificados."id";
+
+ALTER TABLE "public"."CursosCertificadosLogs"
+ALTER COLUMN "formato" DROP DEFAULT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -47,6 +47,7 @@ model Usuarios {
   informacoes          UsuariosInformation?
   cursosComoInstrutor  Cursos[]             @relation("CursosInstrutor")
   turmasMatriculadas   CursosTurmasMatriculas[]
+  certificadosEmitidos CursosCertificadosEmitidos[] @relation("CursosCertificadosEmitidosEmitidoPor")
 
   @@index([status])
   @@index([role])
@@ -243,6 +244,7 @@ model CursosTurmasMatriculas {
   recuperacoes CursosTurmasRecuperacoes[]
   notas CursosNotas[]
   frequencias CursosFrequenciaAlunos[]
+  certificados CursosCertificadosEmitidos[]
 
   @@unique([turmaId, alunoId])
   @@index([alunoId])
@@ -1434,6 +1436,51 @@ enum CursosCertificadosTipos {
   IMPRESSO
   DIGITAL_E_IMPRESSO
   VERIFICAVEL
+}
+
+enum CursosCertificadosLogAcao {
+  EMISSAO
+  VISUALIZACAO
+}
+
+model CursosCertificadosEmitidos {
+  id             String                    @id @default(uuid())
+  matriculaId    String
+  codigo         String                    @unique @db.VarChar(20)
+  tipo           CursosCertificados
+  formato        CursosCertificadosTipos
+  cargaHoraria   Int
+  assinaturaUrl  String?                   @db.VarChar(2048)
+  alunoNome      String                    @db.VarChar(255)
+  alunoCpf       String?                   @db.VarChar(14)
+  cursoNome      String                    @db.VarChar(255)
+  turmaNome      String                    @db.VarChar(255)
+  emitidoPorId   String?
+  emitidoEm      DateTime                  @default(now())
+  observacoes    String?                   @db.VarChar(500)
+
+  matricula CursosTurmasMatriculas @relation(fields: [matriculaId], references: [id], onDelete: Cascade)
+  emitidoPor Usuarios?             @relation("CursosCertificadosEmitidosEmitidoPor", fields: [emitidoPorId], references: [id], onDelete: SetNull)
+  logs       CursosCertificadosLogs[]
+
+  @@index([matriculaId])
+  @@index([emitidoPorId])
+  @@index([emitidoEm])
+}
+
+model CursosCertificadosLogs {
+  id            String                     @id @default(uuid())
+  certificadoId String
+  acao          CursosCertificadosLogAcao
+  formato       CursosCertificadosTipos
+  detalhes      String?                    @db.VarChar(500)
+  criadoEm      DateTime                   @default(now())
+
+  certificado CursosCertificadosEmitidos @relation(fields: [certificadoId], references: [id], onDelete: Cascade)
+
+  @@index([certificadoId])
+  @@index([acao])
+  @@index([criadoEm])
 }
 
 enum EmpresasPlanoStatus {

--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -210,7 +210,14 @@ const options: Options = {
       },
       {
         name: 'Cursos',
-        tags: ['Cursos', 'Cursos - Turmas', 'Cursos - Aulas', 'Cursos - Notas', 'Cursos - Frequências'],
+        tags: [
+          'Cursos',
+          'Cursos - Turmas',
+          'Cursos - Aulas',
+          'Cursos - Notas',
+          'Cursos - Frequências',
+          'Cursos - Certificados',
+        ],
       },
       { name: 'Pagamentos', tags: ['MercadoPago - Assinaturas'] },
     ],
@@ -298,6 +305,24 @@ const options: Options = {
           enum: ['ONLINE', 'PRESENCIAL', 'LIVE', 'SEMIPRESENCIAL'],
           example: 'ONLINE',
           description: 'Formatos de entrega das turmas.',
+        },
+        CursosCertificados: {
+          type: 'string',
+          enum: ['SEM_CERTIFICADO', 'PARTICIPACAO', 'CONCLUSAO', 'APROVEITAMENTO', 'COMPETENCIA'],
+          example: 'CONCLUSAO',
+          description: 'Tipos de certificados acadêmicos disponíveis.',
+        },
+        CursosCertificadosTipos: {
+          type: 'string',
+          enum: ['DIGITAL', 'IMPRESSO', 'DIGITAL_E_IMPRESSO', 'VERIFICAVEL'],
+          example: 'DIGITAL',
+          description: 'Formato de disponibilização do certificado ao aluno.',
+        },
+        CursosCertificadosLogAcao: {
+          type: 'string',
+          enum: ['EMISSAO', 'VISUALIZACAO'],
+          example: 'EMISSAO',
+          description: 'Tipos de eventos registrados no histórico de certificados.',
         },
         CursosMateriais: {
           type: 'string',
@@ -1270,6 +1295,124 @@ const options: Options = {
               type: 'object',
               nullable: true,
               additionalProperties: true,
+            },
+          },
+        },
+        CursoCertificadoLog: {
+          type: 'object',
+          properties: {
+            id: { type: 'string', format: 'uuid' },
+            acao: { $ref: '#/components/schemas/CursosCertificadosLogAcao' },
+            formato: { $ref: '#/components/schemas/CursosCertificadosTipos' },
+            detalhes: { type: 'string', nullable: true },
+            criadoEm: { type: 'string', format: 'date-time' },
+          },
+        },
+        CursoCertificado: {
+          type: 'object',
+          properties: {
+            id: { type: 'string', format: 'uuid' },
+            codigo: { type: 'string', example: 'CERTAB12345' },
+            tipo: { $ref: '#/components/schemas/CursosCertificados' },
+            formato: { $ref: '#/components/schemas/CursosCertificadosTipos' },
+            cargaHoraria: { type: 'integer', example: 40 },
+            assinaturaUrl: { type: 'string', format: 'uri', nullable: true },
+            emitidoEm: { type: 'string', format: 'date-time' },
+            observacoes: { type: 'string', nullable: true },
+            aluno: {
+              type: 'object',
+              properties: {
+                id: { type: 'string', format: 'uuid' },
+                nome: { type: 'string', example: 'João da Silva' },
+                email: { type: 'string', format: 'email', example: 'joao@email.com' },
+                cpf: { type: 'string', nullable: true, example: '123.456.789-00' },
+                cpfMascarado: { type: 'string', nullable: true, example: '***.***.***-00' },
+                matricula: { type: 'string', nullable: true, example: 'MAT12345' },
+              },
+            },
+            curso: {
+              type: 'object',
+              properties: {
+                id: { type: 'integer', example: 1 },
+                nome: { type: 'string', example: 'Excel Avançado' },
+                codigo: { type: 'string', example: 'CRS1234' },
+                cargaHoraria: { type: 'integer', example: 40 },
+              },
+            },
+            turma: {
+              type: 'object',
+              properties: {
+                id: { type: 'string', format: 'uuid' },
+                nome: { type: 'string', example: 'Turma 2025/1' },
+                codigo: { type: 'string', example: 'TRAB1234' },
+              },
+            },
+            emitidoPor: {
+              type: 'object',
+              nullable: true,
+              properties: {
+                id: { type: 'string', format: 'uuid' },
+                nome: { type: 'string', example: 'Maria Oliveira' },
+                email: { type: 'string', format: 'email', example: 'maria@advancemais.com' },
+              },
+            },
+            logs: {
+              type: 'array',
+              items: { $ref: '#/components/schemas/CursoCertificadoLog' },
+            },
+          },
+        },
+        CursoCertificadoCreateInput: {
+          type: 'object',
+          required: ['matriculaId', 'tipo', 'formato'],
+          properties: {
+            matriculaId: { type: 'string', format: 'uuid' },
+            tipo: { $ref: '#/components/schemas/CursosCertificados' },
+            formato: { $ref: '#/components/schemas/CursosCertificadosTipos' },
+            cargaHoraria: { type: 'integer', minimum: 1, nullable: true, example: 40 },
+            assinaturaUrl: { type: 'string', format: 'uri', nullable: true },
+            observacoes: { type: 'string', nullable: true, maxLength: 500 },
+          },
+        },
+        CursoCertificadoResumoMatricula: {
+          type: 'object',
+          properties: {
+            matricula: {
+              type: 'object',
+              properties: {
+                id: { type: 'string', format: 'uuid' },
+                aluno: {
+                  type: 'object',
+                  properties: {
+                    id: { type: 'string', format: 'uuid' },
+                    nome: { type: 'string' },
+                    email: { type: 'string', format: 'email' },
+                    cpf: { type: 'string', nullable: true },
+                    matricula: { type: 'string', nullable: true },
+                  },
+                },
+              },
+            },
+            curso: {
+              type: 'object',
+              properties: {
+                id: { type: 'integer' },
+                nome: { type: 'string' },
+                codigo: { type: 'string' },
+                cargaHoraria: { type: 'integer' },
+              },
+            },
+            turma: {
+              type: 'object',
+              properties: {
+                id: { type: 'string', format: 'uuid' },
+                nome: { type: 'string' },
+                codigo: { type: 'string' },
+              },
+            },
+            certificados: {
+              type: 'array',
+              items: { $ref: '#/components/schemas/CursoCertificado' },
             },
           },
         },

--- a/src/modules/cursos/controllers/certificados.controller.ts
+++ b/src/modules/cursos/controllers/certificados.controller.ts
@@ -1,0 +1,288 @@
+import { Request, Response } from 'express';
+import { ZodError } from 'zod';
+
+import { certificadosService } from '../services/certificados.service';
+import {
+  codigoCertificadoSchema,
+  emitirCertificadoSchema,
+  listarCertificadosQuerySchema,
+} from '../validators/certificados.schema';
+
+const parseCursoId = (raw: unknown) => {
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    return null;
+  }
+
+  return parsed;
+};
+
+const parseTurmaId = (raw: unknown) => {
+  if (typeof raw !== 'string' || raw.trim().length === 0) {
+    return null;
+  }
+
+  return raw;
+};
+
+const parseMatriculaId = (raw: unknown) => {
+  if (typeof raw !== 'string' || raw.trim().length === 0) {
+    return null;
+  }
+
+  return raw;
+};
+
+const ensureSingleValue = (value: unknown) => {
+  if (Array.isArray(value)) {
+    return value[0];
+  }
+
+  return value;
+};
+
+export class CertificadosController {
+  static emitir = async (req: Request, res: Response) => {
+    const cursoId = parseCursoId(req.params.cursoId);
+    const turmaId = parseTurmaId(req.params.turmaId);
+
+    if (!cursoId || !turmaId) {
+      return res.status(400).json({
+        success: false,
+        code: 'VALIDATION_ERROR',
+        message: 'Identificadores de curso ou turma inválidos',
+      });
+    }
+
+    try {
+      const payload = emitirCertificadoSchema.parse(req.body);
+      const usuarioId = req.user?.id;
+
+      const certificado = await certificadosService.emitir(cursoId, turmaId, payload, usuarioId);
+
+      res.status(201).json(certificado);
+    } catch (error: any) {
+      if (error instanceof ZodError) {
+        return res.status(400).json({
+          success: false,
+          code: 'VALIDATION_ERROR',
+          message: 'Dados inválidos para emissão do certificado',
+          issues: error.flatten().fieldErrors,
+        });
+      }
+
+      if (error?.code === 'TURMA_NOT_FOUND' || error?.code === 'MATRICULA_NOT_FOUND') {
+        return res.status(404).json({
+          success: false,
+          code: error.code,
+          message: 'Turma ou matrícula não encontrada para emissão do certificado',
+        });
+      }
+
+      if (error?.code === 'INVALID_CARGA_HORARIA') {
+        return res.status(400).json({
+          success: false,
+          code: 'INVALID_CARGA_HORARIA',
+          message: 'Informe uma carga horária válida para o certificado',
+        });
+      }
+
+      res.status(500).json({
+        success: false,
+        code: 'CERTIFICADO_EMITIR_ERROR',
+        message: 'Erro ao emitir certificado para a turma',
+        error: error?.message,
+      });
+    }
+  };
+
+  static listar = async (req: Request, res: Response) => {
+    const cursoId = parseCursoId(req.params.cursoId);
+    const turmaId = parseTurmaId(req.params.turmaId);
+
+    if (!cursoId || !turmaId) {
+      return res.status(400).json({
+        success: false,
+        code: 'VALIDATION_ERROR',
+        message: 'Identificadores de curso ou turma inválidos',
+      });
+    }
+
+    const parsedQuery = listarCertificadosQuerySchema.safeParse({
+      matriculaId: ensureSingleValue(req.query.matriculaId),
+      tipo: ensureSingleValue(req.query.tipo),
+      formato: ensureSingleValue(req.query.formato),
+    });
+
+    if (!parsedQuery.success) {
+      return res.status(400).json({
+        success: false,
+        code: 'VALIDATION_ERROR',
+        message: 'Parâmetros de consulta inválidos',
+        issues: parsedQuery.error.flatten().fieldErrors,
+      });
+    }
+
+    try {
+      const certificados = await certificadosService.listar(cursoId, turmaId, parsedQuery.data);
+      res.json({ data: certificados });
+    } catch (error: any) {
+      if (error?.code === 'TURMA_NOT_FOUND') {
+        return res.status(404).json({
+          success: false,
+          code: 'TURMA_NOT_FOUND',
+          message: 'Turma não encontrada para o curso informado',
+        });
+      }
+
+      res.status(500).json({
+        success: false,
+        code: 'CERTIFICADO_LIST_ERROR',
+        message: 'Erro ao listar certificados da turma',
+        error: error?.message,
+      });
+    }
+  };
+
+  static listarPorMatricula = async (req: Request, res: Response) => {
+    const matriculaId = parseMatriculaId(req.params.matriculaId);
+
+    if (!matriculaId) {
+      return res.status(400).json({
+        success: false,
+        code: 'VALIDATION_ERROR',
+        message: 'Identificador da matrícula inválido',
+      });
+    }
+
+    try {
+      const resultado = await certificadosService.listarPorMatricula(matriculaId, undefined, {
+        permitirAdmin: true,
+      });
+      res.json(resultado);
+    } catch (error: any) {
+      if (error?.code === 'MATRICULA_NOT_FOUND') {
+        return res.status(404).json({
+          success: false,
+          code: 'MATRICULA_NOT_FOUND',
+          message: 'Matrícula não encontrada',
+        });
+      }
+
+      res.status(500).json({
+        success: false,
+        code: 'CERTIFICADO_MATRICULA_ERROR',
+        message: 'Erro ao consultar certificados da matrícula',
+        error: error?.message,
+      });
+    }
+  };
+
+  static listarMePorMatricula = async (req: Request, res: Response) => {
+    const matriculaId = parseMatriculaId(req.params.matriculaId);
+
+    if (!matriculaId) {
+      return res.status(400).json({
+        success: false,
+        code: 'VALIDATION_ERROR',
+        message: 'Identificador da matrícula inválido',
+      });
+    }
+
+    const usuarioId = req.user?.id;
+
+    if (!usuarioId) {
+      return res.status(401).json({
+        success: false,
+        code: 'UNAUTHORIZED',
+        message: 'Usuário não autenticado',
+      });
+    }
+
+    try {
+      const resultado = await certificadosService.listarPorMatricula(matriculaId, usuarioId);
+      res.json(resultado);
+    } catch (error: any) {
+      if (error?.code === 'MATRICULA_NOT_FOUND') {
+        return res.status(404).json({
+          success: false,
+          code: 'MATRICULA_NOT_FOUND',
+          message: 'Matrícula não encontrada',
+        });
+      }
+
+      if (error?.code === 'FORBIDDEN') {
+        return res.status(403).json({
+          success: false,
+          code: 'FORBIDDEN',
+          message: 'Você não possui acesso aos certificados desta matrícula',
+        });
+      }
+
+      res.status(500).json({
+        success: false,
+        code: 'CERTIFICADO_MATRICULA_ERROR',
+        message: 'Erro ao consultar certificados da matrícula',
+        error: error?.message,
+      });
+    }
+  };
+
+  static listarMe = async (req: Request, res: Response) => {
+    const usuarioId = req.user?.id;
+
+    if (!usuarioId) {
+      return res.status(401).json({
+        success: false,
+        code: 'UNAUTHORIZED',
+        message: 'Usuário não autenticado',
+      });
+    }
+
+    try {
+      const certificados = await certificadosService.listarDoAluno(usuarioId);
+      res.json({ data: certificados });
+    } catch (error: any) {
+      res.status(500).json({
+        success: false,
+        code: 'CERTIFICADO_ME_ERROR',
+        message: 'Erro ao consultar certificados do aluno',
+        error: error?.message,
+      });
+    }
+  };
+
+  static verificarPorCodigo = async (req: Request, res: Response) => {
+    const parsedCodigo = codigoCertificadoSchema.safeParse(req.params.codigo);
+
+    if (!parsedCodigo.success) {
+      return res.status(400).json({
+        success: false,
+        code: 'VALIDATION_ERROR',
+        message: 'Código do certificado inválido',
+        issues: parsedCodigo.error.flatten().fieldErrors,
+      });
+    }
+
+    try {
+      const certificado = await certificadosService.verificarPorCodigo(parsedCodigo.data);
+
+      if (!certificado) {
+        return res.status(404).json({
+          success: false,
+          code: 'CERTIFICADO_NOT_FOUND',
+          message: 'Certificado não encontrado para o código informado',
+        });
+      }
+
+      res.json(certificado);
+    } catch (error: any) {
+      res.status(500).json({
+        success: false,
+        code: 'CERTIFICADO_VERIFICAR_ERROR',
+        message: 'Erro ao verificar certificado pelo código',
+        error: error?.message,
+      });
+    }
+  };
+}

--- a/src/modules/cursos/services/certificados.mapper.ts
+++ b/src/modules/cursos/services/certificados.mapper.ts
@@ -1,0 +1,130 @@
+import { Prisma } from '@prisma/client';
+
+const certificadoWithRelations = Prisma.validator<Prisma.CursosCertificadosEmitidosDefaultArgs>()({
+  include: {
+    emitidoPor: {
+      select: {
+        id: true,
+        nomeCompleto: true,
+        email: true,
+      },
+    },
+    matricula: {
+      select: {
+        id: true,
+        aluno: {
+          select: {
+            id: true,
+            nomeCompleto: true,
+            email: true,
+            cpf: true,
+            informacoes: {
+              select: {
+                matricula: true,
+              },
+            },
+          },
+        },
+        turma: {
+          select: {
+            id: true,
+            nome: true,
+            codigo: true,
+            curso: {
+              select: {
+                id: true,
+                nome: true,
+                codigo: true,
+                cargaHoraria: true,
+              },
+            },
+          },
+        },
+      },
+    },
+    logs: {
+      orderBy: { criadoEm: 'desc' },
+    },
+  },
+});
+
+export type CertificadoWithRelations = Prisma.CursosCertificadosEmitidosGetPayload<
+  typeof certificadoWithRelations
+>;
+
+const digitsOnly = (value?: string | null) => value?.replace(/\D/g, '') ?? '';
+
+const formatCpf = (cpf?: string | null) => {
+  const digits = digitsOnly(cpf);
+  if (digits.length !== 11) {
+    return cpf ?? null;
+  }
+
+  return `${digits.slice(0, 3)}.${digits.slice(3, 6)}.${digits.slice(6, 9)}-${digits.slice(9)}`;
+};
+
+const maskCpfValue = (cpf?: string | null) => {
+  const digits = digitsOnly(cpf);
+  if (digits.length !== 11) {
+    return cpf ?? null;
+  }
+
+  return `***.***.***-${digits.slice(-2)}`;
+};
+
+export const mapCertificado = (
+  certificado: CertificadoWithRelations,
+  { maskCpf = false, includeLogs = true }: { maskCpf?: boolean; includeLogs?: boolean } = {},
+) => {
+  const formattedCpf = formatCpf(certificado.alunoCpf);
+  const maskedCpf = maskCpfValue(certificado.alunoCpf);
+
+  return {
+    id: certificado.id,
+    codigo: certificado.codigo,
+    tipo: certificado.tipo,
+    formato: certificado.formato,
+    cargaHoraria: certificado.cargaHoraria,
+    assinaturaUrl: certificado.assinaturaUrl,
+    emitidoEm: certificado.emitidoEm,
+    observacoes: certificado.observacoes,
+    aluno: {
+      id: certificado.matricula.aluno.id,
+      nome: certificado.matricula.aluno.nomeCompleto,
+      email: certificado.matricula.aluno.email,
+      cpf: maskCpf ? null : formattedCpf,
+      cpfMascarado: maskedCpf,
+      matricula: certificado.matricula.aluno.informacoes?.matricula ?? null,
+    },
+    curso: {
+      id: certificado.matricula.turma.curso.id,
+      nome: certificado.matricula.turma.curso.nome,
+      codigo: certificado.matricula.turma.curso.codigo,
+      cargaHoraria: certificado.cargaHoraria,
+    },
+    turma: {
+      id: certificado.matricula.turma.id,
+      nome: certificado.matricula.turma.nome,
+      codigo: certificado.matricula.turma.codigo,
+    },
+    emitidoPor: certificado.emitidoPor
+      ? {
+          id: certificado.emitidoPor.id,
+          nome: certificado.emitidoPor.nomeCompleto,
+          email: certificado.emitidoPor.email,
+        }
+      : null,
+    logs:
+      includeLogs && certificado.logs
+        ? certificado.logs.map((log) => ({
+            id: log.id,
+            acao: log.acao,
+            formato: log.formato,
+            detalhes: log.detalhes,
+            criadoEm: log.criadoEm,
+          }))
+        : [],
+  };
+};
+
+export { certificadoWithRelations };

--- a/src/modules/cursos/services/certificados.service.ts
+++ b/src/modules/cursos/services/certificados.service.ts
@@ -1,0 +1,288 @@
+import {
+  CursosCertificados,
+  CursosCertificadosLogAcao,
+  CursosCertificadosTipos,
+  Prisma,
+} from '@prisma/client';
+
+import { prisma } from '@/config/prisma';
+import { logger } from '@/utils/logger';
+
+import { generateUniqueCertificateCode } from '../utils/code-generator';
+import { certificadoWithRelations, mapCertificado } from './certificados.mapper';
+
+const certificadosLogger = logger.child({ module: 'CursosCertificadosService' });
+
+type PrismaClientOrTx = Prisma.TransactionClient | typeof prisma;
+
+type EmitirCertificadoData = {
+  matriculaId: string;
+  tipo: CursosCertificados;
+  formato: CursosCertificadosTipos;
+  cargaHoraria?: number | null;
+  assinaturaUrl?: string | null;
+  observacoes?: string | null;
+};
+
+type ListCertificadosFilters = {
+  matriculaId?: string;
+  tipo?: CursosCertificados;
+  formato?: CursosCertificadosTipos;
+};
+
+const ensureTurmaBelongsToCurso = async (client: PrismaClientOrTx, cursoId: number, turmaId: string) => {
+  const turma = await client.cursosTurmas.findFirst({
+    where: { id: turmaId, cursoId },
+    select: { id: true },
+  });
+
+  if (!turma) {
+    const error = new Error('Turma não encontrada para o curso informado');
+    (error as any).code = 'TURMA_NOT_FOUND';
+    throw error;
+  }
+};
+
+const ensureMatriculaBelongsToTurma = async (
+  client: PrismaClientOrTx,
+  turmaId: string,
+  matriculaId: string,
+) => {
+  const matricula = await client.cursosTurmasMatriculas.findFirst({
+    where: { id: matriculaId, turmaId },
+    select: { id: true },
+  });
+
+  if (!matricula) {
+    const error = new Error('Matrícula não encontrada para a turma informada');
+    (error as any).code = 'MATRICULA_NOT_FOUND';
+    throw error;
+  }
+};
+
+export const certificadosService = {
+  async emitir(
+    cursoId: number,
+    turmaId: string,
+    data: EmitirCertificadoData,
+    emitidoPorId?: string,
+  ) {
+    return prisma.$transaction(async (tx) => {
+      await ensureTurmaBelongsToCurso(tx, cursoId, turmaId);
+      await ensureMatriculaBelongsToTurma(tx, turmaId, data.matriculaId);
+
+      const matricula = await tx.cursosTurmasMatriculas.findFirst({
+        where: { id: data.matriculaId },
+        include: {
+          aluno: {
+            select: {
+              id: true,
+              nomeCompleto: true,
+              email: true,
+              cpf: true,
+            },
+          },
+          turma: {
+            select: {
+              id: true,
+              nome: true,
+              codigo: true,
+              curso: {
+                select: {
+                  id: true,
+                  nome: true,
+                  codigo: true,
+                  cargaHoraria: true,
+                },
+              },
+            },
+          },
+        },
+      });
+
+      if (!matricula) {
+        const error = new Error('Matrícula não encontrada');
+        (error as any).code = 'MATRICULA_NOT_FOUND';
+        throw error;
+      }
+
+      const cargaHoraria = data.cargaHoraria ?? matricula.turma.curso.cargaHoraria ?? 0;
+      if (!Number.isFinite(cargaHoraria) || cargaHoraria <= 0) {
+        const error = new Error('Carga horária inválida para o certificado');
+        (error as any).code = 'INVALID_CARGA_HORARIA';
+        throw error;
+      }
+
+      const codigo = await generateUniqueCertificateCode(tx, certificadosLogger);
+
+      const certificado = await tx.cursosCertificadosEmitidos.create({
+        data: {
+          matriculaId: data.matriculaId,
+          codigo,
+          tipo: data.tipo,
+          formato: data.formato,
+          cargaHoraria,
+          assinaturaUrl: data.assinaturaUrl ?? null,
+          alunoNome: matricula.aluno.nomeCompleto,
+          alunoCpf: matricula.aluno.cpf,
+          cursoNome: matricula.turma.curso.nome,
+          turmaNome: matricula.turma.nome,
+          emitidoPorId: emitidoPorId ?? null,
+          observacoes: data.observacoes ?? null,
+          logs: {
+            create: {
+              acao: CursosCertificadosLogAcao.EMISSAO,
+              formato: data.formato,
+              detalhes: emitidoPorId ? `Emitido por usuário ${emitidoPorId}` : null,
+            },
+          },
+        },
+        ...certificadoWithRelations,
+      });
+
+      certificadosLogger.info(
+        { certificadoId: certificado.id, matriculaId: data.matriculaId, turmaId },
+        'Certificado emitido com sucesso',
+      );
+
+      return mapCertificado(certificado);
+    });
+  },
+
+  async listar(cursoId: number, turmaId: string, filtros: ListCertificadosFilters = {}) {
+    await ensureTurmaBelongsToCurso(prisma, cursoId, turmaId);
+
+    const certificados = await prisma.cursosCertificadosEmitidos.findMany({
+      where: {
+        matricula: {
+          turmaId,
+          turma: { cursoId },
+        },
+        ...(filtros.matriculaId ? { matriculaId: filtros.matriculaId } : {}),
+        ...(filtros.tipo ? { tipo: filtros.tipo } : {}),
+        ...(filtros.formato ? { formato: filtros.formato } : {}),
+      },
+      orderBy: { emitidoEm: 'desc' },
+      ...certificadoWithRelations,
+    });
+
+    return certificados.map((item) => mapCertificado(item));
+  },
+
+  async listarPorMatricula(
+    matriculaId: string,
+    requesterId?: string,
+    { permitirAdmin = false }: { permitirAdmin?: boolean } = {},
+  ) {
+    const matricula = await prisma.cursosTurmasMatriculas.findUnique({
+      where: { id: matriculaId },
+      include: {
+        aluno: {
+          select: {
+            id: true,
+            nomeCompleto: true,
+            email: true,
+            cpf: true,
+            informacoes: {
+              select: { matricula: true },
+            },
+          },
+        },
+        turma: {
+          select: {
+            id: true,
+            nome: true,
+            codigo: true,
+            curso: {
+              select: {
+                id: true,
+                nome: true,
+                codigo: true,
+                cargaHoraria: true,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    if (!matricula) {
+      const error = new Error('Matrícula não encontrada');
+      (error as any).code = 'MATRICULA_NOT_FOUND';
+      throw error;
+    }
+
+    if (requesterId && matricula.alunoId !== requesterId && !permitirAdmin) {
+      const error = new Error('Acesso negado');
+      (error as any).code = 'FORBIDDEN';
+      throw error;
+    }
+
+    const certificados = await prisma.cursosCertificadosEmitidos.findMany({
+      where: { matriculaId },
+      orderBy: { emitidoEm: 'desc' },
+      ...certificadoWithRelations,
+    });
+
+    return {
+      matricula: {
+        id: matricula.id,
+        aluno: {
+          id: matricula.aluno.id,
+          nome: matricula.aluno.nomeCompleto,
+          email: matricula.aluno.email,
+          cpf: matricula.aluno.cpf,
+          matricula: matricula.aluno.informacoes?.matricula ?? null,
+        },
+      },
+      curso: {
+        id: matricula.turma.curso.id,
+        nome: matricula.turma.curso.nome,
+        codigo: matricula.turma.curso.codigo,
+        cargaHoraria: matricula.turma.curso.cargaHoraria,
+      },
+      turma: {
+        id: matricula.turma.id,
+        nome: matricula.turma.nome,
+        codigo: matricula.turma.codigo,
+      },
+      certificados: certificados.map((item) => mapCertificado(item)),
+    } as const;
+  },
+
+  async listarDoAluno(usuarioId: string) {
+    const certificados = await prisma.cursosCertificadosEmitidos.findMany({
+      where: { matricula: { alunoId: usuarioId } },
+      orderBy: { emitidoEm: 'desc' },
+      ...certificadoWithRelations,
+    });
+
+    return certificados.map((item) => mapCertificado(item));
+  },
+
+  async verificarPorCodigo(codigo: string) {
+    return prisma.$transaction(async (tx) => {
+      const certificado = await tx.cursosCertificadosEmitidos.findUnique({
+        where: { codigo },
+        ...certificadoWithRelations,
+      });
+
+      if (!certificado) {
+        return null;
+      }
+
+      await tx.cursosCertificadosLogs.create({
+        data: {
+          certificadoId: certificado.id,
+          acao: CursosCertificadosLogAcao.VISUALIZACAO,
+          formato: CursosCertificadosTipos.VERIFICAVEL,
+          detalhes: 'Consulta por código do certificado',
+        },
+      });
+
+      certificadosLogger.info({ codigo }, 'Certificado consultado por código');
+
+      return mapCertificado(certificado, { maskCpf: true, includeLogs: false });
+    });
+  },
+};

--- a/src/modules/cursos/utils/code-generator.ts
+++ b/src/modules/cursos/utils/code-generator.ts
@@ -94,3 +94,22 @@ export const generateUniqueEnrollmentCode = async (
     logger,
   );
 };
+
+export const generateUniqueCertificateCode = async (
+  tx: Prisma.TransactionClient,
+  logger?: AppLogger,
+) => {
+  return attemptUniqueCode(
+    10,
+    () => `CERT${randomPrefix(2)}${randomNumber(5)}`,
+    async (candidate) => {
+      const existing = await tx.cursosCertificadosEmitidos.findUnique({
+        where: { codigo: candidate },
+        select: { id: true },
+      });
+      return !existing;
+    },
+    () => `CERT${withFallback(2, 6)}`,
+    logger,
+  );
+};

--- a/src/modules/cursos/validators/certificados.schema.ts
+++ b/src/modules/cursos/validators/certificados.schema.ts
@@ -1,0 +1,52 @@
+import { CursosCertificados, CursosCertificadosTipos } from '@prisma/client';
+import { z } from 'zod';
+
+const optionalUrlSchema = z
+  .string({ invalid_type_error: 'assinaturaUrl deve ser uma URL válida' })
+  .trim()
+  .url('assinaturaUrl deve ser uma URL válida')
+  .max(2048, 'assinaturaUrl deve conter no máximo 2048 caracteres')
+  .optional()
+  .or(
+    z
+      .literal('')
+      .transform(() => undefined),
+  )
+  .or(z.null().transform(() => undefined));
+
+export const emitirCertificadoSchema = z.object({
+  matriculaId: z.string().uuid('Identificador da matrícula inválido'),
+  tipo: z.nativeEnum(CursosCertificados, {
+    invalid_type_error: 'Tipo de certificado inválido',
+  }),
+  formato: z.nativeEnum(CursosCertificadosTipos, {
+    invalid_type_error: 'Formato de certificado inválido',
+  }),
+  cargaHoraria: z
+    .number({ invalid_type_error: 'Carga horária deve ser um número' })
+    .int('Carga horária deve ser um número inteiro')
+    .min(1, 'Carga horária mínima é 1')
+    .max(1000, 'Carga horária máxima suportada é 1000')
+    .optional(),
+  assinaturaUrl: optionalUrlSchema,
+  observacoes: z
+    .string({ invalid_type_error: 'Observações devem ser um texto' })
+    .trim()
+    .max(500, 'Observações devem conter no máximo 500 caracteres')
+    .nullish(),
+});
+
+export const listarCertificadosQuerySchema = z.object({
+  matriculaId: z.string().uuid('Identificador da matrícula inválido').optional(),
+  tipo: z.nativeEnum(CursosCertificados).optional(),
+  formato: z.nativeEnum(CursosCertificadosTipos).optional(),
+});
+
+export const codigoCertificadoSchema = z
+  .string({ invalid_type_error: 'Código do certificado deve ser um texto' })
+  .trim()
+  .min(6, 'Código do certificado deve conter ao menos 6 caracteres')
+  .max(32, 'Código do certificado deve conter no máximo 32 caracteres');
+
+export type EmitirCertificadoInput = z.infer<typeof emitirCertificadoSchema>;
+export type ListarCertificadosQuery = z.infer<typeof listarCertificadosQuerySchema>;


### PR DESCRIPTION
## Summary
- adicionar coluna de formato nos logs de certificados e migrar dados existentes para refletir o formato do certificado emitido
- propagar o formato do certificado em todos os eventos registrados e respostas da API, inclusive na consulta pública por código
- atualizar o esquema OpenAPI para documentar o formato em cada entrada de log

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d20735564c83328d4b24833f2f9472