### PR TITLE
feat(admin): add candidato management endpoints

### DIFF
--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -6099,6 +6099,21 @@ const options: Options = {
           ],
           example: 'EM_ANALISE',
         },
+        CandidatoLogTipo: {
+          type: 'string',
+          description: 'Eventos registrados automaticamente no histórico administrativo dos candidatos.',
+          enum: [
+            'CURRICULO_CRIADO',
+            'CURRICULO_ATUALIZADO',
+            'CURRICULO_REMOVIDO',
+            'CANDIDATO_ATIVADO',
+            'CANDIDATO_DESATIVADO',
+            'CANDIDATURA_CRIADA',
+            'CANDIDATURA_CANCELADA_CURRICULO',
+            'CANDIDATURA_CANCELADA_BLOQUEIO',
+          ],
+          example: 'CURRICULO_ATUALIZADO',
+        },
         OrigemVagas: {
           type: 'string',
           description: 'Origem do cadastro do processo seletivo associado à vaga.',
@@ -8643,6 +8658,168 @@ const options: Options = {
               total: 1,
               totalPages: 1,
             },
+          },
+        },
+        AdminCandidatoLog: {
+          type: 'object',
+          required: ['id', 'usuarioId', 'tipo', 'criadoEm'],
+          properties: {
+            id: { type: 'string', format: 'uuid', example: 'log-uuid' },
+            usuarioId: { type: 'string', format: 'uuid', example: 'user-uuid' },
+            tipo: { allOf: [{ $ref: '#/components/schemas/CandidatoLogTipo' }] },
+            descricao: {
+              type: 'string',
+              nullable: true,
+              example: 'Candidato atualizou o currículo principal.',
+            },
+            metadata: { type: 'object', nullable: true },
+            criadoEm: { type: 'string', format: 'date-time', example: '2024-05-18T09:30:00Z' },
+          },
+        },
+        AdminCandidatoCandidatura: {
+          type: 'object',
+          required: [
+            'id',
+            'vagaId',
+            'candidatoId',
+            'empresaUsuarioId',
+            'status',
+            'origem',
+            'aplicadaEm',
+            'atualizadaEm',
+          ],
+          properties: {
+            id: { type: 'string', format: 'uuid', example: 'candidatura-uuid' },
+            vagaId: { type: 'string', format: 'uuid', example: 'vaga-uuid' },
+            candidatoId: { type: 'string', format: 'uuid', example: 'usuario-uuid' },
+            curriculoId: { type: 'string', format: 'uuid', nullable: true },
+            empresaUsuarioId: { type: 'string', format: 'uuid', example: 'empresa-uuid' },
+            status: { allOf: [{ $ref: '#/components/schemas/StatusProcesso' }] },
+            origem: { allOf: [{ $ref: '#/components/schemas/OrigemVagas' }] },
+            aplicadaEm: { type: 'string', format: 'date-time', example: '2024-05-11T10:00:00Z' },
+            atualizadaEm: { type: 'string', format: 'date-time', example: '2024-05-11T10:00:00Z' },
+            consentimentos: { type: 'object', nullable: true },
+            curriculo: {
+              allOf: [{ $ref: '#/components/schemas/UsuarioCurriculo' }],
+              nullable: true,
+            },
+            vaga: {
+              allOf: [{ $ref: '#/components/schemas/AdminEmpresaVagaResumo' }],
+              nullable: true,
+            },
+            empresa: {
+              allOf: [{ $ref: '#/components/schemas/AdminVagaUsuarioResumo' }],
+              nullable: true,
+            },
+          },
+        },
+        AdminCandidatoProcesso: {
+          type: 'object',
+          required: [
+            'id',
+            'vagaId',
+            'candidatoId',
+            'status',
+            'origem',
+            'criadoEm',
+            'atualizadoEm',
+          ],
+          properties: {
+            id: { type: 'string', format: 'uuid', example: 'processo-uuid' },
+            vagaId: { type: 'string', format: 'uuid', example: 'vaga-uuid' },
+            candidatoId: { type: 'string', format: 'uuid', example: 'usuario-uuid' },
+            status: { allOf: [{ $ref: '#/components/schemas/StatusProcesso' }] },
+            origem: { allOf: [{ $ref: '#/components/schemas/OrigemVagas' }] },
+            observacoes: {
+              type: 'string',
+              nullable: true,
+              example: 'Entrevista técnica agendada.',
+            },
+            agendadoEm: { type: 'string', format: 'date-time', nullable: true },
+            criadoEm: { type: 'string', format: 'date-time', example: '2024-05-15T10:00:00Z' },
+            atualizadoEm: { type: 'string', format: 'date-time', example: '2024-05-16T16:30:00Z' },
+            vaga: {
+              allOf: [{ $ref: '#/components/schemas/AdminEmpresaVagaResumo' }],
+              nullable: true,
+            },
+          },
+        },
+        AdminCandidatoDetalhe: {
+          allOf: [
+            { $ref: '#/components/schemas/AdminVagaUsuarioResumo' },
+            {
+              type: 'object',
+              required: [
+                'curriculos',
+                'curriculosResumo',
+                'candidaturas',
+                'candidaturasResumo',
+                'processos',
+                'processosResumo',
+                'logs',
+              ],
+              properties: {
+                curriculos: {
+                  type: 'array',
+                  items: { $ref: '#/components/schemas/UsuarioCurriculo' },
+                },
+                curriculosResumo: {
+                  type: 'object',
+                  required: ['total', 'principais'],
+                  properties: {
+                    total: { type: 'integer', example: 2 },
+                    principais: { type: 'integer', example: 1 },
+                  },
+                },
+                candidaturas: {
+                  type: 'array',
+                  items: { $ref: '#/components/schemas/AdminCandidatoCandidatura' },
+                },
+                candidaturasResumo: {
+                  type: 'object',
+                  required: ['total', 'porStatus'],
+                  properties: {
+                    total: { type: 'integer', example: 3 },
+                    porStatus: {
+                      type: 'object',
+                      additionalProperties: { type: 'integer' },
+                      example: { RECEBIDA: 2, ENTREVISTA: 1 },
+                    },
+                  },
+                },
+                processos: {
+                  type: 'array',
+                  items: { $ref: '#/components/schemas/AdminCandidatoProcesso' },
+                },
+                processosResumo: {
+                  type: 'object',
+                  required: ['total', 'porStatus'],
+                  properties: {
+                    total: { type: 'integer', example: 1 },
+                    porStatus: {
+                      type: 'object',
+                      additionalProperties: { type: 'integer' },
+                      example: { ENTREVISTA: 1 },
+                    },
+                  },
+                },
+                logs: {
+                  type: 'array',
+                  items: { $ref: '#/components/schemas/AdminCandidatoLog' },
+                },
+              },
+            },
+          ],
+        },
+        AdminCandidatosListResponse: {
+          type: 'object',
+          required: ['data', 'pagination'],
+          properties: {
+            data: {
+              type: 'array',
+              items: { $ref: '#/components/schemas/AdminCandidatoDetalhe' },
+            },
+            pagination: { allOf: [{ $ref: '#/components/schemas/PaginationMeta' }] },
           },
         },
         EmpresaResumo: {

--- a/src/modules/empresas/admin/controllers/admin-candidatos.controller.ts
+++ b/src/modules/empresas/admin/controllers/admin-candidatos.controller.ts
@@ -1,0 +1,67 @@
+import type { Request, Response } from 'express';
+import { ZodError } from 'zod';
+
+import { adminCandidatosService } from '@/modules/empresas/admin/services/admin-candidatos.service';
+import {
+  adminCandidatosIdParamSchema,
+  adminCandidatosListQuerySchema,
+} from '@/modules/empresas/admin/validators/admin-candidatos.schema';
+
+export class AdminCandidatosController {
+  static list = async (req: Request, res: Response) => {
+    try {
+      const query = adminCandidatosListQuerySchema.parse(req.query);
+      const result = await adminCandidatosService.list(query);
+      return res.json(result);
+    } catch (error: any) {
+      if (error instanceof ZodError) {
+        return res.status(400).json({
+          success: false,
+          code: 'VALIDATION_ERROR',
+          message: 'Parâmetros inválidos para listar candidatos',
+          issues: error.flatten().fieldErrors,
+        });
+      }
+
+      return res.status(500).json({
+        success: false,
+        code: 'ADMIN_CANDIDATOS_LIST_ERROR',
+        message: 'Erro ao listar candidatos',
+        error: error?.message,
+      });
+    }
+  };
+
+  static get = async (req: Request, res: Response) => {
+    try {
+      const params = adminCandidatosIdParamSchema.parse(req.params);
+      const candidato = await adminCandidatosService.get(params.id);
+
+      if (!candidato) {
+        return res.status(404).json({
+          success: false,
+          code: 'ADMIN_CANDIDATO_NOT_FOUND',
+          message: 'Candidato não encontrado ou sem currículos cadastrados',
+        });
+      }
+
+      return res.json(candidato);
+    } catch (error: any) {
+      if (error instanceof ZodError) {
+        return res.status(400).json({
+          success: false,
+          code: 'VALIDATION_ERROR',
+          message: 'Parâmetros inválidos para buscar candidato',
+          issues: error.flatten().fieldErrors,
+        });
+      }
+
+      return res.status(500).json({
+        success: false,
+        code: 'ADMIN_CANDIDATOS_GET_ERROR',
+        message: 'Erro ao buscar candidato',
+        error: error?.message,
+      });
+    }
+  };
+}

--- a/src/modules/empresas/admin/services/admin-candidatos.service.ts
+++ b/src/modules/empresas/admin/services/admin-candidatos.service.ts
@@ -1,0 +1,352 @@
+import type { Prisma } from '@prisma/client';
+
+import { prisma } from '@/config/prisma';
+import {
+  curriculoSelect,
+  mapCurriculo,
+  mapUsuarioAdmin,
+  type CurriculoRecord,
+  type UsuarioAdminRecord,
+  usuarioAdminSelect,
+} from '@/modules/empresas/admin/services/admin-shared';
+
+import type { AdminCandidatosListQuery } from '@/modules/empresas/admin/validators/admin-candidatos.schema';
+
+const vagaResumoSelect = {
+  id: true,
+  codigo: true,
+  slug: true,
+  titulo: true,
+  status: true,
+  inseridaEm: true,
+  atualizadoEm: true,
+  inscricoesAte: true,
+  modoAnonimo: true,
+  modalidade: true,
+  regimeDeTrabalho: true,
+  paraPcd: true,
+  senioridade: true,
+  jornada: true,
+  numeroVagas: true,
+  descricao: true,
+  requisitos: true,
+  atividades: true,
+  beneficios: true,
+  observacoes: true,
+  localizacao: true,
+  salarioMin: true,
+  salarioMax: true,
+  salarioConfidencial: true,
+  maxCandidaturasPorUsuario: true,
+  areaInteresseId: true,
+  subareaInteresseId: true,
+  areaInteresse: {
+    select: {
+      id: true,
+      categoria: true,
+    },
+  },
+  subareaInteresse: {
+    select: {
+      id: true,
+      nome: true,
+      areaId: true,
+    },
+  },
+  destaque: true,
+  destaqueInfo: {
+    select: {
+      empresasPlanoId: true,
+      ativo: true,
+      ativadoEm: true,
+      desativadoEm: true,
+    },
+  },
+  empresa: { select: usuarioAdminSelect },
+} satisfies Prisma.EmpresasVagasSelect;
+
+const candidaturaSelect = {
+  id: true,
+  vagaId: true,
+  candidatoId: true,
+  curriculoId: true,
+  empresaUsuarioId: true,
+  status: true,
+  origem: true,
+  aplicadaEm: true,
+  atualizadaEm: true,
+  consentimentos: true,
+  curriculo: { select: curriculoSelect },
+  vaga: { select: vagaResumoSelect },
+  empresa: { select: usuarioAdminSelect },
+} satisfies Prisma.EmpresasCandidatosSelect;
+
+const processoSelect = {
+  id: true,
+  vagaId: true,
+  candidatoId: true,
+  status: true,
+  origem: true,
+  observacoes: true,
+  agendadoEm: true,
+  criadoEm: true,
+  atualizadoEm: true,
+  vaga: { select: vagaResumoSelect },
+} satisfies Prisma.EmpresasVagasProcessoSelect;
+
+const candidatoSelect = {
+  ...usuarioAdminSelect,
+  curriculos: {
+    orderBy: [
+      { principal: 'desc' },
+      { criadoEm: 'desc' },
+    ],
+    select: curriculoSelect,
+  },
+  candidaturasFeitas: {
+    orderBy: { aplicadaEm: 'desc' },
+    select: candidaturaSelect,
+  },
+  processosCandidatados: {
+    orderBy: { criadoEm: 'desc' },
+    select: processoSelect,
+  },
+  candidatoLogs: {
+    orderBy: { criadoEm: 'desc' },
+    select: {
+      id: true,
+      usuarioId: true,
+      tipo: true,
+      descricao: true,
+      metadata: true,
+      criadoEm: true,
+    },
+  },
+} satisfies Prisma.UsuariosSelect;
+
+type VagaResumoRecord = Prisma.EmpresasVagasGetPayload<{ select: typeof vagaResumoSelect }>;
+type CandidaturaRecord = Prisma.EmpresasCandidatosGetPayload<{ select: typeof candidaturaSelect }>;
+type ProcessoRecord = Prisma.EmpresasVagasProcessoGetPayload<{ select: typeof processoSelect }>;
+type CandidatoRecord = Prisma.UsuariosGetPayload<{ select: typeof candidatoSelect }>;
+
+const countByStatus = <T extends string>(items: { status: T }[]) =>
+  items.reduce<Record<string, number>>((acc, item) => {
+    acc[item.status] = (acc[item.status] ?? 0) + 1;
+    return acc;
+  }, {});
+
+const mapVagaResumo = (vaga?: VagaResumoRecord | null) => {
+  if (!vaga) {
+    return null;
+  }
+
+  return {
+    id: vaga.id,
+    codigo: vaga.codigo,
+    slug: vaga.slug,
+    titulo: vaga.titulo,
+    status: vaga.status,
+    inseridaEm: vaga.inseridaEm,
+    atualizadoEm: vaga.atualizadoEm,
+    inscricoesAte: vaga.inscricoesAte ?? null,
+    modoAnonimo: vaga.modoAnonimo,
+    modalidade: vaga.modalidade,
+    regimeDeTrabalho: vaga.regimeDeTrabalho,
+    paraPcd: vaga.paraPcd,
+    senioridade: vaga.senioridade,
+    jornada: vaga.jornada,
+    numeroVagas: vaga.numeroVagas,
+    descricao: vaga.descricao ?? null,
+    requisitos: vaga.requisitos,
+    atividades: vaga.atividades,
+    beneficios: vaga.beneficios,
+    observacoes: vaga.observacoes ?? null,
+    localizacao: vaga.localizacao ?? null,
+    salarioMin: vaga.salarioMin ?? null,
+    salarioMax: vaga.salarioMax ?? null,
+    salarioConfidencial: vaga.salarioConfidencial,
+    maxCandidaturasPorUsuario: vaga.maxCandidaturasPorUsuario ?? null,
+    areaInteresseId: vaga.areaInteresseId ?? null,
+    subareaInteresseId: vaga.subareaInteresseId ?? null,
+    areaInteresse: vaga.areaInteresse
+      ? {
+          id: vaga.areaInteresse.id,
+          categoria: vaga.areaInteresse.categoria,
+        }
+      : null,
+    subareaInteresse: vaga.subareaInteresse
+      ? {
+          id: vaga.subareaInteresse.id,
+          nome: vaga.subareaInteresse.nome,
+          areaId: vaga.subareaInteresse.areaId,
+        }
+      : null,
+    vagaEmDestaque: vaga.destaque,
+    destaqueInfo: vaga.destaqueInfo
+      ? {
+          empresasPlanoId: vaga.destaqueInfo.empresasPlanoId,
+          ativo: vaga.destaqueInfo.ativo,
+          ativadoEm: vaga.destaqueInfo.ativadoEm,
+          desativadoEm: vaga.destaqueInfo.desativadoEm ?? null,
+        }
+      : null,
+    empresa: mapUsuarioAdmin(vaga.empresa ?? null),
+  };
+};
+
+const mapCandidatura = (candidatura: CandidaturaRecord) => ({
+  id: candidatura.id,
+  vagaId: candidatura.vagaId,
+  candidatoId: candidatura.candidatoId,
+  curriculoId: candidatura.curriculoId ?? null,
+  empresaUsuarioId: candidatura.empresaUsuarioId,
+  status: candidatura.status,
+  origem: candidatura.origem,
+  aplicadaEm: candidatura.aplicadaEm,
+  atualizadaEm: candidatura.atualizadaEm,
+  consentimentos: candidatura.consentimentos ?? null,
+  curriculo: mapCurriculo(candidatura.curriculo ?? null),
+  vaga: mapVagaResumo(candidatura.vaga ?? null),
+  empresa: mapUsuarioAdmin(candidatura.empresa ?? null),
+});
+
+const mapProcesso = (processo: ProcessoRecord) => ({
+  id: processo.id,
+  vagaId: processo.vagaId,
+  candidatoId: processo.candidatoId,
+  status: processo.status,
+  origem: processo.origem,
+  observacoes: processo.observacoes ?? null,
+  agendadoEm: processo.agendadoEm ?? null,
+  criadoEm: processo.criadoEm,
+  atualizadoEm: processo.atualizadoEm,
+  vaga: mapVagaResumo(processo.vaga ?? null),
+});
+
+const mapCandidato = (candidato: CandidatoRecord) => {
+  const base = mapUsuarioAdmin(candidato as UsuarioAdminRecord);
+
+  const curriculos = candidato.curriculos
+    .map((curriculo) => mapCurriculo(curriculo as CurriculoRecord))
+    .filter((curriculo): curriculo is ReturnType<typeof mapCurriculo> => Boolean(curriculo));
+
+  const candidaturas = candidato.candidaturasFeitas.map(mapCandidatura);
+  const processos = candidato.processosCandidatados.map(mapProcesso);
+
+  return {
+    ...base!,
+    curriculos,
+    curriculosResumo: {
+      total: curriculos.length,
+      principais: curriculos.filter((curriculo) => curriculo?.principal).length,
+    },
+    candidaturas,
+    candidaturasResumo: {
+      total: candidaturas.length,
+      porStatus: countByStatus(candidaturas),
+    },
+    processos,
+    processosResumo: {
+      total: processos.length,
+      porStatus: countByStatus(processos),
+    },
+    logs: candidato.candidatoLogs.map((log) => ({
+      id: log.id,
+      usuarioId: log.usuarioId,
+      tipo: log.tipo,
+      descricao: log.descricao ?? null,
+      metadata: log.metadata ?? null,
+      criadoEm: log.criadoEm,
+    })),
+  };
+};
+
+type AdminCandidatoDetalhe = ReturnType<typeof mapCandidato>;
+
+type AdminCandidatosListResult = {
+  data: AdminCandidatoDetalhe[];
+  pagination: {
+    page: number;
+    pageSize: number;
+    total: number;
+    totalPages: number;
+  };
+};
+
+const buildPagination = (page: number, pageSize: number, total: number) => ({
+  page,
+  pageSize,
+  total,
+  totalPages: total === 0 ? 0 : Math.ceil(total / pageSize),
+});
+
+const buildWhere = ({ status, search }: AdminCandidatosListQuery): Prisma.UsuariosWhereInput => {
+  const conditions: Prisma.UsuariosWhereInput[] = [
+    {
+      role: 'ALUNO_CANDIDATO',
+      curriculos: { some: {} },
+    },
+  ];
+
+  if (status) {
+    conditions.push({ status });
+  }
+
+  if (search) {
+    conditions.push({
+      OR: [
+        { nomeCompleto: { contains: search, mode: 'insensitive' } },
+        { email: { contains: search, mode: 'insensitive' } },
+        { codUsuario: { contains: search, mode: 'insensitive' } },
+        { cpf: { contains: search, mode: 'insensitive' } },
+      ],
+    });
+  }
+
+  return conditions.length === 1 ? conditions[0] : { AND: conditions };
+};
+
+export const adminCandidatosService = {
+  list: async (params: AdminCandidatosListQuery): Promise<AdminCandidatosListResult> => {
+    const { page, pageSize } = params;
+    const where = buildWhere(params);
+    const skip = (page - 1) * pageSize;
+
+    const [total, candidatos] = await prisma.$transaction([
+      prisma.usuarios.count({ where }),
+      prisma.usuarios.findMany({
+        where,
+        orderBy: { criadoEm: 'desc' },
+        skip,
+        take: pageSize,
+        select: candidatoSelect,
+      }),
+    ]);
+
+    const data = candidatos
+      .filter((candidato) => candidato.curriculos.length > 0)
+      .map((candidato) => mapCandidato(candidato));
+
+    return {
+      data,
+      pagination: buildPagination(page, pageSize, total),
+    };
+  },
+
+  get: async (id: string) => {
+    const candidato = await prisma.usuarios.findFirst({
+      where: {
+        id,
+        role: 'ALUNO_CANDIDATO',
+        curriculos: { some: {} },
+      },
+      select: candidatoSelect,
+    });
+
+    if (!candidato || candidato.curriculos.length === 0) {
+      return null;
+    }
+
+    return mapCandidato(candidato);
+  },
+};

--- a/src/modules/empresas/admin/services/admin-shared.ts
+++ b/src/modules/empresas/admin/services/admin-shared.ts
@@ -1,0 +1,131 @@
+import type { Prisma } from '@prisma/client';
+
+import { attachEnderecoResumo } from '@/modules/usuarios/utils/address';
+import {
+  mergeUsuarioInformacoes,
+  usuarioInformacoesSelect,
+} from '@/modules/usuarios/utils/information';
+import { mapSocialLinks, usuarioRedesSociaisSelect } from '@/modules/usuarios/utils/social-links';
+
+const usuarioEnderecoSelect = {
+  orderBy: { criadoEm: 'asc' },
+  select: {
+    id: true,
+    logradouro: true,
+    numero: true,
+    bairro: true,
+    cidade: true,
+    estado: true,
+    cep: true,
+  },
+} as const;
+
+export const usuarioAdminSelect = {
+  id: true,
+  codUsuario: true,
+  nomeCompleto: true,
+  email: true,
+  cpf: true,
+  cnpj: true,
+  role: true,
+  tipoUsuario: true,
+  status: true,
+  criadoEm: true,
+  ultimoLogin: true,
+  ...usuarioRedesSociaisSelect,
+  informacoes: { select: usuarioInformacoesSelect },
+  enderecos: usuarioEnderecoSelect,
+} satisfies Prisma.UsuariosSelect;
+
+export const curriculoSelect = {
+  id: true,
+  usuarioId: true,
+  titulo: true,
+  resumo: true,
+  objetivo: true,
+  principal: true,
+  areasInteresse: true,
+  preferencias: true,
+  habilidades: true,
+  idiomas: true,
+  experiencias: true,
+  formacao: true,
+  cursosCertificacoes: true,
+  premiosPublicacoes: true,
+  acessibilidade: true,
+  consentimentos: true,
+  ultimaAtualizacao: true,
+  criadoEm: true,
+  atualizadoEm: true,
+} satisfies Prisma.UsuariosCurriculosSelect;
+
+export type UsuarioAdminRecord = Prisma.UsuariosGetPayload<{ select: typeof usuarioAdminSelect }>;
+export type CurriculoRecord = Prisma.UsuariosCurriculosGetPayload<{ select: typeof curriculoSelect }>;
+
+export const mapUsuarioAdmin = (usuario?: UsuarioAdminRecord | null) => {
+  if (!usuario) {
+    return null;
+  }
+
+  const merged = attachEnderecoResumo(mergeUsuarioInformacoes(usuario));
+
+  if (!merged) {
+    return null;
+  }
+
+  const socialLinks = mapSocialLinks(merged.redesSociais);
+
+  return {
+    id: merged.id,
+    codUsuario: merged.codUsuario,
+    nomeCompleto: merged.nomeCompleto,
+    email: merged.email,
+    cpf: merged.cpf ?? null,
+    cnpj: merged.cnpj ?? null,
+    role: merged.role,
+    tipoUsuario: merged.tipoUsuario,
+    status: merged.status,
+    criadoEm: merged.criadoEm,
+    ultimoLogin: merged.ultimoLogin ?? null,
+    telefone: merged.telefone ?? null,
+    genero: merged.genero ?? null,
+    dataNasc: merged.dataNasc ?? null,
+    inscricao: merged.inscricao ?? null,
+    avatarUrl: merged.avatarUrl ?? null,
+    descricao: merged.descricao ?? null,
+    aceitarTermos: merged.aceitarTermos ?? false,
+    cidade: merged.cidade,
+    estado: merged.estado,
+    enderecos: merged.enderecos,
+    socialLinks,
+    informacoes: merged.informacoes,
+  };
+};
+
+export const mapCurriculo = (curriculo?: CurriculoRecord | null) => {
+  if (!curriculo) {
+    return null;
+  }
+
+  return {
+    id: curriculo.id,
+    usuarioId: curriculo.usuarioId,
+    titulo: curriculo.titulo ?? null,
+    resumo: curriculo.resumo ?? null,
+    objetivo: curriculo.objetivo ?? null,
+    principal: curriculo.principal,
+    areasInteresse: curriculo.areasInteresse ?? null,
+    preferencias: curriculo.preferencias ?? null,
+    habilidades: curriculo.habilidades ?? null,
+    idiomas: curriculo.idiomas ?? null,
+    experiencias: curriculo.experiencias ?? null,
+    formacao: curriculo.formacao ?? null,
+    cursosCertificacoes: curriculo.cursosCertificacoes ?? null,
+    premiosPublicacoes: curriculo.premiosPublicacoes ?? null,
+    acessibilidade: curriculo.acessibilidade ?? null,
+    consentimentos: curriculo.consentimentos ?? null,
+    ultimaAtualizacao: curriculo.ultimaAtualizacao,
+    criadoEm: curriculo.criadoEm,
+    atualizadoEm: curriculo.atualizadoEm,
+  };
+};

--- a/src/modules/empresas/admin/services/admin-vagas.service.ts
+++ b/src/modules/empresas/admin/services/admin-vagas.service.ts
@@ -1,67 +1,14 @@
 import type { Prisma } from '@prisma/client';
 
 import { prisma } from '@/config/prisma';
-import { attachEnderecoResumo } from '@/modules/usuarios/utils/address';
 import {
-  mergeUsuarioInformacoes,
-  usuarioInformacoesSelect,
-} from '@/modules/usuarios/utils/information';
-import { mapSocialLinks, usuarioRedesSociaisSelect } from '@/modules/usuarios/utils/social-links';
+  curriculoSelect,
+  mapCurriculo,
+  mapUsuarioAdmin,
+  usuarioAdminSelect,
+} from '@/modules/empresas/admin/services/admin-shared';
 
 import type { AdminVagasListQuery } from '@/modules/empresas/admin/validators/admin-vagas.schema';
