### PR TITLE
Generate passwords automatically for admin empresa creation

### DIFF
--- a/src/modules/empresas/admin/validators/admin-empresas.schema.ts
+++ b/src/modules/empresas/admin/validators/admin-empresas.schema.ts
@@ -76,9 +76,10 @@ export const adminEmpresasCreateSchema = z.object({
     .min(10, 'Informe um telefone válido')
     .max(20, 'Telefone muito longo'),
   senha: z
-    .string({ required_error: 'Senha é obrigatória' })
+    .string()
     .min(8, 'Senha deve ter pelo menos 8 caracteres')
-    .max(255, 'Senha muito longa'),
+    .max(255, 'Senha muito longa')
+    .optional(),
   supabaseId: z
     .string({ required_error: 'Supabase ID é obrigatório' })
     .trim()


### PR DESCRIPTION
## Summary
- allow admin empresa creation without manually providing a password
- generate a secure random password when none is supplied and reuse it for hashing and email delivery
- relax the admin empresa creation schema so the senha field is optional

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d4b95b7b108325bdebc5cd1287d268