### PR TITLE
Allow admin company creation without password input

### DIFF
--- a/src/modules/empresas/admin/validators/admin-empresas.schema.ts
+++ b/src/modules/empresas/admin/validators/admin-empresas.schema.ts
@@ -17,6 +17,16 @@ const nullableString = z
   .min(1, 'Informe um valor válido')
   .max(255, 'Valor muito longo');
 
+const optionalSanitizedString = <Schema extends z.ZodTypeAny>(schema: Schema) =>
+  z.preprocess((value) => {
+    if (typeof value !== 'string') {
+      return value;
+    }
+
+    const trimmed = value.trim();
+    return trimmed.length === 0 ? undefined : trimmed;
+  }, schema.optional());
+
 const nullableUrl = z.string().trim().url('Informe uma URL válida').max(500, 'URL muito longa');
 
 const socialLinksSchema = z
@@ -75,11 +85,9 @@ export const adminEmpresasCreateSchema = z.object({
     .trim()
     .min(10, 'Informe um telefone válido')
     .max(20, 'Telefone muito longo'),
-  senha: z
-    .string()
-    .min(8, 'Senha deve ter pelo menos 8 caracteres')
-    .max(255, 'Senha muito longa')
-    .optional(),
+  senha: optionalSanitizedString(
+    z.string().min(8, 'Senha deve ter pelo menos 8 caracteres').max(255, 'Senha muito longa'),
+  ),
   supabaseId: z
     .string({ required_error: 'Supabase ID é obrigatório' })
     .trim()


### PR DESCRIPTION
## Summary
- normalize optional password input for admin company creation requests before validation
- ensure empty password values are ignored so the API generates secure credentials automatically

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d4bf6dadd48325af58e5ed2a4b6ff2