### PR TITLE
feat: adicionar contexto de aplicação aos scripts do website

### DIFF
--- a/prisma/migrations/202502111200_add_website_script_aplicacao/migration.sql
+++ b/prisma/migrations/202502111200_add_website_script_aplicacao/migration.sql
@@ -1,0 +1,10 @@
+-- CreateEnum
+CREATE TYPE "public"."WebsiteScriptAplicacao" AS ENUM ('WEBSITE', 'DASHBOARD');
+
+-- AlterTable
+ALTER TABLE "public"."WebsiteScript"
+  ADD COLUMN "aplicacao" "public"."WebsiteScriptAplicacao" NOT NULL DEFAULT 'WEBSITE';
+
+-- CreateIndex
+CREATE INDEX "WebsiteScript_aplicacao_orientacao_status_idx"
+  ON "public"."WebsiteScript"("aplicacao", "orientacao", "status");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1047,12 +1047,14 @@ model WebsiteScript {
   nome        String?
   descricao   String?
   codigo      String                    @db.Text
+  aplicacao   WebsiteScriptAplicacao    @default(WEBSITE)
   orientacao  WebsiteScriptOrientation
   status      WebsiteStatus             @default(RASCUNHO)
   criadoEm    DateTime                  @default(now())
   atualizadoEm DateTime                 @updatedAt
 
   @@index([orientacao, status])
+  @@index([aplicacao, orientacao, status])
 }
 
 model WebsitePlaninhas {
@@ -1306,6 +1308,11 @@ enum WebsiteScriptOrientation {
   HEADER
   BODY
   FOOTER
+}
+
+enum WebsiteScriptAplicacao {
+  WEBSITE
+  DASHBOARD
 }
 
 // ===============================

--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -3142,6 +3142,12 @@ const options: Options = {
           example: 'HEADER',
           description: 'Define em qual parte do documento o script será injetado.',
         },
+        WebsiteScriptAplicacao: {
+          type: 'string',
+          enum: ['WEBSITE', 'DASHBOARD'],
+          example: 'WEBSITE',
+          description: 'Determina onde o script será utilizado (site público ou dashboard).',
+        },
         WebsiteScript: {
           type: 'object',
           properties: {
@@ -3160,6 +3166,9 @@ const options: Options = {
               type: 'string',
               description: 'Código completo do script/pixel a ser injetado.',
               example: '<script>/* código do pixel */</script>',
+            },
+            aplicacao: {
+              $ref: '#/components/schemas/WebsiteScriptAplicacao',
             },
             orientacao: {
               $ref: '#/components/schemas/WebsiteScriptOrientation',
@@ -3181,7 +3190,7 @@ const options: Options = {
         },
         WebsiteScriptCreateInput: {
           type: 'object',
-          required: ['codigo', 'orientacao'],
+          required: ['codigo', 'aplicacao', 'orientacao'],
           properties: {
             nome: {
               type: 'string',
@@ -3197,6 +3206,9 @@ const options: Options = {
               type: 'string',
               description: 'Conteúdo do script/pixel. Aceita HTML e JavaScript.',
               example: '<script>/* código do pixel */</script>',
+            },
+            aplicacao: {
+              $ref: '#/components/schemas/WebsiteScriptAplicacao',
             },
             orientacao: {
               $ref: '#/components/schemas/WebsiteScriptOrientation',
@@ -3226,6 +3238,9 @@ const options: Options = {
               type: 'string',
               description: 'Conteúdo atualizado do script/pixel.',
               example: '<script>/* novo código */</script>',
+            },
+            aplicacao: {
+              $ref: '#/components/schemas/WebsiteScriptAplicacao',
             },
             orientacao: {
               $ref: '#/components/schemas/WebsiteScriptOrientation',

--- a/src/modules/website/routes/scripts.ts
+++ b/src/modules/website/routes/scripts.ts
@@ -14,6 +14,11 @@ const router = Router();
  *     tags: [Website - Scripts]
  *     parameters:
  *       - in: query
+ *         name: aplicacao
+ *         description: Filtro pelo contexto de uso do script
+ *         schema:
+ *           $ref: '#/components/schemas/WebsiteScriptAplicacao'
+ *       - in: query
  *         name: orientacao
  *         description: Filtro pela área onde o script será injetado
  *         schema:
@@ -50,7 +55,7 @@ const router = Router();
  *       - lang: cURL
  *         label: Exemplo
  *         source: |
- *           curl -X GET "http://localhost:3000/api/v1/website/scripts?orientacao=HEADER"
+ *           curl -X GET "http://localhost:3000/api/v1/website/scripts?aplicacao=WEBSITE&orientacao=HEADER"
  */
 router.get('/', publicCache, WebsiteScriptsController.list);
 
@@ -133,7 +138,7 @@ router.get('/:id', publicCache, WebsiteScriptsController.get);
  *           curl -X POST "http://localhost:3000/api/v1/website/scripts" \\
  *            -H "Authorization: Bearer <TOKEN>" \\
  *            -H "Content-Type: application/json" \\
- *            -d '{"nome":"Facebook Pixel","codigo":"<script>...</script>","orientacao":"HEADER","status":"PUBLICADO"}'
+ *            -d '{"nome":"Facebook Pixel","codigo":"<script>...</script>","aplicacao":"WEBSITE","orientacao":"HEADER","status":"PUBLICADO"}'
  */
 router.post(
   '/',
@@ -193,7 +198,7 @@ router.post(
  *           curl -X PUT "http://localhost:3000/api/v1/website/scripts/{id}" \\
  *            -H "Authorization: Bearer <TOKEN>" \\
  *            -H "Content-Type: application/json" \\
- *            -d '{"status":false}'
+ *            -d '{"status":false,"aplicacao":"DASHBOARD"}'
  */
 router.put(
   '/:id',

--- a/src/modules/website/services/scripts.service.ts
+++ b/src/modules/website/services/scripts.service.ts
@@ -1,4 +1,9 @@
-import { Prisma, WebsiteScriptOrientation, WebsiteStatus } from '@prisma/client';
+import {
+  Prisma,
+  WebsiteScriptAplicacao,
+  WebsiteScriptOrientation,
+  WebsiteStatus,
+} from '@prisma/client';
 
 import { prisma } from '@/config/prisma';
 import { WEBSITE_CACHE_TTL } from '@/modules/website/config';
@@ -7,18 +12,20 @@ import { getCache, invalidateCacheByPrefix, setCache } from '@/utils/cache';
 const CACHE_PREFIX = 'website:scripts:list';
 
 type ListFilters = {
+  aplicacao?: WebsiteScriptAplicacao;
   orientacao?: WebsiteScriptOrientation;
   status?: WebsiteStatus;
 };
 
-const buildCacheKey = ({ orientacao, status }: ListFilters = {}) =>
-  `${CACHE_PREFIX}:${orientacao ?? 'all'}:${status ?? 'all'}`;
+const buildCacheKey = ({ aplicacao, orientacao, status }: ListFilters = {}) =>
+  `${CACHE_PREFIX}:${aplicacao ?? 'all'}:${orientacao ?? 'all'}:${status ?? 'all'}`;
 
 const selectFields = {
   id: true,
   nome: true,
   descricao: true,
   codigo: true,
+  aplicacao: true,
   orientacao: true,
   status: true,
   criadoEm: true,
@@ -32,6 +39,9 @@ export const websiteScriptsService = {
     if (cached) return cached;
 
     const where: Record<string, any> = {};
+    if (filters.aplicacao) {
+      where.aplicacao = filters.aplicacao;
+    }
     if (filters.orientacao) {
       where.orientacao = filters.orientacao;
     }
@@ -62,6 +72,7 @@ export const websiteScriptsService = {
     nome?: string;
     descricao?: string;
     codigo: string;
+    aplicacao: WebsiteScriptAplicacao;
     orientacao: WebsiteScriptOrientation;
     status?: WebsiteStatus;
   }) => {
@@ -70,6 +81,7 @@ export const websiteScriptsService = {
         nome: data.nome,
         descricao: data.descricao,
         codigo: data.codigo,
+        aplicacao: data.aplicacao,
         orientacao: data.orientacao,
         status: data.status ?? 'RASCUNHO',
       },
@@ -85,6 +97,7 @@ export const websiteScriptsService = {
       nome?: string;
       descricao?: string;
       codigo?: string;
+      aplicacao?: WebsiteScriptAplicacao;
       orientacao?: WebsiteScriptOrientation;
       status?: WebsiteStatus;
     },


### PR DESCRIPTION
## Resumo
- adicionar campo `aplicacao` ao modelo de WebsiteScript com enum e índice dedicado
- ajustar serviços e validações para exigir a aplicação e permitir filtros por contexto
- documentar novas opções no Swagger/Redoc e exemplos de uso da API

## Testes
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d2ad0d54248332b3f509a113ce301d