### PR TITLE
Expose admin company block status

### DIFF
--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -7091,7 +7091,17 @@ const options: Options = {
         AdminEmpresasDashboardListItem: {
           type: 'object',
           description: 'Resumo otimizado de empresas para exibição em dashboards administrativos.',
-          required: ['id', 'codUsuario', 'nome', 'email', 'status', 'criadoEm', 'vagasPublicadas'],
+          required: [
+            'id',
+            'codUsuario',
+            'nome',
+            'email',
+            'status',
+            'criadoEm',
+            'vagasPublicadas',
+            'bloqueada',
+            'bloqueioAtivo',
+          ],
           properties: {
             id: { type: 'string', format: 'uuid', example: 'empresa-uuid' },
             codUsuario: { type: 'string', example: 'EMP-123456' },
@@ -7146,6 +7156,16 @@ const options: Options = {
               allOf: [{ $ref: '#/components/schemas/AdminEmpresasPlanoResumo' }],
               nullable: true,
             },
+            bloqueada: {
+              type: 'boolean',
+              example: false,
+              description: 'Indica se a empresa possui algum bloqueio ativo aplicado à conta.',
+            },
+            bloqueioAtivo: {
+              allOf: [{ $ref: '#/components/schemas/AdminUsuariosEmBloqueiosResumo' }],
+              nullable: true,
+              description: 'Detalhes do bloqueio ativo quando existente.',
+            },
           },
         },
         AdminEmpresasDashboardListResponse: {
@@ -7189,6 +7209,8 @@ const options: Options = {
                   duracaoEmDias: null,
                   diasRestantes: 18,
                 },
+                bloqueada: false,
+                bloqueioAtivo: null,
               },
             ],
             pagination: {

--- a/src/modules/empresas/admin/routes/index.ts
+++ b/src/modules/empresas/admin/routes/index.ts
@@ -1072,6 +1072,8 @@ router.get('/vagas/:id', supabaseAuthMiddleware(adminRoles), AdminVagasControlle
  *                         quantidadeVagas: 10
  *                         duracaoEmDias: null
  *                         diasRestantes: 18
+ *                       bloqueada: false
+ *                       bloqueioAtivo: null
  *                   pagination:
  *                     page: 1
  *                     pageSize: 10

--- a/src/modules/empresas/admin/services/admin-empresas.service.ts
+++ b/src/modules/empresas/admin/services/admin-empresas.service.ts
@@ -201,6 +201,15 @@ const createUsuarioDashboardSelect = () =>
       },
     },
     planosContratados: createPlanoAtivoSelect(),
+    bloqueiosRecebidos: {
+      where: {
+        status: StatusDeBloqueios.ATIVO,
+        OR: [{ fim: null }, { fim: { gt: new Date() } }],
+      },
+      orderBy: [{ fim: 'desc' }, { criadoEm: 'desc' }],
+      take: 1,
+      select: bloqueioSelect,
+    },
     _count: {
       select: {
         vagasCriadas: {
@@ -371,6 +380,8 @@ type AdminEmpresasDashboardListItem = {
   vagasPublicadas: number;
   limiteVagasPlano: number | null;
   plano: AdminEmpresasPlanoResumo | null;
+  bloqueada: boolean;
+  bloqueioAtivo: AdminUsuariosEmBloqueiosResumo | null;
 };
 
 type AdminUsuariosBloqueioAlvo = {
@@ -1524,6 +1535,7 @@ export const adminEmpresasService = {
     const data: AdminEmpresasDashboardListItem[] = empresas.map((empresa) => {
       const planoAtual = empresa.planosContratados[0];
       const plano = mapPlanoResumo(planoAtual, referenceDate);
+      const bloqueio = mapBloqueioResumo(empresa.bloqueiosRecebidos?.[0] ?? null);
 
       return {
         id: empresa.id,
@@ -1538,6 +1550,8 @@ export const adminEmpresasService = {
         vagasPublicadas: empresa._count?.vagasCriadas ?? 0,
         limiteVagasPlano: plano?.quantidadeVagas ?? null,
         plano,
+        bloqueada: Boolean(bloqueio),
+        bloqueioAtivo: bloqueio,
       } satisfies AdminEmpresasDashboardListItem;
     });
 


### PR DESCRIPTION
## Summary
- surface the active block metadata in the admin empresas dashboard listing payload
- document the new bloqueada and bloqueioAtivo fields in the admin empresas routes and swagger examples

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d5ebd8bcf48325bf84a50e64ff85b0