### PR TITLE
feat(empresas): add admin CNPJ validation endpoint and docs access

### DIFF
--- a/src/modules/empresas/admin/controllers/admin-empresas.controller.ts
+++ b/src/modules/empresas/admin/controllers/admin-empresas.controller.ts
@@ -13,6 +13,7 @@ import {
   adminEmpresasVagaParamSchema,
   adminEmpresasVagasQuerySchema,
   adminEmpresasUpdateSchema,
+  adminEmpresasValidateCnpjQuerySchema,
 } from '@/modules/empresas/admin/validators/admin-empresas.schema';
 
 export class AdminEmpresasController {
@@ -60,6 +61,31 @@ export class AdminEmpresasController {
         success: false,
         code: 'ADMIN_EMPRESAS_CREATE_ERROR',
         message: 'Erro ao criar empresa',
+        error: error?.message,
+      });
+    }
+  };
+
+  static validateCnpj = async (req: Request, res: Response) => {
+    try {
+      const query = adminEmpresasValidateCnpjQuerySchema.parse(req.query);
+      const result = await adminEmpresasService.validateCnpj(query.cnpj);
+
+      res.json(result);
+    } catch (error: any) {
+      if (error instanceof ZodError) {
+        return res.status(400).json({
+          success: false,
+          code: 'VALIDATION_ERROR',
+          message: 'Parâmetros inválidos',
+          issues: error.flatten().fieldErrors,
+        });
+      }
+
+      res.status(500).json({
+        success: false,
+        code: 'ADMIN_EMPRESAS_VALIDATE_CNPJ_ERROR',
+        message: 'Erro ao validar CNPJ',
         error: error?.message,
       });
     }

--- a/src/modules/empresas/admin/routes/index.ts
+++ b/src/modules/empresas/admin/routes/index.ts
@@ -1110,6 +1110,96 @@ router.get(
 
 /**
  * @openapi
+ * /api/v1/empresas/admin/validate-cnpj:
+ *   get:
+ *     summary: (Admin/Moderador) Validar CNPJ de empresa
+ *     description: "Verifica se um CNPJ é válido e identifica se já está cadastrado na plataforma."
+ *     operationId: adminEmpresasValidateCnpj
+ *     tags: [Empresas - Admin]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: cnpj
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: CNPJ a ser validado (com ou sem máscara)
+ *     responses:
+ *       200:
+ *         description: Resultado da validação do CNPJ
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/AdminEmpresaValidateCnpjResponse'
+ *             examples:
+ *               disponivel:
+ *                 summary: CNPJ válido e disponível
+ *                 value:
+ *                   success: true
+ *                   cnpj:
+ *                     input: '11.000.000/0001-00'
+ *                     normalized: '11000000000100'
+ *                     formatted: '11.000.000/0001-00'
+ *                     valid: true
+ *                   exists: false
+ *                   available: true
+ *                   empresa: null
+ *               emUso:
+ *                 summary: CNPJ já vinculado a uma empresa
+ *                 value:
+ *                   success: true
+ *                   cnpj:
+ *                     input: '12.345.678/0001-90'
+ *                     normalized: '12345678000190'
+ *                     formatted: '12.345.678/0001-90'
+ *                     valid: true
+ *                   exists: true
+ *                   available: false
+ *                   empresa:
+ *                     id: 'f66fbad9-4d3c-41f7-90df-2f4f0f32af10'
+ *                     nome: 'Advance Tech Consultoria'
+ *                     email: 'contato@advance.com.br'
+ *                     telefone: '+55 11 99999-0000'
+ *                     codUsuario: 'EMP-123456'
+ *                     status: 'ATIVO'
+ *                     role: 'EMPRESA'
+ *                     tipoUsuario: 'PESSOA_JURIDICA'
+ *                     criadoEm: '2024-01-05T12:00:00Z'
+ *                     atualizadoEm: '2024-05-20T08:15:00Z'
+ *       400:
+ *         description: Parâmetros inválidos
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ValidationErrorResponse'
+ *       401:
+ *         description: Token inválido ou ausente
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/UnauthorizedResponse'
+ *       403:
+ *         description: Acesso negado por falta de permissões válidas
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ForbiddenResponse'
+ *       500:
+ *         description: Erro interno do servidor
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ */
+router.get(
+  '/validate-cnpj',
+  supabaseAuthMiddleware(adminRoles),
+  AdminEmpresasController.validateCnpj,
+);
+
+/**
+ * @openapi
  * /api/v1/empresas/admin:
  *   post:
  *     summary: (Admin) Criar empresa

--- a/src/modules/empresas/admin/services/admin-empresas.service.ts
+++ b/src/modules/empresas/admin/services/admin-empresas.service.ts
@@ -547,6 +547,42 @@ const sanitizeTelefone = (telefone: string) => telefone.trim();
 const sanitizeSupabaseId = (supabaseId: string) => supabaseId.trim();
 const sanitizeSenha = async (senha: string) => bcrypt.hash(senha, 12);
 const normalizeDocumento = (value: string) => value.replace(/\D/g, '');
+const formatCnpj = (value: string) =>
+  value.replace(/(\d{2})(\d{3})(\d{3})(\d{4})(\d{2})/, '$1.$2.$3/$4-$5');
+
+const isValidCnpj = (value: string) => {
+  if (value.length !== 14) {
+    return false;
+  }
+
+  if (/^(\d)\1{13}$/.test(value)) {
+    return false;
+  }
+
+  const calculateDigit = (size: number) => {
+    let sum = 0;
+    let position = size - 7;
+
+    for (let i = size; i >= 1; i--) {
+      const index = size - i;
+      sum += Number(value.charAt(index)) * position--;
+      if (position < 2) {
+        position = 9;
+      }
+    }
+
+    const mod = sum % 11;
+    return mod < 2 ? 0 : 11 - mod;
+  };
+
+  const firstDigit = calculateDigit(12);
+  if (firstDigit !== Number(value.charAt(12))) {
+    return false;
+  }
+
+  const secondDigit = calculateDigit(13);
+  return secondDigit === Number(value.charAt(13));
+};
 
 const PASSWORD_UPPERCASE = 'ABCDEFGHJKLMNPQRSTUVWXYZ';
 const PASSWORD_LOWERCASE = 'abcdefghijkmnopqrstuvwxyz';
@@ -1092,6 +1128,73 @@ const listVagas = async (id: string, { page, pageSize, status }: AdminEmpresasVa
 };
 
 export const adminEmpresasService = {
+  validateCnpj: async (input: string) => {
+    const normalized = normalizeDocumento(input);
+    const hasFourteenDigits = normalized.length === 14;
+    const valid = hasFourteenDigits && isValidCnpj(normalized);
+
+    let empresaResumo:
+      | {
+          id: string;
+          nome: string;
+          email: string;
+          telefone: string | null;
+          codUsuario: string;
+          status: Status;
+          role: Roles;
+          tipoUsuario: TiposDeUsuarios;
+          criadoEm: Date;
+          atualizadoEm: Date;
+        }
+      | null = null;
+
+    if (hasFourteenDigits) {
+      const empresa = await prisma.usuarios.findFirst({
+        where: { cnpj: normalized },
+        select: {
+          id: true,
+          nomeCompleto: true,
+          email: true,
+          codUsuario: true,
+          status: true,
+          role: true,
+          tipoUsuario: true,
+          criadoEm: true,
+          atualizadoEm: true,
+          informacoes: { select: { telefone: true } },
+        },
+      });
+
+      if (empresa) {
+        empresaResumo = {
+          id: empresa.id,
+          nome: empresa.nomeCompleto,
+          email: empresa.email,
+          telefone: empresa.informacoes?.telefone ?? null,
+          codUsuario: empresa.codUsuario,
+          status: empresa.status,
+          role: empresa.role,
+          tipoUsuario: empresa.tipoUsuario,
+          criadoEm: empresa.criadoEm,
+          atualizadoEm: empresa.atualizadoEm,
+        };
+      }
+    }
+
+    return {
+      success: true,
+      cnpj: {
+        input,
+        normalized,
+        formatted: hasFourteenDigits ? formatCnpj(normalized) : null,
+        valid,
+      },
+      exists: empresaResumo !== null,
+      available: valid && !empresaResumo,
+      empresa: empresaResumo,
+    };
+  },
+
   create: async (input: AdminEmpresasCreateInput) => {
     const senhaOriginal = input.senha ?? generateSecurePassword();
     const senhaHash = await sanitizeSenha(senhaOriginal);

--- a/src/modules/empresas/admin/validators/admin-empresas.schema.ts
+++ b/src/modules/empresas/admin/validators/admin-empresas.schema.ts
@@ -199,6 +199,20 @@ export const adminEmpresasDashboardListQuerySchema = z
 
 export type AdminEmpresasDashboardListQuery = z.infer<typeof adminEmpresasDashboardListQuerySchema>;
 
+export const adminEmpresasValidateCnpjQuerySchema = z
+  .object({
+    cnpj: z
+      .string({ required_error: 'CNPJ é obrigatório' })
+      .trim()
+      .min(1, 'Informe um CNPJ para validação')
+      .max(30, 'CNPJ muito longo'),
+  })
+  .transform((values) => ({
+    cnpj: values.cnpj,
+  }));
+
+export type AdminEmpresasValidateCnpjQuery = z.infer<typeof adminEmpresasValidateCnpjQuerySchema>;
+
 export const adminEmpresasIdParamSchema = z.object({
   id: z.string().uuid(),
 });


### PR DESCRIPTION
## Summary
- add an authenticated `/api/v1/empresas/admin/validate-cnpj` endpoint for admins/moderators with service logic and query validation
- document the new validation response in the admin empresas OpenAPI definitions and schemas
- allow ADMIN and MODERADOR roles to open the Swagger UI and ReDoc portals

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d5dc0318488325b47895f3e2ef73a6