### PR TITLE
Relax admin password input validation

### DIFF
--- a/src/modules/empresas/admin/validators/admin-empresas.schema.ts
+++ b/src/modules/empresas/admin/validators/admin-empresas.schema.ts
@@ -17,6 +17,25 @@ const nullableString = z
   .min(1, 'Informe um valor válido')
   .max(255, 'Valor muito longo');
 
+const securePasswordSchema = z
+  .string()
+  .min(8, 'Senha deve ter pelo menos 8 caracteres')
+  .max(255, 'Senha muito longa');
+
+const optionalSecurePassword = z.preprocess((value) => {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+
+  if (trimmed.length < 8) {
+    return undefined;
+  }
+
+  return trimmed;
+}, securePasswordSchema.optional());
+
 const nullableUrl = z.string().trim().url('Informe uma URL válida').max(500, 'URL muito longa');
 
 const socialLinksSchema = z
@@ -75,11 +94,7 @@ export const adminEmpresasCreateSchema = z.object({
     .trim()
     .min(10, 'Informe um telefone válido')
     .max(20, 'Telefone muito longo'),
-  senha: z
-    .string()
-    .min(8, 'Senha deve ter pelo menos 8 caracteres')
-    .max(255, 'Senha muito longa')
-    .optional(),
+  senha: optionalSecurePassword,
   supabaseId: z
     .string({ required_error: 'Supabase ID é obrigatório' })
     .trim()


### PR DESCRIPTION
## Summary
- preprocess optional admin password input so blank or weak values are ignored during validation
- rely on the secure password generator when the admin frontend omits a valid password

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d4bf6dadd48325af58e5ed2a4b6ff2