### PR TITLE
Fix subcategory creation response

### DIFF
--- a/src/modules/cursos/services/categorias.service.ts
+++ b/src/modules/cursos/services/categorias.service.ts
@@ -170,7 +170,7 @@ export const categoriasService = {
         'Subcategoria criada com sucesso',
       );
 
-      return fetchSubcategoria(created.id);
+      return mapSubcategoria(created);
     });
   },
 


### PR DESCRIPTION
## Summary
- return the newly created subcategory directly from the transaction instead of re-querying it outside the transaction
- prevent the SUBCATEGORIA_NOT_FOUND error that occurred immediately after creating a subcategory

## Testing
- `pnpm lint` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d583da10948325bd9e2abf701a1a39