### PR TITLE
Handle null result when attaching address summary

### DIFF
--- a/src/modules/empresas/admin/services/admin-vagas.service.ts
+++ b/src/modules/empresas/admin/services/admin-vagas.service.ts
@@ -164,6 +164,10 @@ const mapUsuarioAdmin = (usuario?: UsuarioAdminRecord | null) => {
   }
 
   const merged = attachEnderecoResumo(mergeUsuarioInformacoes(usuario));
+
+  if (!merged) {
+    return null;
+  }
   const socialLinks = mapSocialLinks(merged.redesSociais);
 
   return {


### PR DESCRIPTION
## Summary
- prevent mapUsuarioAdmin from returning undefined properties by bailing out when address attachment fails

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d4ac17bab483259848a45d30480d65