### PR TITLE
Fix admin candidato select relations

### DIFF
--- a/src/modules/empresas/admin/services/admin-candidatos.service.ts
+++ b/src/modules/empresas/admin/services/admin-candidatos.service.ts
@@ -133,7 +133,7 @@ const candidatoSelect = {
     ],
     select: curriculoSelect,
   },
-  candidaturas: {
+  candidaturasFeitas: {
     orderBy: { aplicadaEm: 'desc' },
     select: candidaturaSelect,
   },
@@ -288,7 +288,7 @@ const mapCandidatoDetalhe = (candidato: CandidatoRecord) => {
   }
 
   const curriculos = candidato.curriculos.map(mapCurriculo);
-  const candidaturas = candidato.candidaturas.map(mapCandidatura);
+  const candidaturas = candidato.candidaturasFeitas.map(mapCandidatura);
 
   return {
     ...base,


### PR DESCRIPTION
## Summary
- select candidaturasFeitas relation in admin candidato queries to match Prisma schema
- update mapping logic to use candidaturasFeitas when building candidaturas list

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68d4bca77d4883258a1818b1ee743a0b