### PR TITLE
Renomeia banimentos para bloqueios em toda a plataforma

### DIFF
--- a/prisma/migrations/20250922180135_prod/migration.sql
+++ b/prisma/migrations/20250922180135_prod/migration.sql
@@ -23,7 +23,7 @@ CREATE TYPE "public"."TiposDeUsuarios" AS ENUM ('PESSOA_FISICA', 'PESSOA_JURIDIC
 CREATE TYPE "public"."Roles" AS ENUM ('ADMIN', 'MODERADOR', 'FINANCEIRO', 'PROFESSOR', 'EMPRESA', 'PEDAGOGICO', 'RECRUTADOR', 'PSICOLOGO', 'ALUNO_CANDIDATO');
 
 -- CreateEnum
-CREATE TYPE "public"."Status" AS ENUM ('ATIVO', 'INATIVO', 'BANIDO', 'PENDENTE', 'SUSPENSO');
+CREATE TYPE "public"."Status" AS ENUM ('ATIVO', 'INATIVO', 'BLOQUEADO', 'PENDENTE', 'SUSPENSO');
 
 -- CreateEnum
 CREATE TYPE "public"."TiposDeEmails" AS ENUM ('BOAS_VINDAS', 'RECUPERACAO_SENHA', 'VERIFICACAO_EMAIL', 'NOTIFICACAO_SISTEMA');
@@ -104,16 +104,16 @@ CREATE TYPE "public"."EmpresasPlanoModo" AS ENUM ('TESTE', 'PARCEIRO');
 CREATE TYPE "public"."EmpresasPlanoOrigin" AS ENUM ('CHECKOUT', 'ADMIN', 'IMPORT');
 
 -- CreateEnum
-CREATE TYPE "public"."TiposDeBanimentos" AS ENUM ('TEMPORARIO', 'PERMANENTE', 'RESTRICAO_DE_RECURSO');
+CREATE TYPE "public"."TiposDeBloqueios" AS ENUM ('TEMPORARIO', 'PERMANENTE', 'RESTRICAO_DE_RECURSO');
 
 -- CreateEnum
-CREATE TYPE "public"."StatusDeBanimentos" AS ENUM ('ATIVO', 'EM_REVISAO', 'REVOGADO', 'EXPIRADO');
+CREATE TYPE "public"."StatusDeBloqueios" AS ENUM ('ATIVO', 'EM_REVISAO', 'REVOGADO', 'EXPIRADO');
 
 -- CreateEnum
-CREATE TYPE "public"."MotivosDeBanimentos" AS ENUM ('SPAM', 'VIOLACAO_POLITICAS', 'FRAUDE', 'ABUSO_DE_RECURSOS', 'OUTROS');
+CREATE TYPE "public"."MotivosDeBloqueios" AS ENUM ('SPAM', 'VIOLACAO_POLITICAS', 'FRAUDE', 'ABUSO_DE_RECURSOS', 'OUTROS');
 
 -- CreateEnum
-CREATE TYPE "public"."AcoesDeLogDeBanimento" AS ENUM ('CRIACAO', 'ATUALIZACAO', 'REVOGACAO', 'REAVALIACAO');
+CREATE TYPE "public"."AcoesDeLogDeBloqueio" AS ENUM ('CRIACAO', 'ATUALIZACAO', 'REVOGACAO', 'REAVALIACAO');
 
 -- CreateTable
 CREATE TABLE "public"."Usuarios" (
@@ -544,32 +544,32 @@ CREATE TABLE "public"."LogsPagamentosDeAssinaturas" (
 );
 
 -- CreateTable
-CREATE TABLE "public"."UsuariosEmBanimentos" (
+CREATE TABLE "public"."UsuariosEmBloqueios" (
     "id" TEXT NOT NULL,
     "usuarioId" TEXT NOT NULL,
     "aplicadoPorId" TEXT NOT NULL,
-    "tipo" "public"."TiposDeBanimentos" NOT NULL,
-    "motivo" "public"."MotivosDeBanimentos" NOT NULL,
-    "status" "public"."StatusDeBanimentos" NOT NULL DEFAULT 'ATIVO',
+    "tipo" "public"."TiposDeBloqueios" NOT NULL,
+    "motivo" "public"."MotivosDeBloqueios" NOT NULL,
+    "status" "public"."StatusDeBloqueios" NOT NULL DEFAULT 'ATIVO',
     "inicio" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "fim" TIMESTAMP(3),
     "observacoes" VARCHAR(500),
     "criadoEm" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "atualizadoEm" TIMESTAMP(3) NOT NULL,
 
-    CONSTRAINT "UsuariosEmBanimentos_pkey" PRIMARY KEY ("id")
+    CONSTRAINT "UsuariosEmBloqueios_pkey" PRIMARY KEY ("id")
 );
 
 -- CreateTable
-CREATE TABLE "public"."UsuariosEmBanimentosLogs" (
+CREATE TABLE "public"."UsuariosEmBloqueiosLogs" (
     "id" TEXT NOT NULL,
-    "banimentoId" TEXT NOT NULL,
-    "acao" "public"."AcoesDeLogDeBanimento" NOT NULL,
+    "bloqueioId" TEXT NOT NULL,
+    "acao" "public"."AcoesDeLogDeBloqueio" NOT NULL,
     "descricao" VARCHAR(500),
     "criadoPorId" TEXT NOT NULL,
     "criadoEm" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
 
-    CONSTRAINT "UsuariosEmBanimentosLogs_pkey" PRIMARY KEY ("id")
+    CONSTRAINT "UsuariosEmBloqueiosLogs_pkey" PRIMARY KEY ("id")
 );
 
 -- CreateTable
@@ -1290,22 +1290,22 @@ CREATE INDEX "LogsPagamentosDeAssinaturas_tipo_idx" ON "public"."LogsPagamentosD
 CREATE INDEX "LogsPagamentosDeAssinaturas_criadoEm_idx" ON "public"."LogsPagamentosDeAssinaturas"("criadoEm");
 
 -- CreateIndex
-CREATE INDEX "UsuariosEmBanimentos_usuarioId_idx" ON "public"."UsuariosEmBanimentos"("usuarioId");
+CREATE INDEX "UsuariosEmBloqueios_usuarioId_idx" ON "public"."UsuariosEmBloqueios"("usuarioId");
 
 -- CreateIndex
-CREATE INDEX "UsuariosEmBanimentos_status_idx" ON "public"."UsuariosEmBanimentos"("status");
+CREATE INDEX "UsuariosEmBloqueios_status_idx" ON "public"."UsuariosEmBloqueios"("status");
 
 -- CreateIndex
-CREATE INDEX "UsuariosEmBanimentos_fim_idx" ON "public"."UsuariosEmBanimentos"("fim");
+CREATE INDEX "UsuariosEmBloqueios_fim_idx" ON "public"."UsuariosEmBloqueios"("fim");
 
 -- CreateIndex
-CREATE INDEX "UsuariosEmBanimentosLogs_banimentoId_idx" ON "public"."UsuariosEmBanimentosLogs"("banimentoId");
+CREATE INDEX "UsuariosEmBloqueiosLogs_bloqueioId_idx" ON "public"."UsuariosEmBloqueiosLogs"("bloqueioId");
 
 -- CreateIndex
-CREATE INDEX "UsuariosEmBanimentosLogs_criadoPorId_idx" ON "public"."UsuariosEmBanimentosLogs"("criadoPorId");
+CREATE INDEX "UsuariosEmBloqueiosLogs_criadoPorId_idx" ON "public"."UsuariosEmBloqueiosLogs"("criadoPorId");
 
 -- CreateIndex
-CREATE INDEX "UsuariosEmBanimentosLogs_criadoEm_idx" ON "public"."UsuariosEmBanimentosLogs"("criadoEm");
+CREATE INDEX "UsuariosEmBloqueiosLogs_criadoEm_idx" ON "public"."UsuariosEmBloqueiosLogs"("criadoEm");
 
 -- CreateIndex
 CREATE UNIQUE INDEX "PlanosEmpresariais_mpPreapprovalPlanId_key" ON "public"."PlanosEmpresariais"("mpPreapprovalPlanId");
@@ -1521,16 +1521,16 @@ ALTER TABLE "public"."EmpresasPlano" ADD CONSTRAINT "EmpresasPlano_usuarioId_fke
 ALTER TABLE "public"."EmpresasPlano" ADD CONSTRAINT "EmpresasPlano_planosEmpresariaisId_fkey" FOREIGN KEY ("planosEmpresariaisId") REFERENCES "public"."PlanosEmpresariais"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "public"."UsuariosEmBanimentos" ADD CONSTRAINT "UsuariosEmBanimentos_usuarioId_fkey" FOREIGN KEY ("usuarioId") REFERENCES "public"."Usuarios"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "public"."UsuariosEmBloqueios" ADD CONSTRAINT "UsuariosEmBloqueios_usuarioId_fkey" FOREIGN KEY ("usuarioId") REFERENCES "public"."Usuarios"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "public"."UsuariosEmBanimentos" ADD CONSTRAINT "UsuariosEmBanimentos_aplicadoPorId_fkey" FOREIGN KEY ("aplicadoPorId") REFERENCES "public"."Usuarios"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "public"."UsuariosEmBloqueios" ADD CONSTRAINT "UsuariosEmBloqueios_aplicadoPorId_fkey" FOREIGN KEY ("aplicadoPorId") REFERENCES "public"."Usuarios"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "public"."UsuariosEmBanimentosLogs" ADD CONSTRAINT "UsuariosEmBanimentosLogs_banimentoId_fkey" FOREIGN KEY ("banimentoId") REFERENCES "public"."UsuariosEmBanimentos"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "public"."UsuariosEmBloqueiosLogs" ADD CONSTRAINT "UsuariosEmBloqueiosLogs_bloqueioId_fkey" FOREIGN KEY ("bloqueioId") REFERENCES "public"."UsuariosEmBloqueios"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "public"."UsuariosEmBanimentosLogs" ADD CONSTRAINT "UsuariosEmBanimentosLogs_criadoPorId_fkey" FOREIGN KEY ("criadoPorId") REFERENCES "public"."Usuarios"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "public"."UsuariosEmBloqueiosLogs" ADD CONSTRAINT "UsuariosEmBloqueiosLogs_criadoPorId_fkey" FOREIGN KEY ("criadoPorId") REFERENCES "public"."Usuarios"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
 
 -- AddForeignKey
 ALTER TABLE "public"."UsuariosEnderecos" ADD CONSTRAINT "UsuariosEnderecos_usuarioId_fkey" FOREIGN KEY ("usuarioId") REFERENCES "public"."Usuarios"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -38,9 +38,9 @@ model Usuarios {
   candidaturasFeitas    EmpresasCandidatos[]   @relation("CandidatoUsuario")
   candidaturasRecebidas EmpresasCandidatos[]   @relation("EmpresaUsuario")
   planosContratados    EmpresasPlano[]    @relation("UsuarioPlanos")
-  banimentosRecebidos  UsuariosEmBanimentos[] @relation("UsuariosEmBanimentosUsuario")
-  banimentosAplicados  UsuariosEmBanimentos[] @relation("UsuariosEmBanimentosAdmin")
-  banimentosLogsCriados UsuariosEmBanimentosLogs[] @relation("UsuariosEmBanimentosLogsAdmin")
+  bloqueiosRecebidos  UsuariosEmBloqueios[] @relation("UsuariosEmBloqueiosUsuario")
+  bloqueiosAplicados  UsuariosEmBloqueios[] @relation("UsuariosEmBloqueiosAdmin")
+  bloqueiosLogsCriados UsuariosEmBloqueiosLogs[] @relation("UsuariosEmBloqueiosLogsAdmin")
   redesSociais         UsuariosRedesSociais?
   recuperacaoSenha     UsuariosRecuperacaoSenha?
   emailVerification    UsuariosVerificacaoEmail?
@@ -731,40 +731,40 @@ model LogsPagamentosDeAssinaturas {
   @@index([criadoEm])
 }
 
-model UsuariosEmBanimentos {
+model UsuariosEmBloqueios {
   id            String              @id @default(uuid())
   usuarioId     String
   aplicadoPorId String
-  tipo          TiposDeBanimentos
-  motivo        MotivosDeBanimentos
-  status        StatusDeBanimentos @default(ATIVO)
+  tipo          TiposDeBloqueios
+  motivo        MotivosDeBloqueios
+  status        StatusDeBloqueios @default(ATIVO)
   inicio        DateTime           @default(now())
   fim           DateTime?
   observacoes   String?            @db.VarChar(500)
   criadoEm      DateTime           @default(now())
   atualizadoEm  DateTime           @updatedAt
 
-  usuario     Usuarios                   @relation("UsuariosEmBanimentosUsuario", fields: [usuarioId], references: [id], onDelete: Cascade)
-  aplicadoPor Usuarios                   @relation("UsuariosEmBanimentosAdmin", fields: [aplicadoPorId], references: [id])
-  logs        UsuariosEmBanimentosLogs[]
+  usuario     Usuarios                   @relation("UsuariosEmBloqueiosUsuario", fields: [usuarioId], references: [id], onDelete: Cascade)
+  aplicadoPor Usuarios                   @relation("UsuariosEmBloqueiosAdmin", fields: [aplicadoPorId], references: [id])
+  logs        UsuariosEmBloqueiosLogs[]
 
   @@index([usuarioId])
   @@index([status])
   @@index([fim])
 }
 
-model UsuariosEmBanimentosLogs {
+model UsuariosEmBloqueiosLogs {
   id           String                 @id @default(uuid())
-  banimentoId  String
-  acao         AcoesDeLogDeBanimento
+  bloqueioId  String
+  acao         AcoesDeLogDeBloqueio
   descricao    String?                @db.VarChar(500)
   criadoPorId  String
   criadoEm     DateTime               @default(now())
 
-  banimento UsuariosEmBanimentos @relation(fields: [banimentoId], references: [id], onDelete: Cascade)
-  criadoPor Usuarios             @relation("UsuariosEmBanimentosLogsAdmin", fields: [criadoPorId], references: [id])
+  bloqueio UsuariosEmBloqueios @relation(fields: [bloqueioId], references: [id], onDelete: Cascade)
+  criadoPor Usuarios             @relation("UsuariosEmBloqueiosLogsAdmin", fields: [criadoPorId], references: [id])
 
-  @@index([banimentoId])
+  @@index([bloqueioId])
   @@index([criadoPorId])
   @@index([criadoEm])
 }
@@ -1251,7 +1251,7 @@ enum Roles {
 enum Status {
   ATIVO
   INATIVO
-  BANIDO
+  BLOQUEADO
   PENDENTE
   SUSPENSO
 }
@@ -1650,20 +1650,20 @@ enum EmpresasPlanoOrigin {
   IMPORT
 }
 
-enum TiposDeBanimentos {
+enum TiposDeBloqueios {
   TEMPORARIO
   PERMANENTE
   RESTRICAO_DE_RECURSO
 }
 
-enum StatusDeBanimentos {
+enum StatusDeBloqueios {
   ATIVO
   EM_REVISAO
   REVOGADO
   EXPIRADO
 }
 
-enum MotivosDeBanimentos {
+enum MotivosDeBloqueios {
   SPAM
   VIOLACAO_POLITICAS
   FRAUDE
@@ -1671,7 +1671,7 @@ enum MotivosDeBanimentos {
   OUTROS
 }
 
-enum AcoesDeLogDeBanimento {
+enum AcoesDeLogDeBloqueio {
   CRIACAO
   ATUALIZACAO
   REVOGACAO

--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -125,7 +125,7 @@ const options: Options = {
       {
         name: 'Empresas - Admin',
         description:
-          'Gestão administrativa completa das empresas: cadastro, planos, pagamentos, vagas, banimentos e monitoramento operacional',
+          'Gestão administrativa completa das empresas: cadastro, planos, pagamentos, vagas, bloqueios e monitoramento operacional',
       },
       {
         name: 'Candidatos',
@@ -6216,7 +6216,7 @@ const options: Options = {
             'parceira',
             'vagasPublicadas',
             'limiteVagasPlano',
-            'banida',
+            'bloqueada',
           ],
           properties: {
             id: { type: 'string', format: 'uuid', example: 'empresa-uuid' },
@@ -6280,13 +6280,13 @@ const options: Options = {
               example: 10,
               description: 'Limite de vagas simultâneas definido pelo plano atual',
             },
-            banida: {
+            bloqueada: {
               type: 'boolean',
               example: false,
-              description: 'Indica se a empresa possui um banimento ativo no momento da consulta',
+              description: 'Indica se a empresa possui um bloqueio ativo no momento da consulta',
             },
-            banimentoAtivo: {
-              allOf: [{ $ref: '#/components/schemas/AdminUsuariosEmBanimentosResumo' }],
+            bloqueioAtivo: {
+              allOf: [{ $ref: '#/components/schemas/AdminUsuariosEmBloqueiosResumo' }],
               nullable: true,
             },
           },
@@ -6331,8 +6331,8 @@ const options: Options = {
             },
             vagasPublicadas: 8,
             limiteVagasPlano: 10,
-            banida: false,
-            banimentoAtivo: null,
+            bloqueada: false,
+            bloqueioAtivo: null,
           },
         },
         AdminEmpresasPlanoInput: {
@@ -6458,7 +6458,7 @@ const options: Options = {
             status: {
               type: 'string',
               nullable: true,
-              enum: ['ATIVO', 'INATIVO', 'BANIDO', 'PENDENTE', 'SUSPENSO'],
+              enum: ['ATIVO', 'INATIVO', 'BLOQUEADO', 'PENDENTE', 'SUSPENSO'],
               example: 'ATIVO',
               description: 'Status inicial da conta da empresa. Padrão: ATIVO',
             },
@@ -6541,7 +6541,7 @@ const options: Options = {
             status: {
               type: 'string',
               nullable: true,
-              enum: ['ATIVO', 'INATIVO', 'BANIDO', 'PENDENTE', 'SUSPENSO'],
+              enum: ['ATIVO', 'INATIVO', 'BLOQUEADO', 'PENDENTE', 'SUSPENSO'],
               example: 'ATIVO',
             },
             plano: {
@@ -6606,7 +6606,7 @@ const options: Options = {
             },
             status: {
               type: 'string',
-              enum: ['ATIVO', 'INATIVO', 'BANIDO', 'PENDENTE', 'SUSPENSO'],
+              enum: ['ATIVO', 'INATIVO', 'BLOQUEADO', 'PENDENTE', 'SUSPENSO'],
               example: 'ATIVO',
               description: 'Status atual do cadastro da empresa.',
             },
@@ -6746,8 +6746,8 @@ const options: Options = {
                 },
                 vagasPublicadas: 8,
                 limiteVagasPlano: 10,
-                banida: false,
-                banimentoAtivo: null,
+                bloqueada: false,
+                bloqueioAtivo: null,
               },
             ],
             pagination: {
@@ -6773,7 +6773,7 @@ const options: Options = {
             'ativa',
             'parceira',
             'vagas',
-            'banida',
+            'bloqueada',
             'pagamento',
           ],
           properties: {
@@ -6817,7 +6817,7 @@ const options: Options = {
             criadoEm: { type: 'string', format: 'date-time', example: '2023-11-01T08:30:00Z' },
             status: {
               type: 'string',
-              enum: ['ATIVO', 'INATIVO', 'BANIDO', 'PENDENTE', 'SUSPENSO'],
+              enum: ['ATIVO', 'INATIVO', 'BLOQUEADO', 'PENDENTE', 'SUSPENSO'],
               example: 'ATIVO',
             },
             ultimoLogin: {
@@ -6833,8 +6833,8 @@ const options: Options = {
               allOf: [{ $ref: '#/components/schemas/AdminEmpresasPlanoResumo' }],
               nullable: true,
             },
-            banimentoAtivo: {
-              allOf: [{ $ref: '#/components/schemas/AdminUsuariosEmBanimentosResumo' }],
+            bloqueioAtivo: {
+              allOf: [{ $ref: '#/components/schemas/AdminUsuariosEmBloqueiosResumo' }],
               nullable: true,
             },
             vagas: {
@@ -6844,10 +6844,10 @@ const options: Options = {
                 limitePlano: { type: 'integer', nullable: true, example: 3 },
               },
             },
-            banida: {
+            bloqueada: {
               type: 'boolean',
               example: false,
-              description: 'Indica se a empresa possui um banimento ativo',
+              description: 'Indica se a empresa possui um bloqueio ativo',
             },
             pagamento: {
               type: 'object',
@@ -6910,12 +6910,12 @@ const options: Options = {
               duracaoEmDias: null,
               diasRestantes: 18,
             },
-            banimentoAtivo: null,
+            bloqueioAtivo: null,
             vagas: {
               publicadas: 8,
               limitePlano: 10,
             },
-            banida: false,
+            bloqueada: false,
             pagamento: {
               modelo: 'ASSINATURA',
               metodo: 'PIX',
@@ -6974,12 +6974,12 @@ const options: Options = {
                 duracaoEmDias: null,
                 diasRestantes: 18,
               },
-              banimentoAtivo: null,
+              bloqueioAtivo: null,
               vagas: {
                 publicadas: 8,
                 limitePlano: 10,
               },
-              banida: false,
+              bloqueada: false,
               pagamento: {
                 modelo: 'ASSINATURA',
                 metodo: 'PIX',
@@ -6995,26 +6995,26 @@ const options: Options = {
             },
           },
         },
-        AdminUsuariosBanimentoAlvo: {
+        AdminUsuariosBloqueioAlvo: {
           type: 'object',
-          description: 'Identificação do alvo banido',
+          description: 'Identificação do alvo bloqueado',
           required: ['tipo', 'id', 'nome', 'role'],
           properties: {
             tipo: {
               type: 'string',
               enum: ['EMPRESA', 'USUARIO', 'ESTUDANTE'],
               example: 'EMPRESA',
-              description: 'Tipo de perfil afetado pelo banimento.',
+              description: 'Tipo de perfil afetado pelo bloqueio.',
             },
             id: {
               type: 'string',
               example: 'cmp_112233',
-              description: 'Identificador do usuário banido no sistema.',
+              description: 'Identificador do usuário bloqueado no sistema.',
             },
             nome: {
               type: 'string',
               example: 'Empresa XPTO',
-              description: 'Nome exibido para o alvo do banimento.',
+              description: 'Nome exibido para o alvo do bloqueio.',
             },
             role: {
               type: 'string',
@@ -7023,9 +7023,9 @@ const options: Options = {
             },
           },
         },
-        AdminUsuariosBanimentoResponsavel: {
+        AdminUsuariosBloqueioResponsavel: {
           type: 'object',
-          description: 'Responsável pela aplicação do banimento',
+          description: 'Responsável pela aplicação do bloqueio',
           required: ['id', 'nome', 'role'],
           properties: {
             id: { type: 'string', example: 'adm_002' },
@@ -7033,9 +7033,9 @@ const options: Options = {
             role: { type: 'string', example: 'ADMIN' },
           },
         },
-        AdminUsuariosBanimentoDados: {
+        AdminUsuariosBloqueioDados: {
           type: 'object',
-          description: 'Detalhes do banimento',
+          description: 'Detalhes do bloqueio',
           required: ['tipo', 'motivo', 'status', 'inicio'],
           properties: {
             tipo: {
@@ -7071,9 +7071,9 @@ const options: Options = {
             },
           },
         },
-        AdminUsuariosBanimentoAuditoria: {
+        AdminUsuariosBloqueioAuditoria: {
           type: 'object',
-          description: 'Metadados de criação e atualização do banimento',
+          description: 'Metadados de criação e atualização do bloqueio',
           required: ['criadoEm', 'atualizadoEm'],
           properties: {
             criadoEm: {
@@ -7088,31 +7088,31 @@ const options: Options = {
             },
           },
         },
-        AdminUsuariosEmBanimentosResumo: {
+        AdminUsuariosEmBloqueiosResumo: {
           type: 'object',
-          description: 'Resumo completo do banimento aplicado ao usuário',
-          required: ['id', 'alvo', 'banimento', 'auditoria'],
+          description: 'Resumo completo do bloqueio aplicado ao usuário',
+          required: ['id', 'alvo', 'bloqueio', 'auditoria'],
           properties: {
-            id: { type: 'string', format: 'uuid', example: 'ban_123456' },
-            alvo: { allOf: [{ $ref: '#/components/schemas/AdminUsuariosBanimentoAlvo' }] },
-            banimento: { allOf: [{ $ref: '#/components/schemas/AdminUsuariosBanimentoDados' }] },
+            id: { type: 'string', format: 'uuid', example: 'bloq_123456' },
+            alvo: { allOf: [{ $ref: '#/components/schemas/AdminUsuariosBloqueioAlvo' }] },
+            bloqueio: { allOf: [{ $ref: '#/components/schemas/AdminUsuariosBloqueioDados' }] },
             aplicadoPor: {
-              allOf: [{ $ref: '#/components/schemas/AdminUsuariosBanimentoResponsavel' }],
+              allOf: [{ $ref: '#/components/schemas/AdminUsuariosBloqueioResponsavel' }],
               nullable: true,
             },
             auditoria: {
-              allOf: [{ $ref: '#/components/schemas/AdminUsuariosBanimentoAuditoria' }],
+              allOf: [{ $ref: '#/components/schemas/AdminUsuariosBloqueioAuditoria' }],
             },
           },
           example: {
-            id: 'ban_123456',
+            id: 'bloq_123456',
             alvo: {
               tipo: 'EMPRESA',
               id: 'cmp_112233',
               nome: 'Empresa XPTO',
               role: 'EMPRESA',
             },
-            banimento: {
+            bloqueio: {
               tipo: 'TEMPORARIO',
               motivo: 'VIOLACAO_POLITICAS',
               status: 'ATIVO',
@@ -7221,27 +7221,27 @@ const options: Options = {
             },
           },
         },
-        AdminUsuariosBanimentosResponse: {
+        AdminUsuariosBloqueiosResponse: {
           type: 'object',
           required: ['data', 'pagination'],
           properties: {
             data: {
               type: 'array',
-              items: { $ref: '#/components/schemas/AdminUsuariosEmBanimentosResumo' },
+              items: { $ref: '#/components/schemas/AdminUsuariosEmBloqueiosResumo' },
             },
             pagination: { allOf: [{ $ref: '#/components/schemas/PaginationMeta' }] },
           },
           example: {
             data: [
               {
-                id: 'ban_123456',
+                id: 'bloq_123456',
                 alvo: {
                   tipo: 'EMPRESA',
                   id: 'cmp_112233',
                   nome: 'Empresa XPTO',
                   role: 'EMPRESA',
                 },
-                banimento: {
+                bloqueio: {
                   tipo: 'TEMPORARIO',
                   motivo: 'VIOLACAO_POLITICAS',
                   status: 'ATIVO',
@@ -7268,7 +7268,7 @@ const options: Options = {
             },
           },
         },
-        AdminUsuariosEmBanimentosCreate: {
+        AdminUsuariosEmBloqueiosCreate: {
           type: 'object',
           required: ['tipo', 'motivo'],
           properties: {
@@ -7276,13 +7276,13 @@ const options: Options = {
               type: 'string',
               enum: ['TEMPORARIO', 'PERMANENTE', 'RESTRICAO_DE_RECURSO'],
               example: 'TEMPORARIO',
-              description: 'Tipo do banimento aplicado.',
+              description: 'Tipo do bloqueio aplicado.',
             },
             motivo: {
               type: 'string',
               enum: ['SPAM', 'VIOLACAO_POLITICAS', 'FRAUDE', 'ABUSO_DE_RECURSOS', 'OUTROS'],
               example: 'VIOLACAO_POLITICAS',
-              description: 'Motivo categorizado do banimento.',
+              description: 'Motivo categorizado do bloqueio.',
             },
             dias: {
               type: 'integer',
@@ -7290,7 +7290,7 @@ const options: Options = {
               maximum: 3650,
               nullable: true,
               example: 30,
-              description: 'Vigência em dias (obrigatório para banimentos temporários).',
+              description: 'Vigência em dias (obrigatório para bloqueios temporários).',
             },
             observacoes: {
               type: 'string',
@@ -7301,22 +7301,22 @@ const options: Options = {
             },
           },
         },
-        AdminUsuariosEmBanimentosResponse: {
+        AdminUsuariosEmBloqueiosResponse: {
           type: 'object',
-          required: ['banimento'],
+          required: ['bloqueio'],
           properties: {
-            banimento: { $ref: '#/components/schemas/AdminUsuariosEmBanimentosResumo' },
+            bloqueio: { $ref: '#/components/schemas/AdminUsuariosEmBloqueiosResumo' },
           },
           example: {
-            banimento: {
-              id: 'ban_123456',
+            bloqueio: {
+              id: 'bloq_123456',
               alvo: {
                 tipo: 'EMPRESA',
                 id: 'cmp_112233',
                 nome: 'Empresa XPTO',
                 role: 'EMPRESA',
               },
-              banimento: {
+              bloqueio: {
                 tipo: 'TEMPORARIO',
                 motivo: 'VIOLACAO_POLITICAS',
                 status: 'ATIVO',
@@ -8375,7 +8375,7 @@ const options: Options = {
             },
             status: {
               type: 'string',
-              enum: ['ATIVO', 'INATIVO', 'BANIDO', 'PENDENTE', 'SUSPENSO'],
+              enum: ['ATIVO', 'INATIVO', 'BLOQUEADO', 'PENDENTE', 'SUSPENSO'],
               example: 'ATIVO',
             },
             tipoUsuario: {
@@ -8585,7 +8585,7 @@ const options: Options = {
             },
             status: {
               type: 'string',
-              enum: ['ATIVO', 'INATIVO', 'BANIDO', 'PENDENTE', 'SUSPENSO'],
+              enum: ['ATIVO', 'INATIVO', 'BLOQUEADO', 'PENDENTE', 'SUSPENSO'],
               example: 'ATIVO',
               description: 'Status inicial do usuário. O padrão é ATIVO.',
             },
@@ -8672,7 +8672,7 @@ const options: Options = {
                 role: { allOf: [{ $ref: '#/components/schemas/Roles' }] },
                 status: {
                   type: 'string',
-                  enum: ['ATIVO', 'INATIVO', 'BANIDO', 'PENDENTE', 'SUSPENSO'],
+                  enum: ['ATIVO', 'INATIVO', 'BLOQUEADO', 'PENDENTE', 'SUSPENSO'],
                   example: 'ATIVO',
                 },
                 criadoEm: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ import { errorMiddleware } from './middlewares/error';
 import { logger } from '@/utils/logger';
 import { startAssinaturasReconJob } from '@/modules/mercadopago/assinaturas/cron/reconcile';
 import { startBoletoWatcherJob } from '@/modules/mercadopago/assinaturas/cron/boleto-watcher';
-import { startBanimentosWatcherJob } from '@/modules/usuarios/banimentos/cron/ban-watcher';
+import { startBloqueiosWatcherJob } from '@/modules/usuarios/bloqueios/cron/bloqueio-watcher';
 import { startEstagiosWatcherJob } from '@/modules/cursos/cron/estagios-watcher';
 
 /**
@@ -155,7 +155,7 @@ try {
   try {
     startAssinaturasReconJob();
     startBoletoWatcherJob();
-    startBanimentosWatcherJob();
+    startBloqueiosWatcherJob();
     startEstagiosWatcherJob();
   } catch (e) {
     routerLogger.warn({ err: e }, '⚠️ Falha ao iniciar cron de assinaturas');

--- a/src/modules/brevo/templates/email-templates.ts
+++ b/src/modules/brevo/templates/email-templates.ts
@@ -791,8 +791,8 @@ Seu plano foi alterado para ${data.planName}. Todas as vagas foram movidas para 
     return { subject, html, text };
   }
 
-  // ========= Banimentos =========
-  public static generateUserBannedEmail(data: {
+  // ========= Bloqueios =========
+  public static generateUserBlockedEmail(data: {
     nomeCompleto: string;
     motivo: string;
     fim?: Date | null;
@@ -802,13 +802,13 @@ Seu plano foi alterado para ${data.planName}. Todas as vagas foram movidas para 
     const untilText = data.fim
       ? `até ${new Date(data.fim).toLocaleString('pt-BR')}`
       : 'por tempo indeterminado';
-    const subject = `Sua conta foi banida`;
+    const subject = `Sua conta foi bloqueada`;
     const html = `<!DOCTYPE html>
 <html lang="pt-BR">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Banimento - Advance+</title>
+  <title>Bloqueio - Advance+</title>
   ${this.getBaseStyles()}
 </head>
 <body>
@@ -822,7 +822,7 @@ Seu plano foi alterado para ${data.planName}. Todas as vagas foram movidas para 
       <div class="content">
         <div class="greeting">Olá, ${firstName}.</div>
         <div class="message">
-          Informamos que sua conta foi <strong>banida</strong> ${untilText}.
+          Informamos que sua conta foi <strong>bloqueada</strong> ${untilText}.
         </div>
         <div class="info-box">
           <p class="info-text"><strong>Motivo:</strong> ${data.motivo}</p>
@@ -838,7 +838,7 @@ Seu plano foi alterado para ${data.planName}. Todas as vagas foram movidas para 
 </html>`;
     const text = `Olá, ${firstName}.
 
-Informamos que sua conta foi banida ${untilText}.
+Informamos que sua conta foi bloqueada ${untilText}.
 Motivo: ${data.motivo}.
 
 Se acreditar que foi um engano, responda este email com mais detalhes.
@@ -847,7 +847,7 @@ Se acreditar que foi um engano, responda este email com mais detalhes.
     return { subject, html, text };
   }
 
-  public static generateUserUnbannedEmail(data: { nomeCompleto: string }): EmailTemplate {
+  public static generateUserUnblockedEmail(data: { nomeCompleto: string }): EmailTemplate {
     const firstName = data.nomeCompleto.split(' ')[0];
     const currentYear = this.getCurrentYear();
     const subject = `Bem-vindo(a) de volta!`;
@@ -856,7 +856,7 @@ Se acreditar que foi um engano, responda este email com mais detalhes.
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Banimento Revogado - Advance+</title>
+  <title>Bloqueio Revogado - Advance+</title>
   ${this.getBaseStyles()}
 </head>
 <body>
@@ -870,7 +870,7 @@ Se acreditar que foi um engano, responda este email com mais detalhes.
       <div class="content">
         <div class="greeting">Olá, ${firstName}!</div>
         <div class="message">
-          Seu banimento foi <strong>revogado</strong>. Seu acesso foi restaurado.
+          Seu bloqueio foi <strong>revogado</strong>. Seu acesso foi restaurado.
         </div>
       </div>
       <div class="footer">
@@ -882,7 +882,7 @@ Se acreditar que foi um engano, responda este email com mais detalhes.
 </html>`;
     const text = `Olá, ${firstName}!
 
-Seu banimento foi revogado. Seu acesso foi restaurado.
+Seu bloqueio foi revogado. Seu acesso foi restaurado.
 
 © ${currentYear} Advance+ - Todos os direitos reservados`;
     return { subject, html, text };

--- a/src/modules/empresas/admin/controllers/admin-empresas.controller.ts
+++ b/src/modules/empresas/admin/controllers/admin-empresas.controller.ts
@@ -3,7 +3,7 @@ import { ZodError } from 'zod';
 
 import { adminEmpresasService } from '@/modules/empresas/admin/services/admin-empresas.service';
 import {
-  adminEmpresasBanSchema,
+  adminEmpresasBloqueioSchema,
   adminEmpresasCreateSchema,
   adminEmpresasDashboardListQuerySchema,
   adminEmpresasHistoryQuerySchema,
@@ -64,13 +64,13 @@ export class AdminEmpresasController {
     }
   };
 
-  static unban = async (req: Request, res: Response) => {
+  static unblock = async (req: Request, res: Response) => {
     try {
       const params = adminEmpresasIdParamSchema.parse(req.params);
       const adminId = req.user?.id;
       if (!adminId) return res.status(401).json({ success: false, code: 'UNAUTHORIZED' });
       const { observacoes } = (req.body || {}) as { observacoes?: string };
-      await adminEmpresasService.revogarBanimento(params.id, adminId, observacoes);
+      await adminEmpresasService.revogarBloqueio(params.id, adminId, observacoes);
       res.status(204).send();
     } catch (error: any) {
       if (error?.code === 'EMPRESA_NOT_FOUND') {
@@ -78,21 +78,21 @@ export class AdminEmpresasController {
           .status(404)
           .json({ success: false, code: 'EMPRESA_NOT_FOUND', message: 'Empresa não encontrada' });
       }
-      if (error?.code === 'BANIMENTO_NOT_FOUND') {
+      if (error?.code === 'BLOQUEIO_NOT_FOUND') {
         return res
           .status(404)
           .json({
             success: false,
-            code: 'BANIMENTO_NOT_FOUND',
-            message: 'Nenhum banimento ativo encontrado',
+            code: 'BLOQUEIO_NOT_FOUND',
+            message: 'Nenhum bloqueio ativo encontrado',
           });
       }
       res
         .status(500)
         .json({
           success: false,
-          code: 'ADMIN_EMPRESAS_UNBAN_ERROR',
-          message: 'Erro ao revogar banimento',
+          code: 'ADMIN_EMPRESAS_UNBLOCK_ERROR',
+          message: 'Erro ao revogar bloqueio',
           error: error?.message,
         });
     }
@@ -385,10 +385,10 @@ export class AdminEmpresasController {
     }
   };
 
-  static ban = async (req: Request, res: Response) => {
+  static block = async (req: Request, res: Response) => {
     try {
       const params = adminEmpresasIdParamSchema.parse(req.params);
-      const payload = adminEmpresasBanSchema.parse(req.body);
+      const payload = adminEmpresasBloqueioSchema.parse(req.body);
 
       const adminId = req.user?.id;
       if (!adminId) {
@@ -399,23 +399,23 @@ export class AdminEmpresasController {
         });
       }
 
-      const banimento = await adminEmpresasService.aplicarBanimento(params.id, adminId, payload);
+      const bloqueio = await adminEmpresasService.aplicarBloqueio(params.id, adminId, payload);
 
-      if (!banimento) {
+      if (!bloqueio) {
         return res.status(500).json({
           success: false,
-          code: 'BANIMENTO_NOT_CREATED',
-          message: 'Não foi possível registrar o banimento',
+          code: 'BLOQUEIO_NOT_CREATED',
+          message: 'Não foi possível registrar o bloqueio',
         });
       }
 
-      res.status(201).json({ banimento });
+      res.status(201).json({ bloqueio });
     } catch (error: any) {
       if (error instanceof ZodError) {
         return res.status(400).json({
           success: false,
           code: 'VALIDATION_ERROR',
-          message: 'Dados inválidos para banimento',
+          message: 'Dados inválidos para bloqueio',
           issues: error.flatten().fieldErrors,
         });
       }
@@ -432,24 +432,24 @@ export class AdminEmpresasController {
         return res.status(403).json({
           success: false,
           code: 'FORBIDDEN',
-          message: 'Somente administradores ou moderadores podem aplicar banimentos',
+          message: 'Somente administradores ou moderadores podem aplicar bloqueios',
         });
       }
 
       res.status(500).json({
         success: false,
-        code: 'ADMIN_EMPRESAS_BAN_ERROR',
-        message: 'Erro ao aplicar banimento',
+        code: 'ADMIN_EMPRESAS_BLOCK_ERROR',
+        message: 'Erro ao aplicar bloqueio',
         error: error?.message,
       });
     }
   };
 
-  static listBanimentos = async (req: Request, res: Response) => {
+  static listBloqueios = async (req: Request, res: Response) => {
     try {
       const params = adminEmpresasIdParamSchema.parse(req.params);
       const query = adminEmpresasHistoryQuerySchema.parse(req.query);
-      const result = await adminEmpresasService.listarBanimentos(params.id, query);
+      const result = await adminEmpresasService.listarBloqueios(params.id, query);
       res.json(result);
     } catch (error: any) {
       if (error instanceof ZodError) {
@@ -471,8 +471,8 @@ export class AdminEmpresasController {
 
       res.status(500).json({
         success: false,
-        code: 'ADMIN_EMPRESAS_BANIMENTOS_ERROR',
-        message: 'Erro ao listar banimentos da empresa',
+        code: 'ADMIN_EMPRESAS_BLOQUEIOS_ERROR',
+        message: 'Erro ao listar bloqueios da empresa',
         error: error?.message,
       });
     }

--- a/src/modules/empresas/admin/routes/index.ts
+++ b/src/modules/empresas/admin/routes/index.ts
@@ -290,8 +290,8 @@ router.get(
  *                         diasRestantes: 18
  *                       vagasPublicadas: 8
  *                       limiteVagasPlano: 10
- *                       banida: false
- *                       banimentoAtivo: null
+ *                       bloqueada: false
+ *                       bloqueioAtivo: null
  *                   pagination:
  *                     page: 1
  *                     pageSize: 20
@@ -500,8 +500,8 @@ router.get('/', supabaseAuthMiddleware(adminRoles), AdminEmpresasController.list
  *                       metodo: PIX
  *                       status: APROVADO
  *                       ultimoPagamentoEm: '2024-02-15T14:20:00Z'
- *                     banida: false
- *                     banimentoAtivo: null
+ *                     bloqueada: false
+ *                     bloqueioAtivo: null
  *                     informacoes:
  *                       telefone: '+55 11 99999-0000'
  *                       descricao: Consultoria especializada em tecnologia e recrutamento.
@@ -634,11 +634,11 @@ router.get(
 
 /**
  * @openapi
- * /api/v1/empresas/admin/{id}/banimentos:
+ * /api/v1/empresas/admin/{id}/bloqueios:
  *   get:
- *     summary: (Admin) Listar banimentos aplicados
- *     description: "Retorna o histórico de banimentos aplicados ao usuário da empresa, detalhando vigência, status e responsável."
- *     operationId: adminEmpresasListBanimentos
+ *     summary: (Admin) Listar bloqueios aplicados
+ *     description: "Retorna o histórico de bloqueios aplicados ao usuário da empresa, detalhando vigência, status e responsável."
+ *     operationId: adminEmpresasListBloqueios
  *     tags: [Empresas - Admin]
  *     security:
  *       - bearerAuth: []
@@ -664,23 +664,23 @@ router.get(
  *           default: 20
  *     responses:
  *       200:
- *         description: Histórico de banimentos retornado com sucesso
+ *         description: Histórico de bloqueios retornado com sucesso
  *         content:
  *           application/json:
  *             schema:
- *               $ref: '#/components/schemas/AdminUsuariosBanimentosResponse'
+ *               $ref: '#/components/schemas/AdminUsuariosBloqueiosResponse'
  *             examples:
  *               default:
- *                 summary: Banimentos da empresa
+ *                 summary: Bloqueios da empresa
  *                 value:
  *                   data:
- *                     - id: ban_123456
+ *                     - id: bloq_123456
  *                       alvo:
  *                         tipo: EMPRESA
  *                         id: cmp_112233
  *                         nome: Empresa XPTO
  *                         role: EMPRESA
- *                       banimento:
+ *                       bloqueio:
  *                         tipo: TEMPORARIO
  *                         motivo: VIOLACAO_POLITICAS
  *                         status: ATIVO
@@ -730,9 +730,9 @@ router.get(
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  *   post:
- *     summary: (Admin) Aplicar banimento à empresa
- *     description: "Centraliza o banimento do usuário da empresa, permitindo banimentos temporários ou permanentes com registro de auditoria."
- *     operationId: adminEmpresasAplicarBanimento
+ *     summary: (Admin) Aplicar bloqueio à empresa
+ *     description: "Centraliza o bloqueio do usuário da empresa, permitindo bloqueios temporários ou permanentes com registro de auditoria."
+ *     operationId: adminEmpresasAplicarBloqueio
  *     tags: [Empresas - Admin]
  *     security:
  *       - bearerAuth: []
@@ -748,10 +748,10 @@ router.get(
  *       content:
  *         application/json:
  *           schema:
- *             $ref: '#/components/schemas/AdminUsuariosEmBanimentosCreate'
+ *             $ref: '#/components/schemas/AdminUsuariosEmBloqueiosCreate'
  *           examples:
  *             default:
- *               summary: Banimento de 30 dias com motivo
+ *               summary: Bloqueio de 30 dias com motivo
  *               value:
  *                 tipo: TEMPORARIO
  *                 motivo: VIOLACAO_POLITICAS
@@ -759,23 +759,23 @@ router.get(
  *                 observacoes: Uso indevido de dados pessoais de candidatos.
  *     responses:
  *       201:
- *         description: Banimento aplicado com sucesso
+ *         description: Bloqueio aplicado com sucesso
  *         content:
  *           application/json:
  *             schema:
- *               $ref: '#/components/schemas/AdminUsuariosEmBanimentosResponse'
+ *               $ref: '#/components/schemas/AdminUsuariosEmBloqueiosResponse'
  *             examples:
  *               created:
- *                 summary: Banimento registrado
+ *                 summary: Bloqueio registrado
  *                 value:
- *                   banimento:
- *                     id: ban_123456
+ *                   bloqueio:
+ *                     id: bloq_123456
  *                     alvo:
  *                       tipo: EMPRESA
  *                       id: cmp_112233
  *                       nome: Empresa XPTO
  *                       role: EMPRESA
- *                     banimento:
+ *                     bloqueio:
  *                       tipo: TEMPORARIO
  *                       motivo: VIOLACAO_POLITICAS
  *                       status: ATIVO
@@ -821,18 +821,18 @@ router.get(
  *               $ref: '#/components/schemas/ErrorResponse'
  */
 router.get(
-  '/:id/banimentos',
+  '/:id/bloqueios',
   supabaseAuthMiddleware(adminRoles),
-  AdminEmpresasController.listBanimentos,
+  AdminEmpresasController.listBloqueios,
 );
-router.post('/:id/banimentos', supabaseAuthMiddleware(adminRoles), AdminEmpresasController.ban);
+router.post('/:id/bloqueios', supabaseAuthMiddleware(adminRoles), AdminEmpresasController.block);
 /**
  * @openapi
- * /api/v1/empresas/admin/{id}/banimentos/revogar:
+ * /api/v1/empresas/admin/{id}/bloqueios/revogar:
  *   post:
- *     summary: (Admin) Revogar banimento ativo
- *     description: "Revoga o banimento ativo da empresa, restaura o status do usuário e registra auditoria da ação."
- *     operationId: adminEmpresasRevogarBanimento
+ *     summary: (Admin) Revogar bloqueio ativo
+ *     description: "Revoga o bloqueio ativo da empresa, restaura o status do usuário e registra auditoria da ação."
+ *     operationId: adminEmpresasRevogarBloqueio
  *     tags: [Empresas - Admin]
  *     security:
  *       - bearerAuth: []
@@ -878,29 +878,29 @@ router.post('/:id/banimentos', supabaseAuthMiddleware(adminRoles), AdminEmpresas
  *             schema:
  *               $ref: '#/components/schemas/ForbiddenResponse'
  *       404:
- *         description: Empresa ou banimento ativo não encontrados
+ *         description: Empresa ou bloqueio ativo não encontrados
  *         content:
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  *             examples:
- *               banimentoInexistente:
- *                 summary: Nenhum banimento ativo encontrado
+ *               bloqueioInexistente:
+ *                 summary: Nenhum bloqueio ativo encontrado
  *                 value:
  *                   success: false
- *                   code: BANIMENTO_NOT_FOUND
- *                   message: Nenhum banimento ativo encontrado
+ *                   code: BLOQUEIO_NOT_FOUND
+ *                   message: Nenhum bloqueio ativo encontrado
  *       500:
- *         description: Erro interno ao revogar banimento
+ *         description: Erro interno ao revogar bloqueio
  *         content:
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  */
 router.post(
-  '/:id/banimentos/revogar',
+  '/:id/bloqueios/revogar',
   supabaseAuthMiddleware(adminRoles),
-  AdminEmpresasController.unban,
+  AdminEmpresasController.unblock,
 );
 
 /**

--- a/src/modules/empresas/admin/validators/admin-empresas.schema.ts
+++ b/src/modules/empresas/admin/validators/admin-empresas.schema.ts
@@ -1,4 +1,4 @@
-import { MotivosDeBanimentos, Status, StatusDeVagas, TiposDeBanimentos } from '@prisma/client';
+import { MotivosDeBloqueios, Status, StatusDeVagas, TiposDeBloqueios } from '@prisma/client';
 import { z } from 'zod';
 
 import { clientePlanoModoSchema } from '@/modules/empresas/clientes/validators/clientes.schema';
@@ -235,18 +235,18 @@ export const adminEmpresasVagasQuerySchema = paginationQueryBaseSchema
 
 export type AdminEmpresasVagasQuery = z.infer<typeof adminEmpresasVagasQuerySchema>;
 
-export const adminEmpresasBanSchema = z
+export const adminEmpresasBloqueioSchema = z
   .object({
-    tipo: z.nativeEnum(TiposDeBanimentos, { required_error: 'Tipo de banimento é obrigatório' }),
-    motivo: z.nativeEnum(MotivosDeBanimentos, {
-      required_error: 'Motivo do banimento é obrigatório',
+    tipo: z.nativeEnum(TiposDeBloqueios, { required_error: 'Tipo de bloqueio é obrigatório' }),
+    motivo: z.nativeEnum(MotivosDeBloqueios, {
+      required_error: 'Motivo do bloqueio é obrigatório',
     }),
     dias: z.coerce
       .number()
       .int()
-      .min(1, 'Informe pelo menos 1 dia de banimento')
-      .max(3650, 'Banimento temporário deve ter no máximo 10 anos')
-      .describe('Quantidade de dias para banimento temporário')
+      .min(1, 'Informe pelo menos 1 dia de bloqueio')
+      .max(3650, 'Bloqueio temporário deve ter no máximo 10 anos')
+      .describe('Quantidade de dias para bloqueio temporário')
       .optional(),
     observacoes: z
       .string()
@@ -257,15 +257,15 @@ export const adminEmpresasBanSchema = z
   })
   .refine(
     (values) =>
-      values.tipo !== TiposDeBanimentos.TEMPORARIO ||
+      values.tipo !== TiposDeBloqueios.TEMPORARIO ||
       (values.dias !== undefined && Number.isFinite(values.dias) && values.dias > 0),
     {
-      message: 'Informe a quantidade de dias para banimentos temporários',
+      message: 'Informe a quantidade de dias para bloqueios temporários',
       path: ['dias'],
     },
   );
 
-export type AdminEmpresasBanInput = z.infer<typeof adminEmpresasBanSchema>;
+export type AdminEmpresasBloqueioInput = z.infer<typeof adminEmpresasBloqueioSchema>;
 
 export const adminEmpresasVagaParamSchema = adminEmpresasIdParamSchema.extend({
   vagaId: z.string().uuid(),

--- a/src/modules/usuarios/bloqueios/cron/bloqueio-watcher.ts
+++ b/src/modules/usuarios/bloqueios/cron/bloqueio-watcher.ts
@@ -1,11 +1,11 @@
 import cron from 'node-cron';
 import { prisma } from '@/config/prisma';
 import { logger } from '@/utils/logger';
-import { AcoesDeLogDeBanimento, Status, StatusDeBanimentos } from '@prisma/client';
+import { AcoesDeLogDeBloqueio, Status, StatusDeBloqueios } from '@prisma/client';
 import { EmailService } from '@/modules/brevo/services/email-service';
 import { EmailTemplates } from '@/modules/brevo/templates/email-templates';
 
-const log = logger.child({ module: 'BanimentosWatcher' });
+const log = logger.child({ module: 'BloqueiosWatcher' });
 
 const metrics = {
   totalProcessed: 0,
@@ -13,45 +13,45 @@ const metrics = {
   lastRunAt: null as Date | null,
 };
 
-export async function processExpiredBans() {
+export async function processExpiredBlocks() {
   const now = new Date();
-  const expirados = await prisma.usuariosEmBanimentos.findMany({
-    where: { status: StatusDeBanimentos.ATIVO, fim: { lt: now } },
+  const expirados = await prisma.usuariosEmBloqueios.findMany({
+    where: { status: StatusDeBloqueios.ATIVO, fim: { lt: now } },
     select: { id: true, usuarioId: true },
   });
 
   let processed = 0;
-  for (const ban of expirados) {
+  for (const bloqueio of expirados) {
     try {
       await prisma.$transaction(async (tx) => {
-        await tx.usuariosEmBanimentos.update({
-          where: { id: ban.id },
+        await tx.usuariosEmBloqueios.update({
+          where: { id: bloqueio.id },
           data: {
-            status: StatusDeBanimentos.REVOGADO,
+            status: StatusDeBloqueios.REVOGADO,
             logs: {
               create: {
-                acao: AcoesDeLogDeBanimento.REVOGACAO,
-                criadoPorId: ban.usuarioId, // auto, sem administrador explícito
-                descricao: 'Revogação automática por expiração da vigência do banimento.',
+                acao: AcoesDeLogDeBloqueio.REVOGACAO,
+                criadoPorId: bloqueio.usuarioId, // auto, sem administrador explícito
+                descricao: 'Revogação automática por expiração da vigência do bloqueio.',
               },
             },
           },
         });
-        await tx.usuarios.update({ where: { id: ban.usuarioId }, data: { status: Status.ATIVO } });
+        await tx.usuarios.update({ where: { id: bloqueio.usuarioId }, data: { status: Status.ATIVO } });
       });
 
       // Notificação por e-mail
       const usuario = await prisma.usuarios.findUnique({
-        where: { id: ban.usuarioId },
+        where: { id: bloqueio.usuarioId },
         select: { email: true, nomeCompleto: true },
       });
       if (usuario?.email) {
         const emailService = new EmailService();
-        const template = EmailTemplates.generateUserUnbannedEmail({
+        const template = EmailTemplates.generateUserUnblockedEmail({
           nomeCompleto: usuario.nomeCompleto,
         });
         await emailService.sendAssinaturaNotificacao(
-          { id: ban.usuarioId, email: usuario.email, nomeCompleto: usuario.nomeCompleto },
+          { id: bloqueio.usuarioId, email: usuario.email, nomeCompleto: usuario.nomeCompleto },
           template,
         );
       }
@@ -59,8 +59,8 @@ export async function processExpiredBans() {
       processed += 1;
     } catch (err) {
       log.warn(
-        { err, banId: ban.id, usuarioId: ban.usuarioId },
-        'Falha ao revogar banimento expirado',
+        { err, bloqueioId: bloqueio.id, usuarioId: bloqueio.usuarioId },
+        'Falha ao revogar bloqueio expirado',
       );
     }
   }
@@ -71,23 +71,23 @@ export async function processExpiredBans() {
   return { processed };
 }
 
-export function startBanimentosWatcherJob() {
+export function startBloqueiosWatcherJob() {
   // A cada hora, minuto 5
-  const schedule = process.env.BANIMENTOS_WATCHER_SCHEDULE || '5 * * * *';
+  const schedule = process.env.BLOQUEIOS_WATCHER_SCHEDULE || '5 * * * *';
   cron.schedule(schedule, async () => {
     try {
-      const result = await processExpiredBans();
+      const result = await processExpiredBlocks();
       if (result.processed > 0) {
-        log.info({ processed: result.processed }, 'Banimentos expirados revogados');
+        log.info({ processed: result.processed }, 'Bloqueios expirados revogados');
       }
     } catch (err) {
-      log.error({ err }, 'Erro ao processar banimentos expirados');
+      log.error({ err }, 'Erro ao processar bloqueios expirados');
     }
   });
-  log.info({ schedule }, '⏱️ Banimentos watcher agendado');
+  log.info({ schedule }, '⏱️ Bloqueios watcher agendado');
 }
 
-export function getBanimentosWatcherMetrics() {
+export function getBloqueiosWatcherMetrics() {
   return {
     totalProcessed: metrics.totalProcessed,
     processedLastRun: metrics.processedLastRun,

--- a/src/modules/usuarios/enums/Status.ts
+++ b/src/modules/usuarios/enums/Status.ts
@@ -5,7 +5,7 @@
 export enum Status {
   ATIVO = 'ATIVO',
   INATIVO = 'INATIVO',
-  BANIDO = 'BANIDO',
+  BLOQUEADO = 'BLOQUEADO',
   PENDENTE = 'PENDENTE',
   SUSPENSO = 'SUSPENSO',
 }

--- a/src/modules/usuarios/routes/admin-routes.ts
+++ b/src/modules/usuarios/routes/admin-routes.ts
@@ -38,7 +38,7 @@ const adminController = new AdminController();
  *         name: status
  *         schema:
  *           type: string
- *           enum: [ATIVO, INATIVO, BANIDO, PENDENTE, SUSPENSO]
+ *           enum: [ATIVO, INATIVO, BLOQUEADO, PENDENTE, SUSPENSO]
  *           example: ATIVO
  *       - in: query
  *         name: tipoUsuario
@@ -307,7 +307,7 @@ router.post('/usuarios', asyncHandler(adminController.criarUsuario));
  *         name: status
  *         schema:
  *           type: string
- *           enum: [ATIVO, INATIVO, BANIDO, PENDENTE, SUSPENSO]
+ *           enum: [ATIVO, INATIVO, BLOQUEADO, PENDENTE, SUSPENSO]
  *           example: ATIVO
  *       - in: query
  *         name: tipoUsuario

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -3,7 +3,7 @@ import { Router, type Request } from 'express';
 import redis from '@/config/redis';
 import { publicCache } from '@/middlewares/cache-control';
 import { docsRoutes } from '@/modules/docs';
-import { getBanimentosWatcherMetrics } from '@/modules/usuarios/banimentos/cron/ban-watcher';
+import { getBloqueiosWatcherMetrics } from '@/modules/usuarios/bloqueios/cron/bloqueio-watcher';
 import { brevoRoutes } from '@/modules/brevo/routes';
 import { mercadopagoRoutes } from '@/modules/mercadopago';
 import { EmailVerificationController } from '@/modules/brevo/controllers/email-verification-controller';
@@ -201,7 +201,7 @@ router.get('/health', publicCache, async (req, res) => {
       redis: redisStatus,
     },
     metrics: {
-      bans: getBanimentosWatcherMetrics(),
+      bloqueios: getBloqueiosWatcherMetrics(),
     },
   };
 


### PR DESCRIPTION
## Summary
- renomeia modelos, enums e migração do Prisma para utilizar nomenclatura de bloqueios
- ajusta serviços, controllers, rotas e cron para aplicar, listar e revogar bloqueios em vez de banimentos
- atualiza templates de e-mail, enum de status e documentação pública para refletir o novo termo

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d36abed8bc83259c90538a5fcb5b83