### PR TITLE
Align cursos categorias list response with API standard

### DIFF
--- a/src/modules/cursos/controllers/categorias.controller.ts
+++ b/src/modules/cursos/controllers/categorias.controller.ts
@@ -69,7 +69,7 @@ export class CategoriasController {
   static list = async (_req: Request, res: Response) => {
     try {
       const data = await categoriasService.list();
-      res.json({ data });
+      res.json(data);
     } catch (error: any) {
       res.status(500).json({
         success: false,

--- a/src/modules/cursos/routes/index.ts
+++ b/src/modules/cursos/routes/index.ts
@@ -54,12 +54,9 @@ router.get('/meta', publicCache, CursosController.meta);
  *         content:
  *           application/json:
  *             schema:
- *               type: object
- *               properties:
- *                 data:
- *                   type: array
- *                   items:
- *                     $ref: '#/components/schemas/CursoCategoria'
+ *               type: array
+ *               items:
+ *                 $ref: '#/components/schemas/CursoCategoria'
  *       500:
  *         description: Erro ao listar categorias
  *         content:


### PR DESCRIPTION
## Summary
- return the cursos categorias listing directly as an array to match the API's common response format
- update the OpenAPI documentation to describe the array response for the categorias endpoint

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d56dbfedc883258d37a802e65836a2