### PR TITLE
Atualiza modo de planos empresariais para assinaturas

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -686,7 +686,7 @@ model EmpresasPlano {
   id                   String               @id @default(uuid())
   usuarioId            String
   planosEmpresariaisId String
-  modo                 EmpresasPlanoModo?
+  modo                 EmpresasPlanoModo    @default(CLIENTE)
   status               EmpresasPlanoStatus  @default(SUSPENSO)
   origin               EmpresasPlanoOrigin  @default(CHECKOUT)
   inicio               DateTime?
@@ -1640,6 +1640,7 @@ enum EmpresasPlanoStatus {
 }
 
 enum EmpresasPlanoModo {
+  CLIENTE
   TESTE
   PARCEIRO
 }

--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -5583,8 +5583,10 @@ const options: Options = {
         },
         ClientePlanoModo: {
           type: 'string',
-          enum: ['teste', 'parceiro'],
-          example: 'teste',
+          enum: ['CLIENTE', 'TESTE', 'PARCEIRO'],
+          example: 'CLIENTE',
+          description:
+            'Identifica se a assinatura é de um cliente pagante (CLIENTE) ou uma concessão de teste/parceria.',
         },
         ClientePlanoEmpresa: {
           type: 'object',
@@ -5637,7 +5639,10 @@ const options: Options = {
             id: { type: 'string', example: 'parceria-uuid' },
             usuarioId: { type: 'string', example: 'usuario-uuid' },
             planosEmpresariaisId: { type: 'string', example: 'plano-uuid' },
-            modo: { allOf: [{ $ref: '#/components/schemas/ClientePlanoModo' }], nullable: true },
+            modo: {
+              allOf: [{ $ref: '#/components/schemas/ClientePlanoModo' }],
+              description: 'Modo da assinatura vinculada à empresa.',
+            },
             origin: { type: 'string', enum: ['CHECKOUT', 'ADMIN', 'IMPORT'], example: 'CHECKOUT' },
             //
             //
@@ -5713,7 +5718,7 @@ const options: Options = {
             code: { type: 'string', example: 'EMPRESA_SEM_PLANO_ATIVO' },
             message: {
               type: 'string',
-              example: 'A empresa não possui um plano parceiro ativo no momento.',
+              example: 'A empresa não possui um plano de assinatura ativo no momento.',
             },
           },
         },
@@ -6347,7 +6352,7 @@ const options: Options = {
             },
             modo: {
               allOf: [{ $ref: '#/components/schemas/ClientePlanoModo' }],
-              description: 'Origem do vínculo do plano (assinatura, teste, parceiro)',
+              description: 'Origem do vínculo do plano (CLIENTE, TESTE ou PARCEIRO)',
             },
             diasTeste: {
               type: 'integer',
@@ -6365,7 +6370,7 @@ const options: Options = {
           },
           example: {
             planosEmpresariaisId: 'b8d96a94-8a3d-4b90-8421-6f0a7bc1d42e',
-            modo: 'teste',
+            modo: 'TESTE',
             diasTeste: 30,
             iniciarEm: '2024-03-01T12:00:00Z',
           },
@@ -6387,7 +6392,7 @@ const options: Options = {
           ],
           example: {
             planosEmpresariaisId: 'b8d96a94-8a3d-4b90-8421-6f0a7bc1d42e',
-            modo: 'parceiro',
+            modo: 'PARCEIRO',
             resetPeriodo: true,
           },
         },
@@ -6486,7 +6491,7 @@ const options: Options = {
             aceitarTermos: true,
             plano: {
               planosEmpresariaisId: 'b8d96a94-8a3d-4b90-8421-6f0a7bc1d42e',
-              modo: 'teste',
+              modo: 'TESTE',
               diasTeste: 30,
             },
           },
@@ -6560,7 +6565,7 @@ const options: Options = {
             status: 'ATIVO',
             plano: {
               planosEmpresariaisId: 'b8d96a94-8a3d-4b90-8421-6f0a7bc1d42e',
-              modo: 'parceiro',
+              modo: 'PARCEIRO',
               resetPeriodo: false,
             },
           },

--- a/src/modules/empresas/admin/services/admin-empresas.service.ts
+++ b/src/modules/empresas/admin/services/admin-empresas.service.ts
@@ -524,7 +524,7 @@ const assignPlanoToEmpresa = async (
   usuarioId: string,
   plano: AdminEmpresasPlanoInput,
 ) => {
-  const modo = (plano.modo as unknown as EmpresasPlanoModo) || undefined;
+  const modo = plano.modo ?? EmpresasPlanoModo.CLIENTE;
   const inicio = plano.iniciarEm ?? new Date();
   const fim = calcularFim(modo, inicio, plano.diasTeste ?? undefined);
   const status = EmpresasPlanoStatus.ATIVO;
@@ -538,7 +538,7 @@ const assignPlanoToEmpresa = async (
     data: {
       usuarioId,
       planosEmpresariaisId: plano.planosEmpresariaisId,
-      ...(modo ? { modo } : {}),
+      modo,
       status,
       origin: 'ADMIN',
       inicio,
@@ -564,7 +564,7 @@ const atualizarPlanoSemReset = async (
 
   const data: Prisma.EmpresasPlanoUpdateInput = {
     plano: { connect: { id: plano.planosEmpresariaisId } },
-    ...(plano.modo ? { modo: plano.modo as unknown as EmpresasPlanoModo } : {}),
+    modo: plano.modo ?? EmpresasPlanoModo.CLIENTE,
   };
 
   await tx.empresasPlano.update({

--- a/src/modules/empresas/admin/validators/admin-empresas.schema.ts
+++ b/src/modules/empresas/admin/validators/admin-empresas.schema.ts
@@ -1,4 +1,10 @@
-import { MotivosDeBloqueios, Status, StatusDeVagas, TiposDeBloqueios } from '@prisma/client';
+import {
+  EmpresasPlanoModo,
+  MotivosDeBloqueios,
+  Status,
+  StatusDeVagas,
+  TiposDeBloqueios,
+} from '@prisma/client';
 import { z } from 'zod';
 
 import { clientePlanoModoSchema } from '@/modules/empresas/clientes/validators/clientes.schema';
@@ -38,7 +44,7 @@ const adminEmpresasPlanoBase = z.object({
 });
 
 export const adminEmpresasPlanoSchema = adminEmpresasPlanoBase.refine(
-  (val) => (val.modo !== 'teste' ? true : typeof val.diasTeste === 'number'),
+  (val) => (val.modo !== EmpresasPlanoModo.TESTE ? true : typeof val.diasTeste === 'number'),
   { message: 'Informe diasTeste para o modo teste', path: ['diasTeste'] },
 );
 
@@ -46,7 +52,7 @@ export type AdminEmpresasPlanoInput = z.infer<typeof adminEmpresasPlanoSchema>;
 
 export const adminEmpresasPlanoUpdateSchema = adminEmpresasPlanoBase
   .extend({ resetPeriodo: z.boolean().optional() })
-  .refine((val) => (val.modo !== 'teste' ? true : typeof val.diasTeste === 'number'), {
+  .refine((val) => (val.modo !== EmpresasPlanoModo.TESTE ? true : typeof val.diasTeste === 'number'), {
     message: 'Informe diasTeste para o modo teste',
     path: ['diasTeste'],
   });

--- a/src/modules/empresas/clientes/controllers/clientes.controller.ts
+++ b/src/modules/empresas/clientes/controllers/clientes.controller.ts
@@ -43,7 +43,7 @@ export class ClientesController {
         return res.status(404).json({
           success: false,
           code: 'PLANO_PARCEIRO_NOT_FOUND',
-          message: 'Plano parceiro da empresa não encontrado',
+          message: 'Plano de assinatura da empresa não encontrado',
         });
       }
 
@@ -52,7 +52,7 @@ export class ClientesController {
       res.status(500).json({
         success: false,
         code: 'PLANOS_PARCEIRO_GET_ERROR',
-        message: 'Erro ao consultar o plano parceiro da empresa',
+        message: 'Erro ao consultar o plano de assinatura da empresa',
         error: error?.message,
       });
     }
@@ -68,7 +68,7 @@ export class ClientesController {
         return res.status(400).json({
           success: false,
           code: 'VALIDATION_ERROR',
-          message: 'Dados inválidos para vincular o plano parceiro',
+          message: 'Dados inválidos para vincular o plano de assinatura',
           issues: error.flatten().fieldErrors,
         });
       }
@@ -84,7 +84,7 @@ export class ClientesController {
       res.status(500).json({
         success: false,
         code: 'PLANOS_PARCEIRO_ASSIGN_ERROR',
-        message: 'Erro ao vincular o plano parceiro à empresa',
+        message: 'Erro ao vincular o plano de assinatura à empresa',
         error: error?.message,
       });
     }
@@ -99,7 +99,7 @@ export class ClientesController {
         return res.status(400).json({
           success: false,
           code: 'VALIDATION_ERROR',
-          message: 'Informe ao menos um campo para atualização do plano parceiro',
+          message: 'Informe ao menos um campo para atualização do plano de assinatura',
         });
       }
 
@@ -110,7 +110,7 @@ export class ClientesController {
         return res.status(400).json({
           success: false,
           code: 'VALIDATION_ERROR',
-          message: 'Dados inválidos para atualizar o plano parceiro',
+          message: 'Dados inválidos para atualizar o plano de assinatura',
           issues: error.flatten().fieldErrors,
         });
       }
@@ -119,7 +119,7 @@ export class ClientesController {
         return res.status(404).json({
           success: false,
           code: 'PLANO_PARCEIRO_NOT_FOUND',
-          message: 'Plano parceiro da empresa não encontrado',
+          message: 'Plano de assinatura da empresa não encontrado',
         });
       }
 
@@ -134,7 +134,7 @@ export class ClientesController {
       res.status(500).json({
         success: false,
         code: 'PLANOS_PARCEIRO_UPDATE_ERROR',
-        message: 'Erro ao atualizar o plano parceiro da empresa',
+        message: 'Erro ao atualizar o plano de assinatura da empresa',
         error: error?.message,
       });
     }
@@ -149,14 +149,14 @@ export class ClientesController {
         return res.status(404).json({
           success: false,
           code: 'PLANO_PARCEIRO_NOT_FOUND',
-          message: 'Plano parceiro da empresa não encontrado',
+          message: 'Plano de assinatura da empresa não encontrado',
         });
       }
 
       res.status(500).json({
         success: false,
         code: 'PLANOS_PARCEIRO_DELETE_ERROR',
-        message: 'Erro ao encerrar o plano parceiro da empresa',
+        message: 'Erro ao encerrar o plano de assinatura da empresa',
         error: error?.message,
       });
     }

--- a/src/modules/empresas/clientes/routes/index.ts
+++ b/src/modules/empresas/clientes/routes/index.ts
@@ -11,8 +11,8 @@ const adminRoles = [Roles.ADMIN, Roles.MODERADOR];
  * @openapi
  * /api/v1/empresas/clientes:
  *   get:
- *     summary: Listar clientes (empresas) vinculados a planos
- *     description: "Retorna o histórico de vinculações de planos para clientes (empresas). Permite filtrar por empresa e status atual. Endpoint restrito a administradores e moderadores (roles: ADMIN, MODERADOR)."
+ *     summary: Listar clientes (empresas) vinculados a planos pagos
+ *     description: "Retorna o histórico de vinculações de planos de assinatura para clientes (empresas). Por padrão retorna apenas assinaturas de clientes pagantes (modo CLIENTE), mas é possível filtrar por outros modos quando necessário. Endpoint restrito a administradores e moderadores (roles: ADMIN, MODERADOR)."
  *     tags: [Empresas - Clientes]
  *     security:
  *       - bearerAuth: []
@@ -29,9 +29,15 @@ const adminRoles = [Roles.ADMIN, Roles.MODERADOR];
  *           type: string
  *           enum: [ATIVO, SUSPENSO, EXPIRADO, CANCELADO]
  *         description: "Quando informado, filtra pelo status do vínculo do plano"
+ *       - in: query
+ *         name: modo
+ *         schema:
+ *           type: string
+ *           enum: [CLIENTE, TESTE, PARCEIRO]
+ *         description: "Permite consultar vínculos em outros modos (teste ou parceiro). O padrão é CLIENTE."
  *     responses:
  *       200:
- *         description: Lista de planos parceiros vinculados
+ *         description: Lista de planos de assinatura vinculados ao cliente
  *         content:
  *           application/json:
  *             schema:
@@ -83,7 +89,7 @@ router.get('/', supabaseAuthMiddleware(adminRoles), ClientesController.list);
  *           format: uuid
  *     responses:
  *       200:
- *         description: Plano parceiro encontrado
+ *         description: Plano de assinatura encontrado
  *         content:
  *           application/json:
  *             schema:
@@ -101,7 +107,7 @@ router.get('/', supabaseAuthMiddleware(adminRoles), ClientesController.list);
  *             schema:
  *               $ref: '#/components/schemas/ForbiddenResponse'
  *       404:
- *         description: Plano parceiro não encontrado
+ *         description: Plano de assinatura não encontrado
  *         content:
  *           application/json:
  *             schema:
@@ -132,7 +138,7 @@ router.get('/:id', supabaseAuthMiddleware(adminRoles), ClientesController.get);
  *             $ref: '#/components/schemas/EmpresaClientePlanoCreateInput'
  *     responses:
  *       201:
- *         description: Plano parceiro vinculado com sucesso
+ *         description: Plano de assinatura vinculado com sucesso
  *         content:
  *           application/json:
  *             schema:
@@ -177,7 +183,7 @@ router.get('/:id', supabaseAuthMiddleware(adminRoles), ClientesController.get);
  *            -d '{
  *                  "usuarioId": "f1d7a9c2-4e0b-4f6d-90ad-8c6b84a0f1a1",
  *                  "planosEmpresariaisId": "31b3b0e1-4d9d-4a3c-9a77-51b872d59bf0",
- *                  "modo": "teste",
+ *                  "modo": "CLIENTE",
  *                  "diasTeste": 7
  *                }'
  */
@@ -207,7 +213,7 @@ router.post('/', supabaseAuthMiddleware(adminRoles), ClientesController.assign);
  *             $ref: '#/components/schemas/EmpresaClientePlanoUpdateInput'
  *     responses:
  *       200:
- *         description: Plano parceiro atualizado
+ *         description: Plano de assinatura atualizado
  *         content:
  *           application/json:
  *             schema:
@@ -231,7 +237,7 @@ router.post('/', supabaseAuthMiddleware(adminRoles), ClientesController.assign);
  *             schema:
  *               $ref: '#/components/schemas/ForbiddenResponse'
  *       404:
- *         description: Plano parceiro ou referência não encontrada
+ *         description: Plano de assinatura ou referência não encontrada
  *         content:
  *           application/json:
  *             schema:
@@ -250,7 +256,7 @@ router.post('/', supabaseAuthMiddleware(adminRoles), ClientesController.assign);
  *            -H "Authorization: Bearer <TOKEN>" \
  *            -H "Content-Type: application/json" \
  *            -d '{
- *                  "modo": "parceiro"
+ *                  "modo": "PARCEIRO"
  *                }'
  */
 router.put('/:id', supabaseAuthMiddleware(adminRoles), ClientesController.update);
@@ -287,7 +293,7 @@ router.put('/:id', supabaseAuthMiddleware(adminRoles), ClientesController.update
  *             schema:
  *               $ref: '#/components/schemas/ForbiddenResponse'
  *       404:
- *         description: Plano parceiro não encontrado
+ *         description: Plano de assinatura não encontrado
  *         content:
  *           application/json:
  *             schema:

--- a/src/modules/empresas/clientes/services/clientes.service.ts
+++ b/src/modules/empresas/clientes/services/clientes.service.ts
@@ -107,7 +107,9 @@ const transformarPlano = (plano: EmpresasPlanoWithRelations) => {
 };
 
 const buildWhere = (filters: ListClientePlanoQuery): Prisma.EmpresasPlanoWhereInput => {
-  const where: Prisma.EmpresasPlanoWhereInput = {};
+  const where: Prisma.EmpresasPlanoWhereInput = {
+    modo: filters.modo ?? EmpresasPlanoModo.CLIENTE,
+  };
 
   if (filters.usuarioId) {
     where.usuarioId = filters.usuarioId;
@@ -161,7 +163,7 @@ export const clientesService = {
   assign: async (data: CreateClientePlanoInput) => {
     await ensureUsuarioEmpresa(data.usuarioId);
     const inicio = data.iniciarEm ?? new Date();
-    const modo = data.modo as EmpresasPlanoModo;
+    const modo = data.modo;
     const fim = calcularFim(modo, inicio, sanitizeUndefined<number>(data.diasTeste) ?? undefined);
     const status = EmpresasPlanoStatus.ATIVO;
 
@@ -211,9 +213,9 @@ export const clientesService = {
 
     let modo = planoAtual.modo;
     if (data.modo !== undefined) {
-      modo = data.modo as EmpresasPlanoModo;
+      modo = data.modo;
       updates.modo = modo;
-      // Ajusta status automaticamente para testes/parceiro
+      // Ajusta status automaticamente para modos de cortesia
       if (modo === EmpresasPlanoModo.TESTE || modo === EmpresasPlanoModo.PARCEIRO) {
         updates.status = EmpresasPlanoStatus.ATIVO;
       }

--- a/src/modules/empresas/clientes/validators/clientes.schema.ts
+++ b/src/modules/empresas/clientes/validators/clientes.schema.ts
@@ -1,7 +1,12 @@
-import { EmpresasPlanoStatus } from '@prisma/client';
+import { EmpresasPlanoModo, EmpresasPlanoStatus } from '@prisma/client';
 import { z } from 'zod';
 
-export const clientePlanoModoSchema = z.enum(['teste', 'parceiro']);
+export const clientePlanoModoSchema = z
+  .string({ required_error: 'Informe o modo do plano' })
+  .trim()
+  .min(1, 'Informe o modo do plano')
+  .transform((value) => value.toUpperCase())
+  .pipe(z.nativeEnum(EmpresasPlanoModo));
 
 const uuidSchema = z.string().uuid('Informe um identificador válido');
 
@@ -20,7 +25,7 @@ export const createClientePlanoSchema = z
     iniciarEm: z.coerce.date({ invalid_type_error: 'Informe uma data válida' }).optional(),
     diasTeste: diasTesteSchema,
   })
-  .refine((val) => (val.modo !== 'teste' ? true : typeof val.diasTeste === 'number'), {
+  .refine((val) => (val.modo !== EmpresasPlanoModo.TESTE ? true : typeof val.diasTeste === 'number'), {
     message: 'Informe diasTeste para o modo teste',
     path: ['diasTeste'],
   });
@@ -44,6 +49,7 @@ export const listClientePlanoQuerySchema = z.object({
         .transform((v) => v as any),
     )
     .optional(),
+  modo: clientePlanoModoSchema.optional(),
 });
 
 export type CreateClientePlanoInput = z.infer<typeof createClientePlanoSchema>;

--- a/src/modules/empresas/shared/planos.ts
+++ b/src/modules/empresas/shared/planos.ts
@@ -19,6 +19,9 @@ export const calcularFim = (
   if (modo === EmpresasPlanoModo.PARCEIRO) {
     return null; // sem validade
   }
+  if (modo === EmpresasPlanoModo.CLIENTE) {
+    return null; // assinatura ativa controlada pelo gateway de pagamento
+  }
   // Assinatura recorrente: controlada pelo gateway; opcionalmente 30 dias
   return null;
 };


### PR DESCRIPTION
## Summary
- adiciona o modo CLIENTE como padrão obrigatório em `EmpresasPlano` e ajusta o enum correspondente
- normaliza o uso dos modos de assinatura em validações e serviços de clientes, filtrando por clientes pagantes por padrão
- atualiza controladores, rotas, serviço administrativo e a documentação Swagger com a terminologia e exemplos de planos de assinatura

## Testing
- pnpm prisma:generate
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d3f2d9b0cc832584aaa2b49ace32ac