### PR TITLE
Renomeia matrículas para inscrições na API de cursos

### DIFF
--- a/prisma/migrations/20250205000000_add_cursos_certificados/migration.sql
+++ b/prisma/migrations/20250205000000_add_cursos_certificados/migration.sql
@@ -4,7 +4,7 @@ CREATE TYPE "public"."CursosCertificadosLogAcao" AS ENUM ('EMISSAO', 'VISUALIZAC
 -- CreateTable
 CREATE TABLE "public"."CursosCertificadosEmitidos" (
     "id" TEXT NOT NULL,
-    "matriculaId" TEXT NOT NULL,
+    "inscricaoId" TEXT NOT NULL,
     "codigo" VARCHAR(20) NOT NULL,
     "tipo" "public"."CursosCertificados" NOT NULL,
     "formato" "public"."CursosCertificadosTipos" NOT NULL,
@@ -36,7 +36,7 @@ CREATE TABLE "public"."CursosCertificadosLogs" (
 CREATE UNIQUE INDEX "CursosCertificadosEmitidos_codigo_key" ON "public"."CursosCertificadosEmitidos"("codigo");
 
 -- CreateIndex
-CREATE INDEX "CursosCertificadosEmitidos_matriculaId_idx" ON "public"."CursosCertificadosEmitidos"("matriculaId");
+CREATE INDEX "CursosCertificadosEmitidos_inscricaoId_idx" ON "public"."CursosCertificadosEmitidos"("inscricaoId");
 
 -- CreateIndex
 CREATE INDEX "CursosCertificadosEmitidos_emitidoPorId_idx" ON "public"."CursosCertificadosEmitidos"("emitidoPorId");
@@ -54,7 +54,7 @@ CREATE INDEX "CursosCertificadosLogs_acao_idx" ON "public"."CursosCertificadosLo
 CREATE INDEX "CursosCertificadosLogs_criadoEm_idx" ON "public"."CursosCertificadosLogs"("criadoEm");
 
 -- AddForeignKey
-ALTER TABLE "public"."CursosCertificadosEmitidos" ADD CONSTRAINT "CursosCertificadosEmitidos_matriculaId_fkey" FOREIGN KEY ("matriculaId") REFERENCES "public"."CursosTurmasMatriculas"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "public"."CursosCertificadosEmitidos" ADD CONSTRAINT "CursosCertificadosEmitidos_inscricaoId_fkey" FOREIGN KEY ("inscricaoId") REFERENCES "public"."CursosTurmasInscricoes"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
 ALTER TABLE "public"."CursosCertificadosEmitidos" ADD CONSTRAINT "CursosCertificadosEmitidos_emitidoPorId_fkey" FOREIGN KEY ("emitidoPorId") REFERENCES "public"."Usuarios"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/migrations/20250210100000_add_cursos_notas/migration.sql
+++ b/prisma/migrations/20250210100000_add_cursos_notas/migration.sql
@@ -5,7 +5,7 @@ CREATE TYPE "public"."CursosNotasTipo" AS ENUM ('PROVA', 'TRABALHO');
 CREATE TABLE "public"."CursosNotas" (
     "id" TEXT NOT NULL,
     "turmaId" TEXT NOT NULL,
-    "matriculaId" TEXT NOT NULL,
+    "inscricaoId" TEXT NOT NULL,
     "tipo" "public"."CursosNotasTipo" NOT NULL,
     "provaId" TEXT,
     "referenciaExterna" VARCHAR(120),
@@ -26,19 +26,19 @@ CREATE TABLE "public"."CursosNotas" (
 ALTER TABLE "public"."CursosNotas" ADD CONSTRAINT "CursosNotas_turmaId_fkey" FOREIGN KEY ("turmaId") REFERENCES "public"."CursosTurmas"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "public"."CursosNotas" ADD CONSTRAINT "CursosNotas_matriculaId_fkey" FOREIGN KEY ("matriculaId") REFERENCES "public"."CursosTurmasMatriculas"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "public"."CursosNotas" ADD CONSTRAINT "CursosNotas_inscricaoId_fkey" FOREIGN KEY ("inscricaoId") REFERENCES "public"."CursosTurmasInscricoes"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
 ALTER TABLE "public"."CursosNotas" ADD CONSTRAINT "CursosNotas_provaId_fkey" FOREIGN KEY ("provaId") REFERENCES "public"."CursosTurmasProvas"("id") ON DELETE SET NULL ON UPDATE CASCADE;
 
 -- CreateIndex
-CREATE UNIQUE INDEX "CursosNotas_matriculaId_provaId_key" ON "public"."CursosNotas"("matriculaId", "provaId");
+CREATE UNIQUE INDEX "CursosNotas_inscricaoId_provaId_key" ON "public"."CursosNotas"("inscricaoId", "provaId");
 
 -- CreateIndex
 CREATE INDEX "CursosNotas_turmaId_idx" ON "public"."CursosNotas"("turmaId");
 
 -- CreateIndex
-CREATE INDEX "CursosNotas_matriculaId_idx" ON "public"."CursosNotas"("matriculaId");
+CREATE INDEX "CursosNotas_inscricaoId_idx" ON "public"."CursosNotas"("inscricaoId");
 
 -- CreateIndex
 CREATE INDEX "CursosNotas_tipo_idx" ON "public"."CursosNotas"("tipo");

--- a/prisma/migrations/20250922180135_prod/migration.sql
+++ b/prisma/migrations/20250922180135_prod/migration.sql
@@ -142,7 +142,7 @@ CREATE TABLE "public"."UsuariosInformation" (
     "telefone" TEXT NOT NULL,
     "genero" TEXT,
     "dataNasc" TIMESTAMP(3),
-    "matricula" TEXT,
+    "inscricao" TEXT,
     "avatarUrl" TEXT,
     "descricao" VARCHAR(500),
     "aceitarTermos" BOOLEAN NOT NULL DEFAULT false,
@@ -273,13 +273,13 @@ CREATE TABLE "public"."CursosTurmasAulasMateriais" (
 );
 
 -- CreateTable
-CREATE TABLE "public"."CursosTurmasMatriculas" (
+CREATE TABLE "public"."CursosTurmasInscricoes" (
     "id" TEXT NOT NULL,
     "turmaId" TEXT NOT NULL,
     "alunoId" TEXT NOT NULL,
     "criadoEm" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
 
-    CONSTRAINT "CursosTurmasMatriculas_pkey" PRIMARY KEY ("id")
+    CONSTRAINT "CursosTurmasInscricoes_pkey" PRIMARY KEY ("id")
 );
 
 -- CreateTable
@@ -304,7 +304,7 @@ CREATE TABLE "public"."CursosTurmasProvas" (
 CREATE TABLE "public"."CursosTurmasProvasEnvios" (
     "id" TEXT NOT NULL,
     "provaId" TEXT NOT NULL,
-    "matriculaId" TEXT NOT NULL,
+    "inscricaoId" TEXT NOT NULL,
     "nota" DECIMAL(4,1),
     "pesoTotal" DECIMAL(5,2),
     "realizadoEm" TIMESTAMP(3),
@@ -336,7 +336,7 @@ CREATE TABLE "public"."CursosTurmasRegrasAvaliacao" (
 CREATE TABLE "public"."CursosTurmasRecuperacoes" (
     "id" TEXT NOT NULL,
     "turmaId" TEXT NOT NULL,
-    "matriculaId" TEXT NOT NULL,
+    "inscricaoId" TEXT NOT NULL,
     "regraId" TEXT,
     "provaId" TEXT,
     "envioId" TEXT,
@@ -1158,10 +1158,10 @@ CREATE INDEX "CursosTurmasAulasMateriais_aulaId_idx" ON "public"."CursosTurmasAu
 CREATE INDEX "CursosTurmasAulasMateriais_tipo_idx" ON "public"."CursosTurmasAulasMateriais"("tipo");
 
 -- CreateIndex
-CREATE INDEX "CursosTurmasMatriculas_alunoId_idx" ON "public"."CursosTurmasMatriculas"("alunoId");
+CREATE INDEX "CursosTurmasInscricoes_alunoId_idx" ON "public"."CursosTurmasInscricoes"("alunoId");
 
 -- CreateIndex
-CREATE UNIQUE INDEX "CursosTurmasMatriculas_turmaId_alunoId_key" ON "public"."CursosTurmasMatriculas"("turmaId", "alunoId");
+CREATE UNIQUE INDEX "CursosTurmasInscricoes_turmaId_alunoId_key" ON "public"."CursosTurmasInscricoes"("turmaId", "alunoId");
 
 -- CreateIndex
 CREATE INDEX "CursosTurmasProvas_turmaId_idx" ON "public"."CursosTurmasProvas"("turmaId");
@@ -1176,10 +1176,10 @@ CREATE INDEX "CursosTurmasProvas_turmaId_ativo_idx" ON "public"."CursosTurmasPro
 CREATE UNIQUE INDEX "CursosTurmasProvas_turmaId_etiqueta_key" ON "public"."CursosTurmasProvas"("turmaId", "etiqueta");
 
 -- CreateIndex
-CREATE INDEX "CursosTurmasProvasEnvios_matriculaId_idx" ON "public"."CursosTurmasProvasEnvios"("matriculaId");
+CREATE INDEX "CursosTurmasProvasEnvios_inscricaoId_idx" ON "public"."CursosTurmasProvasEnvios"("inscricaoId");
 
 -- CreateIndex
-CREATE UNIQUE INDEX "CursosTurmasProvasEnvios_provaId_matriculaId_key" ON "public"."CursosTurmasProvasEnvios"("provaId", "matriculaId");
+CREATE UNIQUE INDEX "CursosTurmasProvasEnvios_provaId_inscricaoId_key" ON "public"."CursosTurmasProvasEnvios"("provaId", "inscricaoId");
 
 -- CreateIndex
 CREATE UNIQUE INDEX "CursosTurmasRegrasAvaliacao_turmaId_key" ON "public"."CursosTurmasRegrasAvaliacao"("turmaId");
@@ -1188,7 +1188,7 @@ CREATE UNIQUE INDEX "CursosTurmasRegrasAvaliacao_turmaId_key" ON "public"."Curso
 CREATE INDEX "CursosTurmasRecuperacoes_turmaId_idx" ON "public"."CursosTurmasRecuperacoes"("turmaId");
 
 -- CreateIndex
-CREATE INDEX "CursosTurmasRecuperacoes_matriculaId_idx" ON "public"."CursosTurmasRecuperacoes"("matriculaId");
+CREATE INDEX "CursosTurmasRecuperacoes_inscricaoId_idx" ON "public"."CursosTurmasRecuperacoes"("inscricaoId");
 
 -- CreateIndex
 CREATE INDEX "CursosTurmasRecuperacoes_statusFinal_idx" ON "public"."CursosTurmasRecuperacoes"("statusFinal");
@@ -1434,10 +1434,10 @@ ALTER TABLE "public"."CursosTurmasAulas" ADD CONSTRAINT "CursosTurmasAulas_modul
 ALTER TABLE "public"."CursosTurmasAulasMateriais" ADD CONSTRAINT "CursosTurmasAulasMateriais_aulaId_fkey" FOREIGN KEY ("aulaId") REFERENCES "public"."CursosTurmasAulas"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "public"."CursosTurmasMatriculas" ADD CONSTRAINT "CursosTurmasMatriculas_turmaId_fkey" FOREIGN KEY ("turmaId") REFERENCES "public"."CursosTurmas"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "public"."CursosTurmasInscricoes" ADD CONSTRAINT "CursosTurmasInscricoes_turmaId_fkey" FOREIGN KEY ("turmaId") REFERENCES "public"."CursosTurmas"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "public"."CursosTurmasMatriculas" ADD CONSTRAINT "CursosTurmasMatriculas_alunoId_fkey" FOREIGN KEY ("alunoId") REFERENCES "public"."Usuarios"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "public"."CursosTurmasInscricoes" ADD CONSTRAINT "CursosTurmasInscricoes_alunoId_fkey" FOREIGN KEY ("alunoId") REFERENCES "public"."Usuarios"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
 ALTER TABLE "public"."CursosTurmasProvas" ADD CONSTRAINT "CursosTurmasProvas_turmaId_fkey" FOREIGN KEY ("turmaId") REFERENCES "public"."CursosTurmas"("id") ON DELETE CASCADE ON UPDATE CASCADE;
@@ -1449,7 +1449,7 @@ ALTER TABLE "public"."CursosTurmasProvas" ADD CONSTRAINT "CursosTurmasProvas_mod
 ALTER TABLE "public"."CursosTurmasProvasEnvios" ADD CONSTRAINT "CursosTurmasProvasEnvios_provaId_fkey" FOREIGN KEY ("provaId") REFERENCES "public"."CursosTurmasProvas"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "public"."CursosTurmasProvasEnvios" ADD CONSTRAINT "CursosTurmasProvasEnvios_matriculaId_fkey" FOREIGN KEY ("matriculaId") REFERENCES "public"."CursosTurmasMatriculas"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "public"."CursosTurmasProvasEnvios" ADD CONSTRAINT "CursosTurmasProvasEnvios_inscricaoId_fkey" FOREIGN KEY ("inscricaoId") REFERENCES "public"."CursosTurmasInscricoes"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
 ALTER TABLE "public"."CursosTurmasRegrasAvaliacao" ADD CONSTRAINT "CursosTurmasRegrasAvaliacao_turmaId_fkey" FOREIGN KEY ("turmaId") REFERENCES "public"."CursosTurmas"("id") ON DELETE CASCADE ON UPDATE CASCADE;
@@ -1458,7 +1458,7 @@ ALTER TABLE "public"."CursosTurmasRegrasAvaliacao" ADD CONSTRAINT "CursosTurmasR
 ALTER TABLE "public"."CursosTurmasRecuperacoes" ADD CONSTRAINT "CursosTurmasRecuperacoes_turmaId_fkey" FOREIGN KEY ("turmaId") REFERENCES "public"."CursosTurmas"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "public"."CursosTurmasRecuperacoes" ADD CONSTRAINT "CursosTurmasRecuperacoes_matriculaId_fkey" FOREIGN KEY ("matriculaId") REFERENCES "public"."CursosTurmasMatriculas"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "public"."CursosTurmasRecuperacoes" ADD CONSTRAINT "CursosTurmasRecuperacoes_inscricaoId_fkey" FOREIGN KEY ("inscricaoId") REFERENCES "public"."CursosTurmasInscricoes"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
 ALTER TABLE "public"."CursosTurmasRecuperacoes" ADD CONSTRAINT "CursosTurmasRecuperacoes_regraId_fkey" FOREIGN KEY ("regraId") REFERENCES "public"."CursosTurmasRegrasAvaliacao"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -46,7 +46,7 @@ model Usuarios {
   emailVerification    UsuariosVerificacaoEmail?
   informacoes          UsuariosInformation?
   cursosComoInstrutor  Cursos[]             @relation("CursosInstrutor")
-  turmasMatriculadas   CursosTurmasMatriculas[]
+  turmasInscritas   CursosTurmasInscricoes[]
   certificadosEmitidos CursosCertificadosEmitidos[] @relation("CursosCertificadosEmitidosEmitidoPor")
   estagiosComoAluno   CursosEstagios[]            @relation("CursosEstagiosAluno")
   estagiosCriados     CursosEstagios[]            @relation("CursosEstagiosCriadoPor")
@@ -65,7 +65,7 @@ model UsuariosInformation {
   telefone      String
   genero        String?
   dataNasc      DateTime?
-  matricula     String?
+  inscricao     String?
   avatarUrl     String?
   descricao     String?  @db.VarChar(500)
   aceitarTermos Boolean  @default(false)
@@ -161,7 +161,7 @@ model CursosTurmas {
   criadoEm             DateTime                 @default(now())
   atualizadoEm         DateTime                 @updatedAt
   curso                Cursos                   @relation(fields: [cursoId], references: [id], onDelete: Cascade)
-  matriculas           CursosTurmasMatriculas[]
+  inscricoes           CursosTurmasInscricoes[]
   aulas                CursosTurmasAulas[]
   modulos              CursosTurmasModulos[]
   provas               CursosTurmasProvas[]
@@ -238,7 +238,7 @@ model CursosTurmasAulasMateriais {
   @@index([tipo])
 }
 
-model CursosTurmasMatriculas {
+model CursosTurmasInscricoes {
   id        String   @id @default(uuid())
   turmaId   String
   alunoId   String
@@ -310,7 +310,7 @@ model CursosTurmasAgenda {
 model CursosTurmasProvasEnvios {
   id          String   @id @default(uuid())
   provaId     String
-  matriculaId String
+  inscricaoId String
   nota        Decimal? @db.Decimal(4, 1)
   pesoTotal   Decimal? @db.Decimal(5, 2)
   realizadoEm DateTime?
@@ -319,11 +319,11 @@ model CursosTurmasProvasEnvios {
   atualizadoEm DateTime @updatedAt
 
   prova      CursosTurmasProvas     @relation(fields: [provaId], references: [id], onDelete: Cascade)
-  matricula  CursosTurmasMatriculas @relation(fields: [matriculaId], references: [id], onDelete: Cascade)
+  inscricao  CursosTurmasInscricoes @relation(fields: [inscricaoId], references: [id], onDelete: Cascade)
   recuperacoes CursosTurmasRecuperacoes[]
 
-  @@unique([provaId, matriculaId])
-  @@index([matriculaId])
+  @@unique([provaId, inscricaoId])
+  @@index([inscricaoId])
 }
 
 model CursosTurmasRegrasAvaliacao {
@@ -346,7 +346,7 @@ model CursosTurmasRegrasAvaliacao {
 model CursosTurmasRecuperacoes {
   id              String                 @id @default(uuid())
   turmaId         String
-  matriculaId     String
+  inscricaoId     String
   regraId         String?
   provaId         String?
   envioId         String?
@@ -362,20 +362,20 @@ model CursosTurmasRecuperacoes {
   atualizadoEm    DateTime               @updatedAt
 
   turma     CursosTurmas               @relation(fields: [turmaId], references: [id], onDelete: Cascade)
-  matricula CursosTurmasMatriculas     @relation(fields: [matriculaId], references: [id], onDelete: Cascade)
+  inscricao CursosTurmasInscricoes     @relation(fields: [inscricaoId], references: [id], onDelete: Cascade)
   regra     CursosTurmasRegrasAvaliacao? @relation(fields: [regraId], references: [id], onDelete: SetNull)
   prova     CursosTurmasProvas?        @relation(fields: [provaId], references: [id], onDelete: SetNull)
   envio     CursosTurmasProvasEnvios?  @relation(fields: [envioId], references: [id], onDelete: SetNull)
 
   @@index([turmaId])
-  @@index([matriculaId])
+  @@index([inscricaoId])
   @@index([statusFinal])
 }
 
 model CursosNotas {
   id                String          @id @default(uuid())
   turmaId           String
-  matriculaId       String
+  inscricaoId       String
   tipo              CursosNotasTipo
   provaId           String?
   referenciaExterna String?         @db.VarChar(120)
@@ -390,19 +390,19 @@ model CursosNotas {
   atualizadoEm      DateTime        @updatedAt
 
   turma      CursosTurmas           @relation(fields: [turmaId], references: [id], onDelete: Cascade)
-  matricula  CursosTurmasMatriculas @relation(fields: [matriculaId], references: [id], onDelete: Cascade)
+  inscricao  CursosTurmasInscricoes @relation(fields: [inscricaoId], references: [id], onDelete: Cascade)
   prova      CursosTurmasProvas?    @relation(fields: [provaId], references: [id], onDelete: SetNull)
 
   @@index([turmaId])
-  @@index([matriculaId])
+  @@index([inscricaoId])
   @@index([tipo])
-  @@unique([matriculaId, provaId])
+  @@unique([inscricaoId, provaId])
 }
 
 model CursosFrequenciaAlunos {
   id             String                  @id @default(uuid())
   turmaId        String
-  matriculaId    String
+  inscricaoId    String
   aulaId         String?
   dataReferencia DateTime                @default(now())
   status         CursosFrequenciaStatus  @default(PRESENTE)
@@ -412,14 +412,14 @@ model CursosFrequenciaAlunos {
   atualizadoEm   DateTime                @updatedAt
 
   turma      CursosTurmas           @relation(fields: [turmaId], references: [id], onDelete: Cascade)
-  matricula  CursosTurmasMatriculas @relation(fields: [matriculaId], references: [id], onDelete: Cascade)
+  inscricao  CursosTurmasInscricoes @relation(fields: [inscricaoId], references: [id], onDelete: Cascade)
   aula       CursosTurmasAulas?     @relation(fields: [aulaId], references: [id], onDelete: SetNull)
 
   @@index([turmaId])
-  @@index([matriculaId])
+  @@index([inscricaoId])
   @@index([aulaId])
   @@index([dataReferencia])
-  @@unique([turmaId, matriculaId, aulaId, dataReferencia], map: "cursos_frequencia_unico")
+  @@unique([turmaId, inscricaoId, aulaId, dataReferencia], map: "cursos_frequencia_unico")
 }
 
 enum CursosSituacaoFinal {
@@ -1459,7 +1459,7 @@ enum CursosCertificadosLogAcao {
 
 model CursosCertificadosEmitidos {
   id             String                    @id @default(uuid())
-  matriculaId    String
+  inscricaoId    String
   codigo         String                    @unique @db.VarChar(20)
   tipo           CursosCertificados
   formato        CursosCertificadosTipos
@@ -1473,11 +1473,11 @@ model CursosCertificadosEmitidos {
   emitidoEm      DateTime                  @default(now())
   observacoes    String?                   @db.VarChar(500)
 
-  matricula CursosTurmasMatriculas @relation(fields: [matriculaId], references: [id], onDelete: Cascade)
+  inscricao CursosTurmasInscricoes @relation(fields: [inscricaoId], references: [id], onDelete: Cascade)
   emitidoPor Usuarios?             @relation("CursosCertificadosEmitidosEmitidoPor", fields: [emitidoPorId], references: [id], onDelete: SetNull)
   logs       CursosCertificadosLogs[]
 
-  @@index([matriculaId])
+  @@index([inscricaoId])
   @@index([emitidoPorId])
   @@index([emitidoEm])
 }
@@ -1501,7 +1501,7 @@ model CursosEstagios {
   id                     String               @id @default(uuid())
   cursoId                Int
   turmaId                String
-  matriculaId            String
+  inscricaoId            String
   alunoId                String
   nome                   String               @db.VarChar(255)
   descricao              String?              @db.Text
@@ -1524,7 +1524,7 @@ model CursosEstagios {
 
   curso        Cursos                    @relation(fields: [cursoId], references: [id], onDelete: Cascade)
   turma        CursosTurmas              @relation(fields: [turmaId], references: [id], onDelete: Cascade)
-  matricula    CursosTurmasMatriculas    @relation(fields: [matriculaId], references: [id], onDelete: Cascade)
+  inscricao    CursosTurmasInscricoes    @relation(fields: [inscricaoId], references: [id], onDelete: Cascade)
   aluno        Usuarios                  @relation("CursosEstagiosAluno", fields: [alunoId], references: [id], onDelete: Cascade)
   criadoPor    Usuarios?                 @relation("CursosEstagiosCriadoPor", fields: [criadoPorId], references: [id], onDelete: SetNull)
   atualizadoPor Usuarios?                @relation("CursosEstagiosAtualizadoPor", fields: [atualizadoPorId], references: [id], onDelete: SetNull)
@@ -1534,7 +1534,7 @@ model CursosEstagios {
 
   @@index([cursoId])
   @@index([turmaId])
-  @@index([matriculaId])
+  @@index([inscricaoId])
   @@index([alunoId])
   @@index([status])
   @@index([dataFim])

--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -141,7 +141,7 @@ const options: Options = {
       },
       {
         name: 'Cursos - Turmas',
-        description: 'Gestão de turmas, inscrições e matrículas dos cursos',
+        description: 'Gestão de turmas e inscrições dos cursos',
       },
       {
         name: 'Cursos - Aulas',
@@ -157,7 +157,7 @@ const options: Options = {
       },
       {
         name: 'Cursos - Estágios',
-        description: 'Gestão dos estágios supervisionados vinculados às matrículas dos cursos',
+        description: 'Gestão dos estágios supervisionados vinculados às inscrições dos cursos',
       },
       {
         name: 'MercadoPago - Assinaturas',
@@ -389,7 +389,7 @@ const options: Options = {
             id: { type: 'string', format: 'uuid', example: 'AL-001' },
             nome: { type: 'string', example: 'Maria Oliveira' },
             email: { type: 'string', format: 'email', example: 'maria.oliveira@example.com' },
-            matricula: { type: 'string', nullable: true, example: 'MAT12345' },
+            inscricao: { type: 'string', nullable: true, example: 'INS12345' },
             telefone: {
               type: 'string',
               nullable: true,
@@ -416,7 +416,7 @@ const options: Options = {
         CursoTurmaAulaMaterial: {
           type: 'object',
           properties: {
-            id: { type: 'string', format: 'uuid', example: 'mat-001' },
+            id: { type: 'string', format: 'uuid', example: 'ins-001' },
             aulaId: { type: 'string', format: 'uuid', example: 'aul-001' },
             titulo: { type: 'string', example: 'Slides de apresentação' },
             descricao: {
@@ -563,7 +563,7 @@ const options: Options = {
             estagioObrigatorio: {
               type: 'boolean',
               nullable: true,
-              description: 'Define se novas matrículas do curso exigirão estágio obrigatório.',
+              description: 'Define se novas inscrições do curso exigirão estágio obrigatório.',
             },
             instrutorId: { type: 'string', format: 'uuid', example: 'P-01' },
             categoriaId: { type: 'integer', nullable: true, example: 2 },
@@ -711,7 +711,7 @@ const options: Options = {
             id: { type: 'string', format: 'uuid', example: 'est-123' },
             cursoId: { type: 'integer', example: 10 },
             turmaId: { type: 'string', format: 'uuid', example: 'tur-123' },
-            matriculaId: { type: 'string', format: 'uuid', example: 'mat-789' },
+            inscricaoId: { type: 'string', format: 'uuid', example: 'ins-789' },
             nome: { type: 'string', example: 'Estágio Supervisionado em RH' },
             descricao: { type: 'string', nullable: true, example: 'Atividades práticas em ambiente corporativo.' },
             obrigatorio: { type: 'boolean', example: true },
@@ -1075,9 +1075,9 @@ const options: Options = {
         },
         CursoTurmaProvaNotaInput: {
           type: 'object',
-          required: ['matriculaId', 'nota'],
+          required: ['inscricaoId', 'nota'],
           properties: {
-            matriculaId: { type: 'string', format: 'uuid' },
+            inscricaoId: { type: 'string', format: 'uuid' },
             nota: { type: 'number', example: 7.5, minimum: 0, maximum: 10 },
             pesoTotal: { type: 'number', nullable: true, example: 1 },
             realizadoEm: { type: 'string', format: 'date-time', nullable: true },
@@ -1096,7 +1096,7 @@ const options: Options = {
           properties: {
             id: { type: 'string', format: 'uuid' },
             turmaId: { type: 'string', format: 'uuid' },
-            matriculaId: { type: 'string', format: 'uuid' },
+            inscricaoId: { type: 'string', format: 'uuid' },
             tipo: { $ref: '#/components/schemas/CursosNotaTipo' },
             provaId: { type: 'string', format: 'uuid', nullable: true },
             referenciaExterna: { type: 'string', nullable: true, example: 'TRAB-2025-01' },
@@ -1122,7 +1122,7 @@ const options: Options = {
                 etiqueta: { type: 'string', example: 'P1' },
               },
             },
-            matricula: {
+            inscricao: {
               type: 'object',
               nullable: true,
               properties: {
@@ -1143,9 +1143,9 @@ const options: Options = {
         },
         CursoNotaCreateInput: {
           type: 'object',
-          required: ['matriculaId', 'tipo'],
+          required: ['inscricaoId', 'tipo'],
           properties: {
-            matriculaId: { type: 'string', format: 'uuid' },
+            inscricaoId: { type: 'string', format: 'uuid' },
             tipo: { $ref: '#/components/schemas/CursosNotaTipo' },
             provaId: { type: 'string', format: 'uuid', nullable: true },
             referenciaExterna: { type: 'string', nullable: true, maxLength: 120 },
@@ -1181,10 +1181,10 @@ const options: Options = {
             observacoes: { type: 'string', nullable: true },
           },
         },
-        CursoNotaResumoMatricula: {
+        CursoNotaResumoInscricao: {
           type: 'object',
           properties: {
-            matricula: {
+            inscricao: {
               type: 'object',
               properties: {
                 id: { type: 'string', format: 'uuid' },
@@ -1312,11 +1312,11 @@ const options: Options = {
             {
               type: 'object',
               properties: {
-                matriculaId: {
+                inscricaoId: {
                   type: 'string',
                   format: 'uuid',
                   nullable: true,
-                  description: 'Identificador da matrícula do aluno na turma relacionada ao evento',
+                  description: 'Identificador da inscrição do aluno na turma relacionada ao evento',
                 },
               },
             },
@@ -1388,7 +1388,7 @@ const options: Options = {
           properties: {
             id: { type: 'string', format: 'uuid' },
             turmaId: { type: 'string', format: 'uuid' },
-            matriculaId: { type: 'string', format: 'uuid' },
+            inscricaoId: { type: 'string', format: 'uuid' },
             aulaId: { type: 'string', format: 'uuid', nullable: true },
             dataReferencia: { type: 'string', format: 'date-time' },
             status: { $ref: '#/components/schemas/CursosFrequenciaStatus' },
@@ -1422,7 +1422,7 @@ const options: Options = {
                 },
               },
             },
-            matricula: {
+            inscricao: {
               type: 'object',
               nullable: true,
               properties: {
@@ -1443,9 +1443,9 @@ const options: Options = {
         },
         CursoFrequenciaCreateInput: {
           type: 'object',
-          required: ['matriculaId', 'status'],
+          required: ['inscricaoId', 'status'],
           properties: {
-            matriculaId: { type: 'string', format: 'uuid' },
+            inscricaoId: { type: 'string', format: 'uuid' },
             aulaId: { type: 'string', format: 'uuid', nullable: true },
             dataReferencia: { type: 'string', format: 'date-time', nullable: true },
             status: { $ref: '#/components/schemas/CursosFrequenciaStatus' },
@@ -1481,10 +1481,10 @@ const options: Options = {
             },
           },
         },
-        CursoFrequenciaResumoMatricula: {
+        CursoFrequenciaResumoInscricao: {
           type: 'object',
           properties: {
-            matricula: {
+            inscricao: {
               type: 'object',
               properties: {
                 id: { type: 'string', format: 'uuid' },
@@ -1559,9 +1559,9 @@ const options: Options = {
         },
         CursoTurmaRecuperacaoInput: {
           type: 'object',
-          required: ['matriculaId'],
+          required: ['inscricaoId'],
           properties: {
-            matriculaId: { type: 'string', format: 'uuid' },
+            inscricaoId: { type: 'string', format: 'uuid' },
             provaId: { type: 'string', format: 'uuid', nullable: true },
             envioId: { type: 'string', format: 'uuid', nullable: true },
             notaRecuperacao: { type: 'number', nullable: true, example: 8 },
@@ -1609,7 +1609,7 @@ const options: Options = {
                 email: { type: 'string', format: 'email', example: 'joao@email.com' },
                 cpf: { type: 'string', nullable: true, example: '123.456.789-00' },
                 cpfMascarado: { type: 'string', nullable: true, example: '***.***.***-00' },
-                matricula: { type: 'string', nullable: true, example: 'MAT12345' },
+                inscricao: { type: 'string', nullable: true, example: 'INS12345' },
               },
             },
             curso: {
@@ -1646,9 +1646,9 @@ const options: Options = {
         },
         CursoCertificadoCreateInput: {
           type: 'object',
-          required: ['matriculaId', 'tipo', 'formato'],
+          required: ['inscricaoId', 'tipo', 'formato'],
           properties: {
-            matriculaId: { type: 'string', format: 'uuid' },
+            inscricaoId: { type: 'string', format: 'uuid' },
             tipo: { $ref: '#/components/schemas/CursosCertificados' },
             formato: { $ref: '#/components/schemas/CursosCertificadosTipos' },
             cargaHoraria: { type: 'integer', minimum: 1, nullable: true, example: 40 },
@@ -1656,10 +1656,10 @@ const options: Options = {
             observacoes: { type: 'string', nullable: true, maxLength: 500 },
           },
         },
-        CursoCertificadoResumoMatricula: {
+        CursoCertificadoResumoInscricao: {
           type: 'object',
           properties: {
-            matricula: {
+            inscricao: {
               type: 'object',
               properties: {
                 id: { type: 'string', format: 'uuid' },
@@ -1670,7 +1670,7 @@ const options: Options = {
                     nome: { type: 'string' },
                     email: { type: 'string', format: 'email' },
                     cpf: { type: 'string', nullable: true },
-                    matricula: { type: 'string', nullable: true },
+                    inscricao: { type: 'string', nullable: true },
                   },
                 },
               },
@@ -1792,7 +1792,7 @@ const options: Options = {
             dataInscricaoFim: { type: 'string', format: 'date-time', nullable: true },
           },
         },
-        CursoTurmaEnrollmentInput: {
+        CursoTurmaInscricaoInput: {
           type: 'object',
           required: ['alunoId'],
           properties: {
@@ -1801,7 +1801,7 @@ const options: Options = {
               format: 'uuid',
               example: 'AL-001',
               description:
-                'Identificador do aluno que receberá a matrícula. Após o encerramento do período de inscrição, apenas usuários ADMIN ou MODERADOR podem realizar esta operação.',
+                'Identificador do aluno que receberá a inscrição. Após o encerramento do período de inscrição, apenas usuários ADMIN ou MODERADOR podem realizar esta operação.',
             },
           },
         },
@@ -2306,7 +2306,7 @@ const options: Options = {
               nullable: true,
               example: '1990-01-01',
             },
-            matricula: { type: 'string', nullable: true, example: 'MAT123' },
+            inscricao: { type: 'string', nullable: true, example: 'INS123' },
             role: {
               allOf: [{ $ref: '#/components/schemas/Roles' }],
               description: 'Role do usuário',
@@ -5944,7 +5944,7 @@ const options: Options = {
               nullable: true,
               example: '1990-01-01',
             },
-            matricula: { type: 'string', nullable: true, example: 'MAT123' },
+            inscricao: { type: 'string', nullable: true, example: 'INS123' },
             avatarUrl: {
               type: 'string',
               nullable: true,
@@ -6084,7 +6084,7 @@ const options: Options = {
               nullable: true,
               example: '1995-07-15',
             },
-            matricula: { type: 'string', nullable: true, example: 'MAT-2024-001' },
+            inscricao: { type: 'string', nullable: true, example: 'INS-2024-001' },
             avatarUrl: {
               type: 'string',
               nullable: true,
@@ -8472,7 +8472,7 @@ const options: Options = {
                   example: '1990-01-01',
                 },
                 genero: { type: 'string', example: 'MASCULINO' },
-                matricula: { type: 'string', example: 'MAT123' },
+                inscricao: { type: 'string', example: 'INS123' },
                 supabaseId: { type: 'string', example: 'uuid-supabase' },
                 cidade: { type: 'string', nullable: true, example: 'Maceió' },
                 estado: { type: 'string', nullable: true, example: 'AL' },
@@ -8731,7 +8731,7 @@ const options: Options = {
                   example: '1990-01-01',
                 },
                 genero: { type: 'string', nullable: true, example: 'MASCULINO' },
-                matricula: { type: 'string', nullable: true, example: 'MAT123' },
+                inscricao: { type: 'string', nullable: true, example: 'INS123' },
                 supabaseId: { type: 'string', example: 'uuid-supabase' },
                 avatarUrl: {
                   type: 'string',

--- a/src/modules/cursos/controllers/agenda.controller.ts
+++ b/src/modules/cursos/controllers/agenda.controller.ts
@@ -431,11 +431,11 @@ export class AgendaController {
 
       res.json({ data: eventos });
     } catch (error: any) {
-      if (error?.code === 'MATRICULA_NOT_FOUND') {
+      if (error?.code === 'INSCRICAO_NOT_FOUND') {
         return res.status(404).json({
           success: false,
-          code: 'MATRICULA_NOT_FOUND',
-          message: 'Você não está matriculado na turma informada',
+          code: 'INSCRICAO_NOT_FOUND',
+          message: 'Você não está inscrito na turma informada',
         });
       }
 

--- a/src/modules/cursos/controllers/avaliacao.controller.ts
+++ b/src/modules/cursos/controllers/avaliacao.controller.ts
@@ -143,7 +143,7 @@ export class AvaliacaoController {
         : undefined;
 
       const recuperacao = await avaliacaoService.registrarRecuperacao(cursoId, turmaId, {
-        matriculaId: parsed.matriculaId,
+        inscricaoId: parsed.inscricaoId,
         provaId: parsed.provaId ?? null,
         envioId: parsed.envioId ?? null,
         notaRecuperacao: parsed.notaRecuperacao ?? null,
@@ -173,11 +173,11 @@ export class AvaliacaoController {
         });
       }
 
-      if (error?.code === 'MATRICULA_NOT_FOUND') {
+      if (error?.code === 'INSCRICAO_NOT_FOUND') {
         return res.status(404).json({
           success: false,
-          code: 'MATRICULA_NOT_FOUND',
-          message: 'Matrícula não encontrada para a turma informada',
+          code: 'INSCRICAO_NOT_FOUND',
+          message: 'Inscrição não encontrada para a turma informada',
         });
       }
 
@@ -193,7 +193,7 @@ export class AvaliacaoController {
         return res.status(404).json({
           success: false,
           code: 'ENVIO_NOT_FOUND',
-          message: 'Envio de prova não encontrado para a matrícula informada',
+          message: 'Envio de prova não encontrado para a inscrição informada',
         });
       }
 
@@ -207,46 +207,46 @@ export class AvaliacaoController {
   };
 
   static getGrades = async (req: Request, res: Response) => {
-    const matriculaId = req.params.matriculaId;
+    const inscricaoId = req.params.inscricaoId;
 
-    if (!matriculaId) {
+    if (!inscricaoId) {
       return res.status(400).json({
         success: false,
         code: 'VALIDATION_ERROR',
-        message: 'Identificador de matrícula inválido',
+        message: 'Identificador de inscrição inválido',
       });
     }
 
     try {
-      const boletim = await avaliacaoService.calcularNotasMatricula(matriculaId, undefined, { permitirAdmin: true });
+      const boletim = await avaliacaoService.calcularNotasInscricao(inscricaoId, undefined, { permitirAdmin: true });
       res.json(boletim);
     } catch (error: any) {
-      if (error?.code === 'MATRICULA_NOT_FOUND') {
+      if (error?.code === 'INSCRICAO_NOT_FOUND') {
         return res.status(404).json({
           success: false,
-          code: 'MATRICULA_NOT_FOUND',
-          message: 'Matrícula não encontrada',
+          code: 'INSCRICAO_NOT_FOUND',
+          message: 'Inscrição não encontrada',
         });
       }
 
       res.status(500).json({
         success: false,
         code: 'AVALIACAO_GRADE_ERROR',
-        message: 'Erro ao consultar notas da matrícula',
+        message: 'Erro ao consultar notas da inscrição',
         error: error?.message,
       });
     }
   };
 
   static getMyGrades = async (req: Request, res: Response) => {
-    const matriculaId = req.params.matriculaId;
+    const inscricaoId = req.params.inscricaoId;
     const usuarioId = req.user?.id;
 
-    if (!matriculaId) {
+    if (!inscricaoId) {
       return res.status(400).json({
         success: false,
         code: 'VALIDATION_ERROR',
-        message: 'Identificador de matrícula inválido',
+        message: 'Identificador de inscrição inválido',
       });
     }
 
@@ -259,14 +259,14 @@ export class AvaliacaoController {
     }
 
     try {
-      const boletim = await avaliacaoService.calcularNotasMatricula(matriculaId, usuarioId);
+      const boletim = await avaliacaoService.calcularNotasInscricao(inscricaoId, usuarioId);
       res.json(boletim);
     } catch (error: any) {
-      if (error?.code === 'MATRICULA_NOT_FOUND') {
+      if (error?.code === 'INSCRICAO_NOT_FOUND') {
         return res.status(404).json({
           success: false,
-          code: 'MATRICULA_NOT_FOUND',
-          message: 'Matrícula não encontrada',
+          code: 'INSCRICAO_NOT_FOUND',
+          message: 'Inscrição não encontrada',
         });
       }
 
@@ -274,14 +274,14 @@ export class AvaliacaoController {
         return res.status(403).json({
           success: false,
           code: 'FORBIDDEN',
-          message: 'Você não tem permissão para visualizar as notas desta matrícula',
+          message: 'Você não tem permissão para visualizar as notas desta inscrição',
         });
       }
 
       res.status(500).json({
         success: false,
         code: 'AVALIACAO_GRADE_ME_ERROR',
-        message: 'Erro ao consultar notas da matrícula do aluno',
+        message: 'Erro ao consultar notas da inscrição do aluno',
         error: error?.message,
       });
     }

--- a/src/modules/cursos/controllers/certificados.controller.ts
+++ b/src/modules/cursos/controllers/certificados.controller.ts
@@ -25,7 +25,7 @@ const parseTurmaId = (raw: unknown) => {
   return raw;
 };
 
-const parseMatriculaId = (raw: unknown) => {
+const parseInscricaoId = (raw: unknown) => {
   if (typeof raw !== 'string' || raw.trim().length === 0) {
     return null;
   }
@@ -71,11 +71,11 @@ export class CertificadosController {
         });
       }
 
-      if (error?.code === 'TURMA_NOT_FOUND' || error?.code === 'MATRICULA_NOT_FOUND') {
+      if (error?.code === 'TURMA_NOT_FOUND' || error?.code === 'INSCRICAO_NOT_FOUND') {
         return res.status(404).json({
           success: false,
           code: error.code,
-          message: 'Turma ou matrícula não encontrada para emissão do certificado',
+          message: 'Turma ou inscrição não encontrada para emissão do certificado',
         });
       }
 
@@ -117,7 +117,7 @@ export class CertificadosController {
     }
 
     const parsedQuery = listarCertificadosQuerySchema.safeParse({
-      matriculaId: ensureSingleValue(req.query.matriculaId),
+      inscricaoId: ensureSingleValue(req.query.inscricaoId),
       tipo: ensureSingleValue(req.query.tipo),
       formato: ensureSingleValue(req.query.formato),
     });
@@ -152,48 +152,48 @@ export class CertificadosController {
     }
   };
 
-  static listarPorMatricula = async (req: Request, res: Response) => {
-    const matriculaId = parseMatriculaId(req.params.matriculaId);
+  static listarPorInscricao = async (req: Request, res: Response) => {
+    const inscricaoId = parseInscricaoId(req.params.inscricaoId);
 
-    if (!matriculaId) {
+    if (!inscricaoId) {
       return res.status(400).json({
         success: false,
         code: 'VALIDATION_ERROR',
-        message: 'Identificador da matrícula inválido',
+        message: 'Identificador da inscrição inválido',
       });
     }
 
     try {
-      const resultado = await certificadosService.listarPorMatricula(matriculaId, undefined, {
+      const resultado = await certificadosService.listarPorInscricao(inscricaoId, undefined, {
         permitirAdmin: true,
       });
       res.json(resultado);
     } catch (error: any) {
-      if (error?.code === 'MATRICULA_NOT_FOUND') {
+      if (error?.code === 'INSCRICAO_NOT_FOUND') {
         return res.status(404).json({
           success: false,
-          code: 'MATRICULA_NOT_FOUND',
-          message: 'Matrícula não encontrada',
+          code: 'INSCRICAO_NOT_FOUND',
+          message: 'Inscrição não encontrada',
         });
       }
 
       res.status(500).json({
         success: false,
-        code: 'CERTIFICADO_MATRICULA_ERROR',
-        message: 'Erro ao consultar certificados da matrícula',
+        code: 'CERTIFICADO_INSCRICAO_ERROR',
+        message: 'Erro ao consultar certificados da inscrição',
         error: error?.message,
       });
     }
   };
 
-  static listarMePorMatricula = async (req: Request, res: Response) => {
-    const matriculaId = parseMatriculaId(req.params.matriculaId);
+  static listarMePorInscricao = async (req: Request, res: Response) => {
+    const inscricaoId = parseInscricaoId(req.params.inscricaoId);
 
-    if (!matriculaId) {
+    if (!inscricaoId) {
       return res.status(400).json({
         success: false,
         code: 'VALIDATION_ERROR',
-        message: 'Identificador da matrícula inválido',
+        message: 'Identificador da inscrição inválido',
       });
     }
 
@@ -208,14 +208,14 @@ export class CertificadosController {
     }
 
     try {
-      const resultado = await certificadosService.listarPorMatricula(matriculaId, usuarioId);
+      const resultado = await certificadosService.listarPorInscricao(inscricaoId, usuarioId);
       res.json(resultado);
     } catch (error: any) {
-      if (error?.code === 'MATRICULA_NOT_FOUND') {
+      if (error?.code === 'INSCRICAO_NOT_FOUND') {
         return res.status(404).json({
           success: false,
-          code: 'MATRICULA_NOT_FOUND',
-          message: 'Matrícula não encontrada',
+          code: 'INSCRICAO_NOT_FOUND',
+          message: 'Inscrição não encontrada',
         });
       }
 
@@ -223,14 +223,14 @@ export class CertificadosController {
         return res.status(403).json({
           success: false,
           code: 'FORBIDDEN',
-          message: 'Você não possui acesso aos certificados desta matrícula',
+          message: 'Você não possui acesso aos certificados desta inscrição',
         });
       }
 
       res.status(500).json({
         success: false,
-        code: 'CERTIFICADO_MATRICULA_ERROR',
-        message: 'Erro ao consultar certificados da matrícula',
+        code: 'CERTIFICADO_INSCRICAO_ERROR',
+        message: 'Erro ao consultar certificados da inscrição',
         error: error?.message,
       });
     }

--- a/src/modules/cursos/controllers/cursos.controller.ts
+++ b/src/modules/cursos/controllers/cursos.controller.ts
@@ -39,7 +39,7 @@ export class CursosController {
       endpoints: {
         cursos: '/',
         turmas: '/:cursoId/turmas',
-        matriculas: '/:cursoId/turmas/:turmaId/enrollments',
+        inscricoes: '/:cursoId/turmas/:turmaId/inscricoes',
       },
       status: 'operational',
     });

--- a/src/modules/cursos/controllers/estagios.controller.ts
+++ b/src/modules/cursos/controllers/estagios.controller.ts
@@ -29,9 +29,9 @@ export class EstagiosController {
   static async create(req: Request, res: Response) {
     const cursoId = parseCursoId(req.params.cursoId);
     const turmaId = parseUuid(req.params.turmaId);
-    const matriculaId = parseUuid(req.params.matriculaId);
+    const inscricaoId = parseUuid(req.params.inscricaoId);
 
-    if (!cursoId || !turmaId || !matriculaId) {
+    if (!cursoId || !turmaId || !inscricaoId) {
       return res.status(400).json({
         success: false,
         code: 'VALIDATION_ERROR',
@@ -43,7 +43,7 @@ export class EstagiosController {
       const payload = createEstagioSchema.parse(req.body);
       const usuarioId = req.user?.id;
 
-      const estagio = await estagiosService.create(cursoId, turmaId, matriculaId, payload, usuarioId);
+      const estagio = await estagiosService.create(cursoId, turmaId, inscricaoId, payload, usuarioId);
 
       return res.status(201).json(estagio);
     } catch (error: any) {
@@ -56,29 +56,29 @@ export class EstagiosController {
         });
       }
 
-      if (error?.code === 'TURMA_NOT_FOUND' || error?.code === 'MATRICULA_NOT_FOUND') {
+      if (error?.code === 'TURMA_NOT_FOUND' || error?.code === 'INSCRICAO_NOT_FOUND') {
         return res.status(404).json({
           success: false,
           code: error.code,
-          message: 'Turma ou matrícula não encontrada para o curso informado',
+          message: 'Turma ou inscrição não encontrada para o curso informado',
         });
       }
 
       return res.status(500).json({
         success: false,
         code: 'ESTAGIO_CREATE_ERROR',
-        message: 'Erro ao criar estágio para a matrícula informada',
+        message: 'Erro ao criar estágio para a inscrição informada',
         error: error?.message,
       });
     }
   }
 
-  static async listByMatricula(req: Request, res: Response) {
+  static async listByInscricao(req: Request, res: Response) {
     const cursoId = parseCursoId(req.params.cursoId);
     const turmaId = parseUuid(req.params.turmaId);
-    const matriculaId = parseUuid(req.params.matriculaId);
+    const inscricaoId = parseUuid(req.params.inscricaoId);
 
-    if (!cursoId || !turmaId || !matriculaId) {
+    if (!cursoId || !turmaId || !inscricaoId) {
       return res.status(400).json({
         success: false,
         code: 'VALIDATION_ERROR',
@@ -87,21 +87,21 @@ export class EstagiosController {
     }
 
     try {
-      const estagios = await estagiosService.listByMatricula(cursoId, turmaId, matriculaId);
+      const estagios = await estagiosService.listByInscricao(cursoId, turmaId, inscricaoId);
       return res.json({ data: estagios });
     } catch (error: any) {
-      if (error?.code === 'TURMA_NOT_FOUND' || error?.code === 'MATRICULA_NOT_FOUND') {
+      if (error?.code === 'TURMA_NOT_FOUND' || error?.code === 'INSCRICAO_NOT_FOUND') {
         return res.status(404).json({
           success: false,
           code: error.code,
-          message: 'Turma ou matrícula não encontrada',
+          message: 'Turma ou inscrição não encontrada',
         });
       }
 
       return res.status(500).json({
         success: false,
         code: 'ESTAGIO_LIST_ERROR',
-        message: 'Erro ao listar estágios da matrícula',
+        message: 'Erro ao listar estágios da inscrição',
         error: error?.message,
       });
     }
@@ -109,7 +109,7 @@ export class EstagiosController {
 
   static async listMe(req: Request, res: Response) {
     const usuarioId = req.user?.id;
-    const matriculaId = parseUuid(req.params.matriculaId);
+    const inscricaoId = parseUuid(req.params.inscricaoId);
 
     if (!usuarioId) {
       return res.status(401).json({
@@ -119,23 +119,23 @@ export class EstagiosController {
       });
     }
 
-    if (!matriculaId) {
+    if (!inscricaoId) {
       return res.status(400).json({
         success: false,
         code: 'VALIDATION_ERROR',
-        message: 'Identificador da matrícula inválido',
+        message: 'Identificador da inscrição inválido',
       });
     }
 
     try {
-      const estagios = await estagiosService.listForAluno(matriculaId, usuarioId);
+      const estagios = await estagiosService.listForAluno(inscricaoId, usuarioId);
       return res.json({ data: estagios });
     } catch (error: any) {
       if (error?.code === 'FORBIDDEN') {
         return res.status(403).json({
           success: false,
           code: 'FORBIDDEN',
-          message: 'Matrícula não encontrada para o usuário autenticado',
+          message: 'Inscrição não encontrada para o usuário autenticado',
         });
       }
 

--- a/src/modules/cursos/controllers/frequencia.controller.ts
+++ b/src/modules/cursos/controllers/frequencia.controller.ts
@@ -27,7 +27,7 @@ const parseFrequenciaId = (raw: string) => {
   return raw;
 };
 
-const parseMatriculaId = (raw: unknown) => {
+const parseInscricaoId = (raw: unknown) => {
   if (typeof raw !== 'string' || raw.trim().length === 0) {
     return null;
   }
@@ -88,12 +88,12 @@ export class FrequenciaController {
       });
     }
 
-    const matriculaId = parseMatriculaId(req.query.matriculaId);
-    if (matriculaId === null && req.query.matriculaId !== undefined) {
+    const inscricaoId = parseInscricaoId(req.query.inscricaoId);
+    if (inscricaoId === null && req.query.inscricaoId !== undefined) {
       return res.status(400).json({
         success: false,
         code: 'VALIDATION_ERROR',
-        message: 'Identificador da matrícula inválido',
+        message: 'Identificador da inscrição inválido',
       });
     }
 
@@ -128,7 +128,7 @@ export class FrequenciaController {
 
     try {
       const frequencias = await frequenciaService.list(cursoId, turmaId, {
-        matriculaId: matriculaId ?? undefined,
+        inscricaoId: inscricaoId ?? undefined,
         aulaId,
         status,
         dataInicio,
@@ -145,11 +145,11 @@ export class FrequenciaController {
         });
       }
 
-      if (error?.code === 'MATRICULA_NOT_FOUND') {
+      if (error?.code === 'INSCRICAO_NOT_FOUND') {
         return res.status(404).json({
           success: false,
-          code: 'MATRICULA_NOT_FOUND',
-          message: 'Matrícula não encontrada para a turma informada',
+          code: 'INSCRICAO_NOT_FOUND',
+          message: 'Inscrição não encontrada para a turma informada',
         });
       }
 
@@ -244,11 +244,11 @@ export class FrequenciaController {
         });
       }
 
-      if (error?.code === 'MATRICULA_NOT_FOUND') {
+      if (error?.code === 'INSCRICAO_NOT_FOUND') {
         return res.status(404).json({
           success: false,
-          code: 'MATRICULA_NOT_FOUND',
-          message: 'Matrícula não encontrada para a turma informada',
+          code: 'INSCRICAO_NOT_FOUND',
+          message: 'Inscrição não encontrada para a turma informada',
         });
       }
 
@@ -385,46 +385,46 @@ export class FrequenciaController {
     }
   };
 
-  static listByMatricula = async (req: Request, res: Response) => {
-    const matriculaId = parseMatriculaId(req.params.matriculaId);
+  static listByInscricao = async (req: Request, res: Response) => {
+    const inscricaoId = parseInscricaoId(req.params.inscricaoId);
 
-    if (!matriculaId) {
+    if (!inscricaoId) {
       return res.status(400).json({
         success: false,
         code: 'VALIDATION_ERROR',
-        message: 'Identificador da matrícula inválido',
+        message: 'Identificador da inscrição inválido',
       });
     }
 
     try {
-      const resultado = await frequenciaService.listByMatricula(matriculaId, undefined, { permitirAdmin: true });
+      const resultado = await frequenciaService.listByInscricao(inscricaoId, undefined, { permitirAdmin: true });
       res.json(resultado);
     } catch (error: any) {
-      if (error?.code === 'MATRICULA_NOT_FOUND') {
+      if (error?.code === 'INSCRICAO_NOT_FOUND') {
         return res.status(404).json({
           success: false,
-          code: 'MATRICULA_NOT_FOUND',
-          message: 'Matrícula não encontrada',
+          code: 'INSCRICAO_NOT_FOUND',
+          message: 'Inscrição não encontrada',
         });
       }
 
       res.status(500).json({
         success: false,
-        code: 'FREQUENCIA_MATRICULA_ERROR',
-        message: 'Erro ao consultar frequência da matrícula',
+        code: 'FREQUENCIA_INSCRICAO_ERROR',
+        message: 'Erro ao consultar frequência da inscrição',
         error: error?.message,
       });
     }
   };
 
   static listMy = async (req: Request, res: Response) => {
-    const matriculaId = parseMatriculaId(req.params.matriculaId);
+    const inscricaoId = parseInscricaoId(req.params.inscricaoId);
 
-    if (!matriculaId) {
+    if (!inscricaoId) {
       return res.status(400).json({
         success: false,
         code: 'VALIDATION_ERROR',
-        message: 'Identificador da matrícula inválido',
+        message: 'Identificador da inscrição inválido',
       });
     }
 
@@ -439,14 +439,14 @@ export class FrequenciaController {
     }
 
     try {
-      const resultado = await frequenciaService.listByMatricula(matriculaId, usuarioId);
+      const resultado = await frequenciaService.listByInscricao(inscricaoId, usuarioId);
       res.json(resultado);
     } catch (error: any) {
-      if (error?.code === 'MATRICULA_NOT_FOUND') {
+      if (error?.code === 'INSCRICAO_NOT_FOUND') {
         return res.status(404).json({
           success: false,
-          code: 'MATRICULA_NOT_FOUND',
-          message: 'Matrícula não encontrada',
+          code: 'INSCRICAO_NOT_FOUND',
+          message: 'Inscrição não encontrada',
         });
       }
 
@@ -454,14 +454,14 @@ export class FrequenciaController {
         return res.status(403).json({
           success: false,
           code: 'FORBIDDEN',
-          message: 'Você não tem permissão para visualizar a frequência desta matrícula',
+          message: 'Você não tem permissão para visualizar a frequência desta inscrição',
         });
       }
 
       res.status(500).json({
         success: false,
-        code: 'FREQUENCIA_ME_MATRICULA_ERROR',
-        message: 'Erro ao consultar frequência da matrícula do aluno',
+        code: 'FREQUENCIA_ME_INSCRICAO_ERROR',
+        message: 'Erro ao consultar frequência da inscrição do aluno',
         error: error?.message,
       });
     }

--- a/src/modules/cursos/controllers/notas.controller.ts
+++ b/src/modules/cursos/controllers/notas.controller.ts
@@ -27,7 +27,7 @@ const parseNotaId = (raw: string) => {
   return raw;
 };
 
-const parseMatriculaId = (raw: unknown) => {
+const parseInscricaoId = (raw: unknown) => {
   if (typeof raw !== 'string' || raw.trim().length === 0) {
     return null;
   }
@@ -47,11 +47,11 @@ export class NotasController {
       });
     }
 
-    const matriculaId = parseMatriculaId(req.query.matriculaId);
+    const inscricaoId = parseInscricaoId(req.query.inscricaoId);
 
     try {
       const notas = await notasService.list(cursoId, turmaId, {
-        matriculaId: matriculaId ?? undefined,
+        inscricaoId: inscricaoId ?? undefined,
       });
       res.json({ data: notas });
     } catch (error: any) {
@@ -143,11 +143,11 @@ export class NotasController {
         });
       }
 
-      if (error?.code === 'MATRICULA_NOT_FOUND') {
+      if (error?.code === 'INSCRICAO_NOT_FOUND') {
         return res.status(404).json({
           success: false,
-          code: 'MATRICULA_NOT_FOUND',
-          message: 'Matrícula não encontrada para a turma informada',
+          code: 'INSCRICAO_NOT_FOUND',
+          message: 'Inscrição não encontrada para a turma informada',
         });
       }
 
@@ -282,46 +282,46 @@ export class NotasController {
     }
   };
 
-  static listByMatricula = async (req: Request, res: Response) => {
-    const matriculaId = parseMatriculaId(req.params.matriculaId);
+  static listByInscricao = async (req: Request, res: Response) => {
+    const inscricaoId = parseInscricaoId(req.params.inscricaoId);
 
-    if (!matriculaId) {
+    if (!inscricaoId) {
       return res.status(400).json({
         success: false,
         code: 'VALIDATION_ERROR',
-        message: 'Identificador da matrícula inválido',
+        message: 'Identificador da inscrição inválido',
       });
     }
 
     try {
-      const resultado = await notasService.listByMatricula(matriculaId, undefined, { permitirAdmin: true });
+      const resultado = await notasService.listByInscricao(inscricaoId, undefined, { permitirAdmin: true });
       res.json(resultado);
     } catch (error: any) {
-      if (error?.code === 'MATRICULA_NOT_FOUND') {
+      if (error?.code === 'INSCRICAO_NOT_FOUND') {
         return res.status(404).json({
           success: false,
-          code: 'MATRICULA_NOT_FOUND',
-          message: 'Matrícula não encontrada',
+          code: 'INSCRICAO_NOT_FOUND',
+          message: 'Inscrição não encontrada',
         });
       }
 
       res.status(500).json({
         success: false,
-        code: 'NOTAS_MATRICULA_ERROR',
-        message: 'Erro ao consultar notas da matrícula',
+        code: 'NOTAS_INSCRICAO_ERROR',
+        message: 'Erro ao consultar notas da inscrição',
         error: error?.message,
       });
     }
   };
 
   static listMy = async (req: Request, res: Response) => {
-    const matriculaId = parseMatriculaId(req.params.matriculaId);
+    const inscricaoId = parseInscricaoId(req.params.inscricaoId);
 
-    if (!matriculaId) {
+    if (!inscricaoId) {
       return res.status(400).json({
         success: false,
         code: 'VALIDATION_ERROR',
-        message: 'Identificador da matrícula inválido',
+        message: 'Identificador da inscrição inválido',
       });
     }
 
@@ -336,14 +336,14 @@ export class NotasController {
     }
 
     try {
-      const resultado = await notasService.listByMatricula(matriculaId, usuarioId);
+      const resultado = await notasService.listByInscricao(inscricaoId, usuarioId);
       res.json(resultado);
     } catch (error: any) {
-      if (error?.code === 'MATRICULA_NOT_FOUND') {
+      if (error?.code === 'INSCRICAO_NOT_FOUND') {
         return res.status(404).json({
           success: false,
-          code: 'MATRICULA_NOT_FOUND',
-          message: 'Matrícula não encontrada',
+          code: 'INSCRICAO_NOT_FOUND',
+          message: 'Inscrição não encontrada',
         });
       }
 
@@ -351,14 +351,14 @@ export class NotasController {
         return res.status(403).json({
           success: false,
           code: 'FORBIDDEN',
-          message: 'Você não tem permissão para visualizar as notas desta matrícula',
+          message: 'Você não tem permissão para visualizar as notas desta inscrição',
         });
       }
 
       res.status(500).json({
         success: false,
-        code: 'NOTAS_ME_MATRICULA_ERROR',
-        message: 'Erro ao consultar notas da matrícula do aluno',
+        code: 'NOTAS_ME_INSCRICAO_ERROR',
+        message: 'Erro ao consultar notas da inscrição do aluno',
         error: error?.message,
       });
     }

--- a/src/modules/cursos/controllers/provas.controller.ts
+++ b/src/modules/cursos/controllers/provas.controller.ts
@@ -278,11 +278,11 @@ export class ProvasController {
         });
       }
 
-      if (error?.code === 'MATRICULA_NOT_FOUND') {
+      if (error?.code === 'INSCRICAO_NOT_FOUND') {
         return res.status(404).json({
           success: false,
-          code: 'MATRICULA_NOT_FOUND',
-          message: 'Matrícula não encontrada para a turma informada',
+          code: 'INSCRICAO_NOT_FOUND',
+          message: 'Inscrição não encontrada para a turma informada',
         });
       }
 

--- a/src/modules/cursos/controllers/turmas.controller.ts
+++ b/src/modules/cursos/controllers/turmas.controller.ts
@@ -4,11 +4,7 @@ import { ZodError } from 'zod';
 
 import { turmasService } from '../services/turmas.service';
 import { cursosService } from '../services/cursos.service';
-import {
-  createTurmaSchema,
-  turmaEnrollmentSchema,
-  updateTurmaSchema,
-} from '../validators/turmas.schema';
+import { createTurmaSchema, turmaInscricaoSchema, updateTurmaSchema } from '../validators/turmas.schema';
 
 const parseCursoId = (raw: string) => {
   const id = Number(raw);
@@ -227,7 +223,7 @@ export class TurmasController {
         return res.status(400).json({
           success: false,
           code: 'INVALID_VAGAS_TOTAIS',
-          message: 'Vagas totais não podem ser menores que matrículas ativas',
+          message: 'Vagas totais não podem ser menores que inscrições ativas',
         });
       }
 
@@ -253,7 +249,7 @@ export class TurmasController {
     }
 
     try {
-      const data = turmaEnrollmentSchema.parse(req.body);
+      const data = turmaInscricaoSchema.parse(req.body);
       const actorRole = (req.user?.role as Roles | undefined) ?? null;
       const turma = await turmasService.enroll(cursoId, turmaId, data.alunoId, {
         id: req.user?.id ?? null,
@@ -265,7 +261,7 @@ export class TurmasController {
         return res.status(400).json({
           success: false,
           code: 'VALIDATION_ERROR',
-          message: 'Dados inválidos para matrícula na turma',
+          message: 'Dados inválidos para inscrição na turma',
           issues: error.flatten().fieldErrors,
         });
       }
@@ -310,11 +306,11 @@ export class TurmasController {
         });
       }
 
-      if (error?.code === 'ALUNO_JA_MATRICULADO') {
+      if (error?.code === 'ALUNO_JA_INSCRITO') {
         return res.status(409).json({
           success: false,
-          code: 'ALUNO_JA_MATRICULADO',
-          message: 'Aluno já está matriculado nesta turma',
+          code: 'ALUNO_JA_INSCRITO',
+          message: 'Aluno já está inscrito nesta turma',
         });
       }
 
@@ -322,14 +318,14 @@ export class TurmasController {
         return res.status(400).json({
           success: false,
           code: 'ALUNO_INFORMATION_NOT_FOUND',
-          message: 'Informações do aluno não encontradas para geração da matrícula',
+          message: 'Informações do aluno não encontradas para geração da inscrição',
         });
       }
 
       res.status(500).json({
         success: false,
         code: 'TURMA_ENROLL_ERROR',
-        message: 'Erro ao matricular aluno na turma',
+        message: 'Erro ao inscrever aluno na turma',
         error: error?.message,
       });
     }
@@ -360,18 +356,18 @@ export class TurmasController {
         });
       }
 
-      if (error?.code === 'ALUNO_NAO_MATRICULADO') {
+      if (error?.code === 'ALUNO_NAO_INSCRITO') {
         return res.status(404).json({
           success: false,
-          code: 'ALUNO_NAO_MATRICULADO',
-          message: 'Aluno não está matriculado nesta turma',
+          code: 'ALUNO_NAO_INSCRITO',
+          message: 'Aluno não está inscrito nesta turma',
         });
       }
 
       res.status(500).json({
         success: false,
         code: 'TURMA_UNENROLL_ERROR',
-        message: 'Erro ao remover matrícula do aluno na turma',
+        message: 'Erro ao remover inscrição do aluno na turma',
         error: error?.message,
       });
     }

--- a/src/modules/cursos/routes/index.ts
+++ b/src/modules/cursos/routes/index.ts
@@ -425,9 +425,9 @@ router.put(
 
 /**
  * @openapi
- * /api/v1/cursos/{cursoId}/turmas/{turmaId}/enrollments:
+ * /api/v1/cursos/{cursoId}/turmas/{turmaId}/inscricoes:
  *   post:
- *     summary: Matricular um aluno em uma turma
+ *     summary: Inscrever um aluno em uma turma
  *     description: >-
  *       Respeita automaticamente o período de inscrição informado na turma. Após o encerramento,
  *       apenas usuários com perfis ADMIN ou MODERADOR podem incluir alunos manualmente.
@@ -448,32 +448,32 @@ router.put(
  *       content:
  *         application/json:
  *           schema:
- *             $ref: '#/components/schemas/CursoTurmaEnrollmentInput'
+ *             $ref: '#/components/schemas/CursoTurmaInscricaoInput'
  *     responses:
  *       201:
- *         description: Matrícula registrada com sucesso
+ *         description: Inscrição registrada com sucesso
  *         content:
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/CursoTurma'
  *       400:
- *         description: Dados inválidos para matrícula
+ *         description: Dados inválidos para inscrição
  *       404:
  *         description: Curso, turma ou aluno não encontrado
  *       409:
- *         description: Conflitos de matrícula ou período de inscrição encerrado para perfis sem privilégio
+ *         description: Conflitos de inscrição ou período de inscrição encerrado para perfis sem privilégio
  */
 router.post(
-  '/:cursoId/turmas/:turmaId/enrollments',
+  '/:cursoId/turmas/:turmaId/inscricoes',
   supabaseAuthMiddleware([Roles.ADMIN, Roles.MODERADOR, Roles.PEDAGOGICO, Roles.PROFESSOR]),
   TurmasController.enroll,
 );
 
 /**
  * @openapi
- * /api/v1/cursos/{cursoId}/turmas/{turmaId}/enrollments/{alunoId}:
+ * /api/v1/cursos/{cursoId}/turmas/{turmaId}/inscricoes/{alunoId}:
  *   delete:
- *     summary: Remover matrícula de um aluno na turma
+ *     summary: Remover inscrição de um aluno na turma
  *     tags: ['Cursos - Turmas']
  *     security:
  *       - bearerAuth: []
@@ -492,7 +492,7 @@ router.post(
  *         schema: { type: string, format: uuid }
  *     responses:
  *       200:
- *         description: Matrícula removida com sucesso
+ *         description: Inscrição removida com sucesso
  *         content:
  *           application/json:
  *             schema:
@@ -501,7 +501,7 @@ router.post(
  *         description: Turma ou aluno não encontrado
  */
 router.delete(
-  '/:cursoId/turmas/:turmaId/enrollments/:alunoId',
+  '/:cursoId/turmas/:turmaId/inscricoes/:alunoId',
   supabaseAuthMiddleware([Roles.ADMIN, Roles.MODERADOR, Roles.PEDAGOGICO, Roles.PROFESSOR]),
   TurmasController.unenroll,
 );
@@ -1034,10 +1034,10 @@ router.delete(
  *         required: true
  *         schema: { type: string, format: uuid }
  *       - in: query
- *         name: matriculaId
+ *         name: inscricaoId
  *         required: false
  *         schema: { type: string, format: uuid }
- *         description: Filtra registros de frequência de uma matrícula específica
+ *         description: Filtra registros de frequência de uma inscrição específica
  *       - in: query
  *         name: aulaId
  *         required: false
@@ -1244,10 +1244,10 @@ router.delete(
  *         required: true
  *         schema: { type: string, format: uuid }
  *       - in: query
- *         name: matriculaId
+ *         name: inscricaoId
  *         required: false
  *         schema: { type: string, format: uuid }
- *         description: Filtra notas lançadas para uma matrícula específica
+ *         description: Filtra notas lançadas para uma inscrição específica
  *     responses:
  *       200:
  *         description: Lista de notas lançadas
@@ -1616,7 +1616,7 @@ router.delete(
  * @openapi
  * /api/v1/cursos/me/agenda:
  *   get:
- *     summary: Consultar eventos das turmas em que o aluno está matriculado
+ *     summary: Consultar eventos das turmas em que o aluno está inscrito
  *     tags: ['Cursos - Agenda']
  *     security:
  *       - bearerAuth: []
@@ -1654,34 +1654,34 @@ router.get('/me/agenda', supabaseAuthMiddleware([Roles.ALUNO_CANDIDATO]), Agenda
 
 /**
  * @openapi
- * /api/v1/cursos/matriculas/{matriculaId}/frequencias-detalhadas:
+ * /api/v1/cursos/inscricoes/{inscricaoId}/frequencias-detalhadas:
  *   get:
- *     summary: Consultar registros de frequência de uma matrícula (admin)
+ *     summary: Consultar registros de frequência de uma inscrição (admin)
  *     tags: ['Cursos - Frequências']
  *     security:
  *       - bearerAuth: []
  *     parameters:
  *       - in: path
- *         name: matriculaId
+ *         name: inscricaoId
  *         required: true
  *         schema: { type: string, format: uuid }
  *     responses:
  *       200:
- *         description: Frequência lançada e informações da matrícula
+ *         description: Frequência lançada e informações da inscrição
  *         content:
  *           application/json:
  *             schema:
- *               $ref: '#/components/schemas/CursoFrequenciaResumoMatricula'
+ *               $ref: '#/components/schemas/CursoFrequenciaResumoInscricao'
  */
 router.get(
-  '/matriculas/:matriculaId/frequencias-detalhadas',
+  '/inscricoes/:inscricaoId/frequencias-detalhadas',
   supabaseAuthMiddleware([Roles.ADMIN, Roles.MODERADOR, Roles.PEDAGOGICO, Roles.PROFESSOR]),
-  FrequenciaController.listByMatricula,
+  FrequenciaController.listByInscricao,
 );
 
 /**
  * @openapi
- * /api/v1/cursos/me/matriculas/{matriculaId}/frequencias-detalhadas:
+ * /api/v1/cursos/me/inscricoes/{inscricaoId}/frequencias-detalhadas:
  *   get:
  *     summary: Consultar registros de frequência do aluno autenticado
  *     tags: ['Cursos - Frequências']
@@ -1689,19 +1689,19 @@ router.get(
  *       - bearerAuth: []
  *     parameters:
  *       - in: path
- *         name: matriculaId
+ *         name: inscricaoId
  *         required: true
  *         schema: { type: string, format: uuid }
  *     responses:
  *       200:
- *         description: Frequência lançada associada à matrícula do aluno
+ *         description: Frequência lançada associada à inscrição do aluno
  *         content:
  *           application/json:
  *             schema:
- *               $ref: '#/components/schemas/CursoFrequenciaResumoMatricula'
+ *               $ref: '#/components/schemas/CursoFrequenciaResumoInscricao'
  */
 router.get(
-  '/me/matriculas/:matriculaId/frequencias-detalhadas',
+  '/me/inscricoes/:inscricaoId/frequencias-detalhadas',
   supabaseAuthMiddleware([Roles.ALUNO_CANDIDATO]),
   FrequenciaController.listMy,
 );
@@ -1829,34 +1829,34 @@ router.post(
 
 /**
  * @openapi
- * /api/v1/cursos/matriculas/{matriculaId}/notas-detalhadas:
+ * /api/v1/cursos/inscricoes/{inscricaoId}/notas-detalhadas:
  *   get:
- *     summary: Consultar notas lançadas de uma matrícula (admin)
+ *     summary: Consultar notas lançadas de uma inscrição (admin)
  *     tags: ['Cursos - Notas']
  *     security:
  *       - bearerAuth: []
  *     parameters:
  *       - in: path
- *         name: matriculaId
+ *         name: inscricaoId
  *         required: true
  *         schema: { type: string, format: uuid }
  *     responses:
  *       200:
- *         description: Notas lançadas e informações da matrícula
+ *         description: Notas lançadas e informações da inscrição
  *         content:
  *           application/json:
  *             schema:
- *               $ref: '#/components/schemas/CursoNotaResumoMatricula'
+ *               $ref: '#/components/schemas/CursoNotaResumoInscricao'
  */
 router.get(
-  '/matriculas/:matriculaId/notas-detalhadas',
+  '/inscricoes/:inscricaoId/notas-detalhadas',
   supabaseAuthMiddleware([Roles.ADMIN, Roles.MODERADOR, Roles.PEDAGOGICO, Roles.PROFESSOR]),
-  NotasController.listByMatricula,
+  NotasController.listByInscricao,
 );
 
 /**
  * @openapi
- * /api/v1/cursos/me/matriculas/{matriculaId}/notas-detalhadas:
+ * /api/v1/cursos/me/inscricoes/{inscricaoId}/notas-detalhadas:
  *   get:
  *     summary: Consultar notas lançadas do aluno autenticado
  *     tags: ['Cursos - Notas']
@@ -1864,46 +1864,46 @@ router.get(
  *       - bearerAuth: []
  *     parameters:
  *       - in: path
- *         name: matriculaId
+ *         name: inscricaoId
  *         required: true
  *         schema: { type: string, format: uuid }
  *     responses:
  *       200:
- *         description: Notas lançadas associadas à matrícula do aluno
+ *         description: Notas lançadas associadas à inscrição do aluno
  *         content:
  *           application/json:
  *             schema:
- *               $ref: '#/components/schemas/CursoNotaResumoMatricula'
+ *               $ref: '#/components/schemas/CursoNotaResumoInscricao'
  */
 router.get(
-  '/me/matriculas/:matriculaId/notas-detalhadas',
+  '/me/inscricoes/:inscricaoId/notas-detalhadas',
   supabaseAuthMiddleware([Roles.ALUNO_CANDIDATO]),
   NotasController.listMy,
 );
 
 /**
  * @openapi
- * /api/v1/cursos/matriculas/{matriculaId}/notas:
+ * /api/v1/cursos/inscricoes/{inscricaoId}/notas:
  *   get:
- *     summary: Consultar notas consolidadas de uma matrícula (admin)
+ *     summary: Consultar notas consolidadas de uma inscrição (admin)
  *     tags: ['Cursos - Avaliação']
  *     security:
  *       - bearerAuth: []
  *     parameters:
  *       - in: path
- *         name: matriculaId
+ *         name: inscricaoId
  *         required: true
  *         schema: { type: string, format: uuid }
  */
 router.get(
-  '/matriculas/:matriculaId/notas',
+  '/inscricoes/:inscricaoId/notas',
   supabaseAuthMiddleware([Roles.ADMIN, Roles.MODERADOR, Roles.PEDAGOGICO]),
   AvaliacaoController.getGrades,
 );
 
 /**
  * @openapi
- * /api/v1/cursos/me/matriculas/{matriculaId}/notas:
+ * /api/v1/cursos/me/inscricoes/{inscricaoId}/notas:
  *   get:
  *     summary: Consultar notas consolidadas do aluno autenticado
  *     tags: ['Cursos - Avaliação']
@@ -1911,12 +1911,12 @@ router.get(
  *       - bearerAuth: []
  *     parameters:
  *       - in: path
- *         name: matriculaId
+ *         name: inscricaoId
  *         required: true
  *         schema: { type: string, format: uuid }
  */
 router.get(
-  '/me/matriculas/:matriculaId/notas',
+  '/me/inscricoes/:inscricaoId/notas',
   supabaseAuthMiddleware([Roles.ALUNO_CANDIDATO]),
   AvaliacaoController.getMyGrades,
 );
@@ -1925,7 +1925,7 @@ router.get(
  * @openapi
  * /api/v1/cursos/{cursoId}/turmas/{turmaId}/certificados:
  *   post:
- *     summary: Emitir certificado para um aluno matriculado na turma
+ *     summary: Emitir certificado para um aluno inscrito na turma
  *     tags: ['Cursos - Certificados']
  *     security:
  *       - bearerAuth: []
@@ -1958,7 +1958,7 @@ router.get(
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  *       404:
- *         description: Turma ou matrícula não encontrada
+ *         description: Turma ou inscrição não encontrada
  *         content:
  *           application/json:
  *             schema:
@@ -1972,9 +1972,9 @@ router.post(
 
 /**
  * @openapi
- * /api/v1/cursos/{cursoId}/turmas/{turmaId}/matriculas/{matriculaId}/estagios:
+ * /api/v1/cursos/{cursoId}/turmas/{turmaId}/inscricoes/{inscricaoId}/estagios:
  *   post:
- *     summary: Criar estágio supervisionado para a matrícula
+ *     summary: Criar estágio supervisionado para a inscrição
  *     tags: ['Cursos - Estágios']
  *     security:
  *       - bearerAuth: []
@@ -1988,7 +1988,7 @@ router.post(
  *         required: true
  *         schema: { type: string, format: uuid }
  *       - in: path
- *         name: matriculaId
+ *         name: inscricaoId
  *         required: true
  *         schema: { type: string, format: uuid }
  *     requestBody:
@@ -2011,23 +2011,23 @@ router.post(
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  *       404:
- *         description: Curso, turma ou matrícula não localizada
+ *         description: Curso, turma ou inscrição não localizada
  *         content:
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  */
 router.post(
-  '/:cursoId/turmas/:turmaId/matriculas/:matriculaId/estagios',
+  '/:cursoId/turmas/:turmaId/inscricoes/:inscricaoId/estagios',
   supabaseAuthMiddleware([Roles.ADMIN, Roles.MODERADOR, Roles.PEDAGOGICO]),
   EstagiosController.create,
 );
 
 /**
  * @openapi
- * /api/v1/cursos/{cursoId}/turmas/{turmaId}/matriculas/{matriculaId}/estagios:
+ * /api/v1/cursos/{cursoId}/turmas/{turmaId}/inscricoes/{inscricaoId}/estagios:
  *   get:
- *     summary: Listar estágios cadastrados para a matrícula
+ *     summary: Listar estágios cadastrados para a inscrição
  *     tags: ['Cursos - Estágios']
  *     security:
  *       - bearerAuth: []
@@ -2041,12 +2041,12 @@ router.post(
  *         required: true
  *         schema: { type: string, format: uuid }
  *       - in: path
- *         name: matriculaId
+ *         name: inscricaoId
  *         required: true
  *         schema: { type: string, format: uuid }
  *     responses:
  *       200:
- *         description: Lista de estágios vinculados à matrícula
+ *         description: Lista de estágios vinculados à inscrição
  *         content:
  *           application/json:
  *             schema:
@@ -2057,16 +2057,16 @@ router.post(
  *                   items:
  *                     $ref: '#/components/schemas/CursoEstagio'
  *       404:
- *         description: Curso, turma ou matrícula não localizada
+ *         description: Curso, turma ou inscrição não localizada
  *         content:
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/ErrorResponse'
  */
 router.get(
-  '/:cursoId/turmas/:turmaId/matriculas/:matriculaId/estagios',
+  '/:cursoId/turmas/:turmaId/inscricoes/:inscricaoId/estagios',
   supabaseAuthMiddleware([Roles.ADMIN, Roles.MODERADOR, Roles.PEDAGOGICO, Roles.PROFESSOR]),
-  EstagiosController.listByMatricula,
+  EstagiosController.listByInscricao,
 );
 
 /**
@@ -2087,9 +2087,9 @@ router.get(
  *         required: true
  *         schema: { type: string, format: uuid }
  *       - in: query
- *         name: matriculaId
+ *         name: inscricaoId
  *         schema: { type: string, format: uuid }
- *         description: Filtra certificados de uma matrícula específica
+ *         description: Filtra certificados de uma inscrição específica
  *       - in: query
  *         name: tipo
  *         schema: { $ref: '#/components/schemas/CursosCertificados' }
@@ -2117,47 +2117,47 @@ router.get(
 
 /**
  * @openapi
- * /api/v1/cursos/matriculas/{matriculaId}/certificados:
+ * /api/v1/cursos/inscricoes/{inscricaoId}/certificados:
  *   get:
- *     summary: Consultar certificados emitidos de uma matrícula (admin)
+ *     summary: Consultar certificados emitidos de uma inscrição (admin)
  *     tags: ['Cursos - Certificados']
  *     security:
  *       - bearerAuth: []
  *     parameters:
  *       - in: path
- *         name: matriculaId
+ *         name: inscricaoId
  *         required: true
  *         schema: { type: string, format: uuid }
  *     responses:
  *       200:
- *         description: Certificados emitidos para a matrícula informada
+ *         description: Certificados emitidos para a inscrição informada
  *         content:
  *           application/json:
  *             schema:
- *               $ref: '#/components/schemas/CursoCertificadoResumoMatricula'
+ *               $ref: '#/components/schemas/CursoCertificadoResumoInscricao'
  */
 router.get(
-  '/matriculas/:matriculaId/certificados',
+  '/inscricoes/:inscricaoId/certificados',
   supabaseAuthMiddleware([Roles.ADMIN, Roles.MODERADOR, Roles.PEDAGOGICO, Roles.PROFESSOR]),
-  CertificadosController.listarPorMatricula,
+  CertificadosController.listarPorInscricao,
 );
 
 /**
  * @openapi
- * /api/v1/cursos/me/matriculas/{matriculaId}/estagios:
+ * /api/v1/cursos/me/inscricoes/{inscricaoId}/estagios:
  *   get:
- *     summary: Listar estágios do aluno autenticado para a matrícula
+ *     summary: Listar estágios do aluno autenticado para a inscrição
  *     tags: ['Cursos - Estágios']
  *     security:
  *       - bearerAuth: []
  *     parameters:
  *       - in: path
- *         name: matriculaId
+ *         name: inscricaoId
  *         required: true
  *         schema: { type: string, format: uuid }
  *     responses:
  *       200:
- *         description: Estágios vinculados à matrícula do aluno
+ *         description: Estágios vinculados à inscrição do aluno
  *         content:
  *           application/json:
  *             schema:
@@ -2168,39 +2168,39 @@ router.get(
  *                   items:
  *                     $ref: '#/components/schemas/CursoEstagio'
  *       403:
- *         description: Matrícula não pertence ao aluno autenticado
+ *         description: Inscrição não pertence ao aluno autenticado
  */
 router.get(
-  '/me/matriculas/:matriculaId/estagios',
+  '/me/inscricoes/:inscricaoId/estagios',
   supabaseAuthMiddleware([Roles.ALUNO_CANDIDATO]),
   EstagiosController.listMe,
 );
 
 /**
  * @openapi
- * /api/v1/cursos/me/matriculas/{matriculaId}/certificados:
+ * /api/v1/cursos/me/inscricoes/{inscricaoId}/certificados:
  *   get:
- *     summary: Consultar certificados emitidos do aluno autenticado para uma matrícula
+ *     summary: Consultar certificados emitidos do aluno autenticado para uma inscrição
  *     tags: ['Cursos - Certificados']
  *     security:
  *       - bearerAuth: []
  *     parameters:
  *       - in: path
- *         name: matriculaId
+ *         name: inscricaoId
  *         required: true
  *         schema: { type: string, format: uuid }
  *     responses:
  *       200:
- *         description: Certificados emitidos associados à matrícula do aluno
+ *         description: Certificados emitidos associados à inscrição do aluno
  *         content:
  *           application/json:
  *             schema:
- *               $ref: '#/components/schemas/CursoCertificadoResumoMatricula'
+ *               $ref: '#/components/schemas/CursoCertificadoResumoInscricao'
  */
 router.get(
-  '/me/matriculas/:matriculaId/certificados',
+  '/me/inscricoes/:inscricaoId/certificados',
   supabaseAuthMiddleware([Roles.ALUNO_CANDIDATO]),
-  CertificadosController.listarMePorMatricula,
+  CertificadosController.listarMePorInscricao,
 );
 
 /**

--- a/src/modules/cursos/services/agenda.service.ts
+++ b/src/modules/cursos/services/agenda.service.ts
@@ -362,7 +362,7 @@ export const agendaService = {
       turmaId?: string;
     } = {},
   ) {
-    const matriculas = await prisma.cursosTurmasMatriculas.findMany({
+    const inscricoes = await prisma.cursosTurmasInscricoes.findMany({
       where: { alunoId },
       select: {
         id: true,
@@ -370,16 +370,16 @@ export const agendaService = {
       },
     });
 
-    if (matriculas.length === 0) {
+    if (inscricoes.length === 0) {
       return [];
     }
 
-    let turmaIds = matriculas.map((matricula) => matricula.turmaId);
+    let turmaIds = inscricoes.map((inscricao) => inscricao.turmaId);
 
     if (filters.turmaId) {
       if (!turmaIds.includes(filters.turmaId)) {
-        const error = new Error('Aluno não está matriculado na turma informada');
-        (error as any).code = 'MATRICULA_NOT_FOUND';
+        const error = new Error('Aluno não está inscrito na turma informada');
+        (error as any).code = 'INSCRICAO_NOT_FOUND';
         throw error;
       }
       turmaIds = [filters.turmaId];
@@ -404,11 +404,11 @@ export const agendaService = {
       ...agendaWithRelations,
     });
 
-    const matriculaPorTurma = new Map(matriculas.map((matricula) => [matricula.turmaId, matricula.id]));
+    const inscricaoPorTurma = new Map(inscricoes.map((inscricao) => [inscricao.turmaId, inscricao.id]));
 
     return eventos.map((evento) => ({
       ...mapAgendaItem(evento),
-      matriculaId: matriculaPorTurma.get(evento.turmaId) ?? null,
+      inscricaoId: inscricaoPorTurma.get(evento.turmaId) ?? null,
     }));
   },
 };

--- a/src/modules/cursos/services/certificados.mapper.ts
+++ b/src/modules/cursos/services/certificados.mapper.ts
@@ -9,7 +9,7 @@ const certificadoWithRelations = Prisma.validator<Prisma.CursosCertificadosEmiti
         email: true,
       },
     },
-    matricula: {
+    inscricao: {
       select: {
         id: true,
         aluno: {
@@ -20,7 +20,7 @@ const certificadoWithRelations = Prisma.validator<Prisma.CursosCertificadosEmiti
             cpf: true,
             informacoes: {
               select: {
-                matricula: true,
+                inscricao: true,
               },
             },
           },
@@ -89,23 +89,23 @@ export const mapCertificado = (
     emitidoEm: certificado.emitidoEm,
     observacoes: certificado.observacoes,
     aluno: {
-      id: certificado.matricula.aluno.id,
-      nome: certificado.matricula.aluno.nomeCompleto,
-      email: certificado.matricula.aluno.email,
+      id: certificado.inscricao.aluno.id,
+      nome: certificado.inscricao.aluno.nomeCompleto,
+      email: certificado.inscricao.aluno.email,
       cpf: maskCpf ? null : formattedCpf,
       cpfMascarado: maskedCpf,
-      matricula: certificado.matricula.aluno.informacoes?.matricula ?? null,
+      inscricao: certificado.inscricao.aluno.informacoes?.inscricao ?? null,
     },
     curso: {
-      id: certificado.matricula.turma.curso.id,
-      nome: certificado.matricula.turma.curso.nome,
-      codigo: certificado.matricula.turma.curso.codigo,
+      id: certificado.inscricao.turma.curso.id,
+      nome: certificado.inscricao.turma.curso.nome,
+      codigo: certificado.inscricao.turma.curso.codigo,
       cargaHoraria: certificado.cargaHoraria,
     },
     turma: {
-      id: certificado.matricula.turma.id,
-      nome: certificado.matricula.turma.nome,
-      codigo: certificado.matricula.turma.codigo,
+      id: certificado.inscricao.turma.id,
+      nome: certificado.inscricao.turma.nome,
+      codigo: certificado.inscricao.turma.codigo,
     },
     emitidoPor: certificado.emitidoPor
       ? {

--- a/src/modules/cursos/services/cursos.service.ts
+++ b/src/modules/cursos/services/cursos.service.ts
@@ -56,7 +56,7 @@ const regrasAvaliacaoSelect = {
 
 const turmaDetailedInclude = Prisma.validator<Prisma.CursosTurmasDefaultArgs>()({
   include: {
-    matriculas: {
+    inscricoes: {
       include: {
         aluno: {
           select: {
@@ -64,7 +64,7 @@ const turmaDetailedInclude = Prisma.validator<Prisma.CursosTurmasDefaultArgs>()(
             nomeCompleto: true,
             email: true,
             informacoes: {
-              select: { matricula: true, telefone: true },
+              select: { inscricao: true, telefone: true },
             },
             enderecos: {
               select: {
@@ -217,15 +217,15 @@ const mapTurmaDetailed = (turma: TurmaDetailedPayload) => {
     dataFim: turma.dataFim?.toISOString() ?? null,
     dataInscricaoInicio: turma.dataInscricaoInicio?.toISOString() ?? null,
     dataInscricaoFim: turma.dataInscricaoFim?.toISOString() ?? null,
-    alunos: turma.matriculas.map((matricula) => {
-      const endereco = matricula.aluno.enderecos?.[0];
+    alunos: turma.inscricoes.map((inscricao) => {
+      const endereco = inscricao.aluno.enderecos?.[0];
 
       return {
-        id: matricula.aluno.id,
-        nome: matricula.aluno.nomeCompleto,
-        email: matricula.aluno.email,
-        matricula: matricula.aluno.informacoes?.matricula ?? null,
-        telefone: matricula.aluno.informacoes?.telefone ?? null,
+        id: inscricao.aluno.id,
+        nome: inscricao.aluno.nomeCompleto,
+        email: inscricao.aluno.email,
+        inscricao: inscricao.aluno.informacoes?.inscricao ?? null,
+        telefone: inscricao.aluno.informacoes?.telefone ?? null,
         endereco: endereco
           ? {
               logradouro: endereco.logradouro ?? null,
@@ -297,7 +297,7 @@ const mapCourse = (course: RawCourse) => {
       : null,
     turmas: turmas
       ? turmas.map((turma) =>
-          'matriculas' in turma ? mapTurmaDetailed(turma as any) : mapTurmaSummary(turma as any),
+          'inscricoes' in turma ? mapTurmaDetailed(turma as any) : mapTurmaSummary(turma as any),
         )
       : undefined,
     turmasCount: course._count?.turmas ?? undefined,

--- a/src/modules/cursos/services/estagios.mapper.ts
+++ b/src/modules/cursos/services/estagios.mapper.ts
@@ -17,7 +17,7 @@ export const estagioWithRelations = Prisma.validator<Prisma.CursosEstagiosDefaul
         codigo: true,
       },
     },
-    matricula: {
+    inscricao: {
       select: {
         id: true,
       },
@@ -114,7 +114,7 @@ export const mapEstagio = (
   id: estagio.id,
   cursoId: estagio.cursoId,
   turmaId: estagio.turmaId,
-  matriculaId: estagio.matriculaId,
+  inscricaoId: estagio.inscricaoId,
   aluno: {
     id: estagio.aluno.id,
     nome: estagio.aluno.nomeCompleto,

--- a/src/modules/cursos/services/frequencia.mapper.ts
+++ b/src/modules/cursos/services/frequencia.mapper.ts
@@ -2,7 +2,7 @@ import { Prisma } from '@prisma/client';
 
 export const frequenciaWithRelations = Prisma.validator<Prisma.CursosFrequenciaAlunosDefaultArgs>()({
   include: {
-    matricula: {
+    inscricao: {
       select: {
         id: true,
         alunoId: true,
@@ -37,7 +37,7 @@ export type FrequenciaWithRelations = Prisma.CursosFrequenciaAlunosGetPayload<ty
 export const mapFrequencia = (frequencia: FrequenciaWithRelations) => ({
   id: frequencia.id,
   turmaId: frequencia.turmaId,
-  matriculaId: frequencia.matriculaId,
+  inscricaoId: frequencia.inscricaoId,
   aulaId: frequencia.aulaId,
   dataReferencia: frequencia.dataReferencia.toISOString(),
   status: frequencia.status,
@@ -59,15 +59,15 @@ export const mapFrequencia = (frequencia: FrequenciaWithRelations) => ({
           : null,
       }
     : null,
-  matricula: frequencia.matricula
+  inscricao: frequencia.inscricao
     ? {
-        id: frequencia.matricula.id,
-        alunoId: frequencia.matricula.alunoId,
-        aluno: frequencia.matricula.aluno
+        id: frequencia.inscricao.id,
+        alunoId: frequencia.inscricao.alunoId,
+        aluno: frequencia.inscricao.aluno
           ? {
-              id: frequencia.matricula.aluno.id,
-              nome: frequencia.matricula.aluno.nomeCompleto,
-              email: frequencia.matricula.aluno.email,
+              id: frequencia.inscricao.aluno.id,
+              nome: frequencia.inscricao.aluno.nomeCompleto,
+              email: frequencia.inscricao.aluno.email,
             }
           : null,
       }

--- a/src/modules/cursos/services/notas.mapper.ts
+++ b/src/modules/cursos/services/notas.mapper.ts
@@ -2,7 +2,7 @@ import { Prisma } from '@prisma/client';
 
 export const notaWithRelations = Prisma.validator<Prisma.CursosNotasDefaultArgs>()({
   include: {
-    matricula: {
+    inscricao: {
       select: {
         id: true,
         alunoId: true,
@@ -38,7 +38,7 @@ const normalizeDecimal = (value: Prisma.Decimal | number | null | undefined) => 
 export const mapNota = (nota: NotaWithRelations) => ({
   id: nota.id,
   turmaId: nota.turmaId,
-  matriculaId: nota.matriculaId,
+  inscricaoId: nota.inscricaoId,
   tipo: nota.tipo,
   referenciaExterna: nota.referenciaExterna ?? null,
   titulo: nota.titulo,
@@ -57,15 +57,15 @@ export const mapNota = (nota: NotaWithRelations) => ({
         etiqueta: nota.prova.etiqueta,
       }
     : null,
-  matricula: nota.matricula
+  inscricao: nota.inscricao
     ? {
-        id: nota.matricula.id,
-        alunoId: nota.matricula.alunoId,
-        aluno: nota.matricula.aluno
+        id: nota.inscricao.id,
+        alunoId: nota.inscricao.alunoId,
+        aluno: nota.inscricao.aluno
           ? {
-              id: nota.matricula.aluno.id,
-              nome: nota.matricula.aluno.nomeCompleto,
-              email: nota.matricula.aluno.email,
+              id: nota.inscricao.aluno.id,
+              nome: nota.inscricao.aluno.nomeCompleto,
+              email: nota.inscricao.aluno.email,
             }
           : null,
       }

--- a/src/modules/cursos/services/provas.mapper.ts
+++ b/src/modules/cursos/services/provas.mapper.ts
@@ -8,7 +8,7 @@ export const provaWithEnviosInclude = Prisma.validator<Prisma.CursosTurmasProvas
   include: {
     envios: {
       include: {
-        matricula: {
+        inscricao: {
           select: {
             id: true,
             alunoId: true,
@@ -48,8 +48,8 @@ export const mapProva = (prova: ProvaWithRelations | ProvaWithEnvios) => ({
     ? prova.envios.map((envio) => ({
         id: envio.id,
         provaId: envio.provaId,
-        matriculaId: envio.matriculaId,
-        alunoId: envio.matricula.alunoId,
+        inscricaoId: envio.inscricaoId,
+        alunoId: envio.inscricao.alunoId,
         nota: normalizeDecimal(envio.nota),
         pesoTotal: normalizeDecimal(envio.pesoTotal),
         realizadoEm: envio.realizadoEm?.toISOString() ?? null,

--- a/src/modules/cursos/services/provas.service.ts
+++ b/src/modules/cursos/services/provas.service.ts
@@ -221,7 +221,7 @@ export const provasService = {
     turmaId: string,
     provaId: string,
     data: {
-      matriculaId: string;
+      inscricaoId: string;
       nota: number;
       pesoTotal?: number | null;
       realizadoEm?: Date | null;
@@ -231,14 +231,14 @@ export const provasService = {
     return prisma.$transaction(async (tx) => {
       await ensureProvaBelongsToTurma(tx, cursoId, turmaId, provaId);
 
-      const matricula = await tx.cursosTurmasMatriculas.findFirst({
-        where: { id: data.matriculaId, turmaId },
+      const inscricao = await tx.cursosTurmasInscricoes.findFirst({
+        where: { id: data.inscricaoId, turmaId },
         select: { id: true },
       });
 
-      if (!matricula) {
-        const error = new Error('Matrícula não encontrada para a turma informada');
-        (error as any).code = 'MATRICULA_NOT_FOUND';
+      if (!inscricao) {
+        const error = new Error('Inscrição não encontrada para a turma informada');
+        (error as any).code = 'INSCRICAO_NOT_FOUND';
         throw error;
       }
 
@@ -255,9 +255,9 @@ export const provasService = {
 
       const envio = await tx.cursosTurmasProvasEnvios.upsert({
         where: {
-          provaId_matriculaId: {
+          provaId_inscricaoId: {
             provaId,
-            matriculaId: data.matriculaId,
+            inscricaoId: data.inscricaoId,
           },
         },
         update: {
@@ -268,7 +268,7 @@ export const provasService = {
         },
         create: {
           provaId,
-          matriculaId: data.matriculaId,
+          inscricaoId: data.inscricaoId,
           nota: toDecimal(data.nota),
           pesoTotal: toDecimal(data.pesoTotal ?? null),
           realizadoEm: data.realizadoEm ?? null,
@@ -283,8 +283,8 @@ export const provasService = {
 
       await tx.cursosNotas.upsert({
         where: {
-          matriculaId_provaId: {
-            matriculaId: data.matriculaId,
+          inscricaoId_provaId: {
+            inscricaoId: data.inscricaoId,
             provaId,
           },
         },
@@ -298,7 +298,7 @@ export const provasService = {
         },
         create: {
           turmaId,
-          matriculaId: data.matriculaId,
+          inscricaoId: data.inscricaoId,
           tipo: CursosNotasTipo.PROVA,
           provaId,
           titulo: prova.titulo,

--- a/src/modules/cursos/utils/code-generator.ts
+++ b/src/modules/cursos/utils/code-generator.ts
@@ -76,21 +76,21 @@ export const generateUniqueTurmaCode = async (
   );
 };
 
-export const generateUniqueEnrollmentCode = async (
+export const generateUniqueInscricaoCode = async (
   tx: Prisma.TransactionClient,
   logger?: AppLogger,
 ) => {
   return attemptUniqueCode(
     10,
-    () => `MAT${randomNumber(5)}`,
+    () => `INS${randomNumber(5)}`,
     async (candidate) => {
       const existing = await tx.usuariosInformation.findFirst({
-        where: { matricula: candidate },
+        where: { inscricao: candidate },
         select: { usuarioId: true },
       });
       return !existing;
     },
-    () => `MAT${withFallback(2, 5)}`,
+    () => `INS${withFallback(2, 5)}`,
     logger,
   );
 };

--- a/src/modules/cursos/validators/avaliacao.schema.ts
+++ b/src/modules/cursos/validators/avaliacao.schema.ts
@@ -28,7 +28,7 @@ export const updateRegrasAvaliacaoSchema = z.object({
 const uuidSchema = z.string().uuid('Identificador inválido');
 
 export const registrarRecuperacaoSchema = z.object({
-  matriculaId: uuidSchema,
+  inscricaoId: uuidSchema,
   provaId: uuidSchema.nullish(),
   envioId: uuidSchema.nullish(),
   notaRecuperacao: decimalNotaSchema.nullish(),

--- a/src/modules/cursos/validators/certificados.schema.ts
+++ b/src/modules/cursos/validators/certificados.schema.ts
@@ -15,7 +15,7 @@ const optionalUrlSchema = z
   .or(z.null().transform(() => undefined));
 
 export const emitirCertificadoSchema = z.object({
-  matriculaId: z.string().uuid('Identificador da matrícula inválido'),
+  inscricaoId: z.string().uuid('Identificador da inscrição inválido'),
   tipo: z.nativeEnum(CursosCertificados, {
     invalid_type_error: 'Tipo de certificado inválido',
   }),
@@ -37,7 +37,7 @@ export const emitirCertificadoSchema = z.object({
 });
 
 export const listarCertificadosQuerySchema = z.object({
-  matriculaId: z.string().uuid('Identificador da matrícula inválido').optional(),
+  inscricaoId: z.string().uuid('Identificador da inscrição inválido').optional(),
   tipo: z.nativeEnum(CursosCertificados).optional(),
   formato: z.nativeEnum(CursosCertificadosTipos).optional(),
 });

--- a/src/modules/cursos/validators/frequencia.schema.ts
+++ b/src/modules/cursos/validators/frequencia.schema.ts
@@ -16,7 +16,7 @@ const dateSchema = z
   .optional();
 
 const aulaIdSchema = z.string().uuid('Identificador da aula inválido').nullish();
-const matriculaIdSchema = z.string().uuid('Identificador da matrícula inválido');
+const inscricaoIdSchema = z.string().uuid('Identificador da inscrição inválido');
 
 const justificativaSchema = z
   .string({ invalid_type_error: 'Justificativa deve ser um texto' })
@@ -33,7 +33,7 @@ const observacoesSchema = z
 
 export const createFrequenciaSchema = z
   .object({
-    matriculaId: matriculaIdSchema,
+    inscricaoId: inscricaoIdSchema,
     aulaId: aulaIdSchema,
     dataReferencia: dateSchema,
     status: statusSchema,

--- a/src/modules/cursos/validators/notas.schema.ts
+++ b/src/modules/cursos/validators/notas.schema.ts
@@ -78,7 +78,7 @@ const referenciaExternaSchema = z
 
 export const createNotaSchema = z
   .object({
-    matriculaId: z.string().uuid('Identificador da matrícula inválido'),
+    inscricaoId: z.string().uuid('Identificador da inscrição inválido'),
     tipo: notaTipoSchema,
     provaId: z.string().uuid('Identificador da prova inválido').nullish(),
     referenciaExterna: referenciaExternaSchema,

--- a/src/modules/cursos/validators/provas.schema.ts
+++ b/src/modules/cursos/validators/provas.schema.ts
@@ -45,7 +45,7 @@ export const createProvaSchema = provaBaseSchema;
 export const updateProvaSchema = provaBaseSchema.partial({ peso: true });
 
 export const registrarNotaSchema = z.object({
-  matriculaId: z.string().uuid('Identificador da matrícula inválido'),
+  inscricaoId: z.string().uuid('Identificador da inscrição inválido'),
   nota: z
     .number({ invalid_type_error: 'Nota deve ser um número' })
     .min(0, 'Nota mínima é 0')

--- a/src/modules/cursos/validators/turmas.schema.ts
+++ b/src/modules/cursos/validators/turmas.schema.ts
@@ -68,6 +68,6 @@ export const createTurmaSchema = applyDateValidations(turmaBaseSchema);
 
 export const updateTurmaSchema = applyDateValidations(turmaBaseSchema.partial());
 
-export const turmaEnrollmentSchema = z.object({
+export const turmaInscricaoSchema = z.object({
   alunoId: z.string().uuid(),
 });

--- a/src/modules/usuarios/controllers/usuario-controller.ts
+++ b/src/modules/usuarios/controllers/usuario-controller.ts
@@ -69,7 +69,7 @@ interface UsuarioPerfil {
   telefone: string | null;
   dataNasc: Date | null;
   genero: string | null;
-  matricula: string | null;
+  inscricao: string | null;
   role: string;
   status: string;
   tipoUsuario: string;
@@ -110,7 +110,7 @@ const reviveUsuario = (usuario: UsuarioPerfil): UsuarioPerfil => {
     dataNasc,
     telefone: informacoes.telefone,
     genero: informacoes.genero,
-    matricula: informacoes.matricula,
+    inscricao: informacoes.inscricao,
     avatarUrl: informacoes.avatarUrl,
     descricao: informacoes.descricao,
     aceitarTermos: informacoes.aceitarTermos,
@@ -401,7 +401,7 @@ export const loginUsuario = async (req: Request, res: Response, next: NextFuncti
       telefone: usuario.telefone,
       genero: usuario.genero,
       dataNasc: usuario.dataNasc,
-      matricula: usuario.matricula,
+      inscricao: usuario.inscricao,
       role: usuario.role,
       tipoUsuario: usuario.tipoUsuario,
       supabaseId: usuario.supabaseId,
@@ -765,7 +765,7 @@ export const refreshToken = async (req: Request, res: Response, next: NextFuncti
       telefone: usuario.telefone,
       genero: usuario.genero,
       dataNasc: usuario.dataNasc,
-      matricula: usuario.matricula,
+      inscricao: usuario.inscricao,
       role: usuario.role,
       tipoUsuario: usuario.tipoUsuario,
       supabaseId: usuario.supabaseId,

--- a/src/modules/usuarios/utils/information.ts
+++ b/src/modules/usuarios/utils/information.ts
@@ -4,7 +4,7 @@ export const usuarioInformacoesSelect = {
   telefone: true,
   genero: true,
   dataNasc: true,
-  matricula: true,
+  inscricao: true,
   avatarUrl: true,
   descricao: true,
   aceitarTermos: true,
@@ -22,7 +22,7 @@ export interface UsuarioInformacoesDto {
   telefone: string | null;
   genero: string | null;
   dataNasc: Date | null;
-  matricula: string | null;
+  inscricao: string | null;
   avatarUrl: string | null;
   descricao: string | null;
   aceitarTermos: boolean;
@@ -42,7 +42,7 @@ export const mapUsuarioInformacoes = (
   telefone: informacoes?.telefone ?? null,
   genero: informacoes?.genero ?? null,
   dataNasc: resolveDate(informacoes?.dataNasc ?? null),
-  matricula: informacoes?.matricula ?? null,
+  inscricao: informacoes?.inscricao ?? null,
   avatarUrl: informacoes?.avatarUrl ?? null,
   descricao: informacoes?.descricao ?? null,
   aceitarTermos: informacoes?.aceitarTermos ?? false,
@@ -57,7 +57,7 @@ export const mergeUsuarioInformacoes = <
   telefone: string | null;
   genero: string | null;
   dataNasc: Date | null;
-  matricula: string | null;
+  inscricao: string | null;
   avatarUrl: string | null;
   descricao: string | null;
   aceitarTermos: boolean;


### PR DESCRIPTION
## Summary
- renomeia o modelo de matrículas para inscrições no schema Prisma e atualiza as migrações relacionadas
- ajusta seeds, serviços, controladores e utilitários para utilizar inscrição em vez de matrícula em toda a API
- atualiza a documentação Swagger/Redoc com os novos nomes de rotas, esquemas e exemplos de inscrição

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d376b699348325854f6f1b0d038b16