-
-const usuarioEnderecoSelect = {
-  orderBy: { criadoEm: 'asc' },
-  select: {
-    id: true,
-    logradouro: true,
-    numero: true,
-    bairro: true,
-    cidade: true,
-    estado: true,
-    cep: true,
-  },
-} as const;
-
-const usuarioAdminSelect = {
-  id: true,
-  codUsuario: true,
-  nomeCompleto: true,
-  email: true,
-  cpf: true,
-  cnpj: true,
-  role: true,
-  tipoUsuario: true,
-  status: true,
-  criadoEm: true,
-  ultimoLogin: true,
-  ...usuarioRedesSociaisSelect,
-  informacoes: { select: usuarioInformacoesSelect },
-  enderecos: usuarioEnderecoSelect,
-} satisfies Prisma.UsuariosSelect;
-
-const curriculoSelect = {
-  id: true,
-  usuarioId: true,
-  titulo: true,
-  resumo: true,
-  objetivo: true,
-  principal: true,
-  areasInteresse: true,
-  preferencias: true,
-  habilidades: true,
-  idiomas: true,
-  experiencias: true,
-  formacao: true,
-  cursosCertificacoes: true,
-  premiosPublicacoes: true,
-  acessibilidade: true,
-  consentimentos: true,
-  ultimaAtualizacao: true,
-  criadoEm: true,
-  atualizadoEm: true,
-} satisfies Prisma.UsuariosCurriculosSelect;
-
 const candidaturaSelect = {
   id: true,
   vagaId: true,
@@ -152,74 +99,9 @@ const vagaSelect = {
   },
 } satisfies Prisma.EmpresasVagasSelect;
 
