### PR TITLE
Atualiza status de cupons para WebsiteStatus

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -829,7 +829,7 @@ model CuponsDesconto {
   periodoInicio              DateTime?
   periodoFim                 DateTime?
   usosTotais                 Int                  @default(0)
-  ativo                      Boolean              @default(true)
+  status                     WebsiteStatus        @default(PUBLICADO)
   criadoPorId                String
   criadoEm                   DateTime             @default(now())
   atualizadoEm               DateTime             @updatedAt
@@ -839,8 +839,8 @@ model CuponsDesconto {
   planos    CuponsDescontoPlanos[]
 
   @@index([codigo])
-  @@index([ativo])
-  @@index([aplicarEm, ativo])
+  @@index([status])
+  @@index([aplicarEm, status])
 }
 
 model CuponsDescontoCursos {

--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -381,7 +381,10 @@ const options: Options = {
               example: '2025-03-01T23:59:59.000Z',
             },
             usosTotais: { type: 'integer', example: 12 },
-            ativo: { type: 'boolean', example: true },
+            status: {
+              $ref: '#/components/schemas/WebsiteStatus',
+              description: 'Estado de publicação do cupom',
+            },
             criadoEm: { type: 'string', format: 'date-time' },
             atualizadoEm: { type: 'string', format: 'date-time' },
             criadoPor: {
@@ -487,10 +490,9 @@ const options: Options = {
               format: 'date-time',
               nullable: true,
             },
-            ativo: {
-              type: 'boolean',
-              nullable: true,
-              example: true,
+            status: {
+              allOf: [{ $ref: '#/components/schemas/WebsiteStatus' }],
+              description: 'Quando não informado, o cupom é criado como PUBLICADO',
             },
           },
         },
@@ -549,9 +551,9 @@ const options: Options = {
               format: 'date-time',
               nullable: true,
             },
-            ativo: {
-              type: 'boolean',
-              nullable: true,
+            status: {
+              allOf: [{ $ref: '#/components/schemas/WebsiteStatus' }],
+              description: 'Atualiza o estado do cupom para PUBLICADO ou RASCUNHO',
             },
           },
         },

--- a/src/modules/cupons/services/cupons.service.ts
+++ b/src/modules/cupons/services/cupons.service.ts
@@ -5,6 +5,7 @@ import {
   CuponsLimiteUsuario,
   CuponsPeriodo,
   CuponsTipoDesconto,
+  WebsiteStatus,
 } from '@prisma/client';
 
 import { prisma } from '@/config/prisma';
@@ -82,7 +83,7 @@ const transformCupom = (cupom: CupomWithRelations) => ({
   periodoInicio: cupom.periodoInicio,
   periodoFim: cupom.periodoFim,
   usosTotais: cupom.usosTotais,
-  ativo: cupom.ativo,
+  status: cupom.status,
   criadoEm: cupom.criadoEm,
   atualizadoEm: cupom.atualizadoEm,
   criadoPor: cupom.criadoPor,
@@ -212,7 +213,7 @@ export const cuponsService = {
           periodoTipo: parsed.periodoTipo,
           periodoInicio: periodoValores.inicio,
           periodoFim: periodoValores.fim,
-          ativo: parsed.ativo ?? true,
+          status: parsed.status ?? WebsiteStatus.PUBLICADO,
           criadoPorId,
         },
       });
@@ -323,7 +324,7 @@ export const cuponsService = {
       periodoTipo: periodoTipoFinal,
       periodoInicio: periodoInicioFinal,
       periodoFim: periodoFimFinal,
-      ativo: data.ativo ?? existente.ativo,
+      status: data.status ?? existente.status,
     });
 
     const periodoValores = ensurePeriodoValores(
@@ -362,7 +363,7 @@ export const cuponsService = {
           periodoTipo: { set: periodoTipoFinal },
           periodoInicio: periodoValores.inicio,
           periodoFim: periodoValores.fim,
-          ativo: data.ativo ?? undefined,
+          status: data.status ? { set: data.status } : undefined,
         },
       });
 

--- a/src/modules/cupons/validators/cupons.schema.ts
+++ b/src/modules/cupons/validators/cupons.schema.ts
@@ -4,6 +4,7 @@ import {
   CuponsLimiteUsuario,
   CuponsPeriodo,
   CuponsTipoDesconto,
+  WebsiteStatus,
 } from '@prisma/client';
 import { RefinementCtx, z } from 'zod';
 
@@ -160,7 +161,7 @@ const baseCupomSchema = z
     periodoTipo: z.nativeEnum(CuponsPeriodo),
     periodoInicio: optionalDateSchema,
     periodoFim: optionalDateSchema,
-    ativo: z.boolean().optional(),
+    status: z.nativeEnum(WebsiteStatus).optional(),
   })
   .strict();
 
@@ -316,7 +317,7 @@ export const updateCupomDescontoSchema = z
     periodoTipo: z.nativeEnum(CuponsPeriodo).optional(),
     periodoInicio: optionalDateSchema,
     periodoFim: optionalDateSchema,
-    ativo: z.boolean().optional(),
+    status: z.nativeEnum(WebsiteStatus).optional(),
   })
   .strict();
 


### PR DESCRIPTION
## Summary
- altera o modelo de cupons para usar o campo `status` baseado em `WebsiteStatus`
- ajusta serviços, validações e respostas para expor o novo campo
- atualiza a documentação do Swagger/Redoc para refletir a mudança

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d5bb8e79a4832595040d7699623ae8