### PR TITLE
Atualiza email de bloqueio e documentação

### DIFF
--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -7938,6 +7938,8 @@ const options: Options = {
               type: 'string',
               nullable: true,
               example: 'Uso indevido de dados pessoais de candidatos.',
+              description:
+                'Detalhamento adicional sobre o bloqueio. Quando preenchido, é enviado como "Descrição" no e-mail de bloqueio.',
             },
           },
         },

--- a/src/modules/empresas/admin/services/admin-empresas.service.ts
+++ b/src/modules/empresas/admin/services/admin-empresas.service.ts
@@ -1956,7 +1956,9 @@ export const adminEmpresasService = {
         const template = EmailTemplates.generateUserBlockedEmail({
           nomeCompleto: user.nomeCompleto,
           motivo: input.motivo,
-          fim,
+          fim: input.tipo === TiposDeBloqueios.TEMPORARIO ? fim : null,
+          descricao: input.observacoes ?? null,
+          tipo: input.tipo,
         });
         await emailService.sendAssinaturaNotificacao(
           { id: empresaId, email: user.email, nomeCompleto: user.nomeCompleto },


### PR DESCRIPTION
## Summary
- atualiza o template do e-mail de bloqueio com novo assunto, mensagem, lista de instruções e oculta o término para bloqueios permanentes
- inclui a descrição opcional no e-mail somente quando preenchida
- documenta no Swagger/Redoc que as observações do bloqueio são enviadas como "Descrição" no e-mail

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d5ee134a60832597bbe4b5c086b76a