### PR TITLE
Add timestamps to cursos category models

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -104,6 +104,8 @@ model CursosCategorias {
   codCategoria String          @unique @db.VarChar(12)
   nome      String             @db.VarChar(120)
   descricao String?            @db.VarChar(255)
+  criadoEm  DateTime           @default(now())
+  atualizadoEm DateTime        @updatedAt
   subcats   CursosSubcategorias[]
   cursos    Cursos[]
 
@@ -117,6 +119,8 @@ model CursosSubcategorias {
   nome         String          @db.VarChar(120)
   descricao    String?         @db.VarChar(255)
   categoriaId  Int
+  criadoEm     DateTime        @default(now())
+  atualizadoEm DateTime        @updatedAt
   categoria    CursosCategorias  @relation(fields: [categoriaId], references: [id], onDelete: Cascade)
   cursos       Cursos[]
 


### PR DESCRIPTION
## Summary
- add criadoEm and atualizadoEm timestamp columns to the Prisma models for CursosCategorias and CursosSubcategorias to match service expectations
- regenerate the Prisma client so the new fields are available to TypeScript consumers

## Testing
- pnpm run build

------
https://chatgpt.com/codex/tasks/task_e_68d554ed87c88325a5ab05c5ee2e225a