-type UsuarioAdminRecord = Prisma.UsuariosGetPayload<{ select: typeof usuarioAdminSelect }>;
-type CurriculoRecord = Prisma.UsuariosCurriculosGetPayload<{ select: typeof curriculoSelect }>;
 type CandidaturaRecord = Prisma.EmpresasCandidatosGetPayload<{ select: typeof candidaturaSelect }>;
 type ProcessoRecord = Prisma.EmpresasVagasProcessoGetPayload<{ select: typeof processoSelect }>;
 type VagaRecord = Prisma.EmpresasVagasGetPayload<{ select: typeof vagaSelect }>;
-
-const mapUsuarioAdmin = (usuario?: UsuarioAdminRecord | null) => {
-  if (!usuario) {
-    return null;
-  }
-
-  const merged = attachEnderecoResumo(mergeUsuarioInformacoes(usuario));
-  const socialLinks = mapSocialLinks(merged.redesSociais);
-
-  return {
-    id: merged.id,
-    codUsuario: merged.codUsuario,
-    nomeCompleto: merged.nomeCompleto,
-    email: merged.email,
-    cpf: merged.cpf ?? null,
-    cnpj: merged.cnpj ?? null,
-    role: merged.role,
-    tipoUsuario: merged.tipoUsuario,
-    status: merged.status,
-    criadoEm: merged.criadoEm,
-    ultimoLogin: merged.ultimoLogin ?? null,
-    telefone: merged.telefone ?? null,
-    genero: merged.genero ?? null,
-    dataNasc: merged.dataNasc ?? null,
-    inscricao: merged.inscricao ?? null,
-    avatarUrl: merged.avatarUrl ?? null,
-    descricao: merged.descricao ?? null,
-    aceitarTermos: merged.aceitarTermos ?? false,
-    cidade: merged.cidade,
-    estado: merged.estado,
-    enderecos: merged.enderecos,
-    socialLinks,
-    informacoes: merged.informacoes,
-  };
-};
-
-const mapCurriculo = (curriculo?: CurriculoRecord | null) => {
-  if (!curriculo) {
-    return null;
-  }
-
-  return {
-    id: curriculo.id,
-    usuarioId: curriculo.usuarioId,
-    titulo: curriculo.titulo ?? null,
-    resumo: curriculo.resumo ?? null,
-    objetivo: curriculo.objetivo ?? null,
-    principal: curriculo.principal,
-    areasInteresse: curriculo.areasInteresse ?? null,
-    preferencias: curriculo.preferencias ?? null,
-    habilidades: curriculo.habilidades ?? null,
-    idiomas: curriculo.idiomas ?? null,
-    experiencias: curriculo.experiencias ?? null,
-    formacao: curriculo.formacao ?? null,
-    cursosCertificacoes: curriculo.cursosCertificacoes ?? null,
-    premiosPublicacoes: curriculo.premiosPublicacoes ?? null,
-    acessibilidade: curriculo.acessibilidade ?? null,
-    consentimentos: curriculo.consentimentos ?? null,
-    ultimaAtualizacao: curriculo.ultimaAtualizacao,
-    criadoEm: curriculo.criadoEm,
-    atualizadoEm: curriculo.atualizadoEm,
-  };
-};
 
 const mapCandidatura = (candidatura: CandidaturaRecord) => ({
   id: candidatura.id,

--- a/src/modules/empresas/admin/validators/admin-candidatos.schema.ts
+++ b/src/modules/empresas/admin/validators/admin-candidatos.schema.ts
@@ -1,0 +1,48 @@
+import { Status } from '@prisma/client';
+import { z } from 'zod';
+
+const statusSchema = z
+  .string()
+  .optional()
+  .transform((value) => {
+    if (!value) return undefined;
+    const normalized = value.trim().toUpperCase();
+    return normalized.length > 0 ? normalized : undefined;
+  })
+  .refine(
+    (value) =>
+      value === undefined || Object.prototype.hasOwnProperty.call(Status, value as Status),
+    {
+      message: 'Informe um status válido (ATIVO, INATIVO, BLOQUEADO, PENDENTE ou SUSPENSO)',
+    },
+  )
+  .transform((value) => (value ? (value as Status) : undefined));
+
+export const adminCandidatosListQuerySchema = z
+  .object({
+    page: z.coerce.number().int().min(1).optional(),
+    pageSize: z.coerce.number().int().min(1).max(100).optional(),
+    status: statusSchema,
+    search: z
+      .string()
+      .optional()
+      .transform((value) => {
+        if (typeof value !== 'string') return undefined;
+        const trimmed = value.trim();
+        return trimmed.length > 0 ? trimmed : undefined;
+      }),
+  })
+  .transform((values) => ({
+    page: values.page ?? 1,
+    pageSize: values.pageSize ?? 20,
+    status: values.status,
+    search: values.search,
+  }));
+
+export type AdminCandidatosListQuery = z.infer<typeof adminCandidatosListQuerySchema>;
+
+export const adminCandidatosIdParamSchema = z.object({
+  id: z.string().uuid(),
+});
+
+export type AdminCandidatosIdParam = z.infer<typeof adminCandidatosIdParamSchema>;


### PR DESCRIPTION
## Summary
- add shared admin mapping utilities for user and curriculum records reused across services
- implement admin candidate listing/detail service with controller, validator and secured routes for `/empresas/admin/candidato`
- extend swagger documentation with candidate schemas and update admin vagas service to consume shared helpers

## Testing
- pnpm lint
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d4b29e91a48325b0847f430ecfe7c4