### PR TITLE
feat: allow manual admin plan assignment

### DIFF
--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -6905,6 +6905,33 @@ const options: Options = {
                     'Quando verdadeiro, reinicia os campos de início e fim do novo plano. Caso não seja enviado, mantém as datas anteriores.',
                   example: true,
                 },
+                modeloPagamento: {
+                  allOf: [{ $ref: '#/components/schemas/ModeloPagamento' }],
+                  nullable: true,
+                  description: 'Modelo de cobrança associado ao plano (ex.: ASSINATURA, LICENCA).',
+                },
+                metodoPagamento: {
+                  allOf: [{ $ref: '#/components/schemas/MetodoPagamento' }],
+                  nullable: true,
+                  description: 'Método utilizado para pagamento do plano (PIX, CARTAO, etc.).',
+                },
+                statusPagamento: {
+                  allOf: [{ $ref: '#/components/schemas/StatusPagamento' }],
+                  nullable: true,
+                  description: 'Situação atual do pagamento vinculado ao plano.',
+                },
+                proximaCobranca: {
+                  type: 'string',
+                  format: 'date-time',
+                  nullable: true,
+                  description: 'Data agendada para a próxima cobrança do plano, quando aplicável.',
+                },
+                graceUntil: {
+                  type: 'string',
+                  format: 'date-time',
+                  nullable: true,
+                  description: 'Data limite de carência (grace period) configurada para o plano.',
+                },
               },
             },
           ],
@@ -6912,6 +6939,55 @@ const options: Options = {
             planosEmpresariaisId: 'b8d96a94-8a3d-4b90-8421-6f0a7bc1d42e',
             modo: 'PARCEIRO',
             resetPeriodo: true,
+            modeloPagamento: 'ASSINATURA',
+            statusPagamento: 'APROVADO',
+            proximaCobranca: '2024-06-15T12:00:00Z',
+          },
+        },
+        AdminEmpresasPlanoManualAssignInput: {
+          allOf: [
+            { $ref: '#/components/schemas/AdminEmpresasPlanoInput' },
+            {
+              type: 'object',
+              properties: {
+                modeloPagamento: {
+                  allOf: [{ $ref: '#/components/schemas/ModeloPagamento' }],
+                  nullable: true,
+                  description: 'Modelo de cobrança registrado manualmente para o plano',
+                },
+                metodoPagamento: {
+                  allOf: [{ $ref: '#/components/schemas/MetodoPagamento' }],
+                  nullable: true,
+                  description: 'Método utilizado para registrar o pagamento manual (PIX, BOLETO, etc.)',
+                },
+                statusPagamento: {
+                  allOf: [{ $ref: '#/components/schemas/StatusPagamento' }],
+                  nullable: true,
+                  description: 'Situação atual do pagamento associado ao plano manual',
+                },
+                proximaCobranca: {
+                  type: 'string',
+                  format: 'date-time',
+                  nullable: true,
+                  description: 'Data planejada para a próxima cobrança manual registrada.',
+                },
+                graceUntil: {
+                  type: 'string',
+                  format: 'date-time',
+                  nullable: true,
+                  description: 'Data limite do período de carência acordado manualmente.',
+                },
+              },
+            },
+          ],
+          example: {
+            planosEmpresariaisId: '7d1c88e3-90e7-43df-9a29-b4096b5a79c4',
+            modo: 'CLIENTE',
+            iniciarEm: '2024-05-10T12:00:00Z',
+            modeloPagamento: 'ASSINATURA',
+            metodoPagamento: 'PIX',
+            statusPagamento: 'APROVADO',
+            proximaCobranca: '2024-06-10T12:00:00Z',
           },
         },
         AdminEmpresaCreateInput: {

--- a/src/modules/empresas/admin/controllers/admin-empresas.controller.ts
+++ b/src/modules/empresas/admin/controllers/admin-empresas.controller.ts
@@ -9,6 +9,7 @@ import {
   adminEmpresasHistoryQuerySchema,
   adminEmpresasIdParamSchema,
   adminEmpresasListQuerySchema,
+  adminEmpresasPlanoManualAssignSchema,
   adminEmpresasPlanoUpdateSchema,
   adminEmpresasVagaParamSchema,
   adminEmpresasVagasQuerySchema,
@@ -298,6 +299,56 @@ export class AdminEmpresasController {
         success: false,
         code: 'ADMIN_EMPRESAS_UPDATE_PLANO_ERROR',
         message: 'Erro ao atualizar plano da empresa',
+        error: error?.message,
+      });
+    }
+  };
+
+  static assignPlanoManual = async (req: Request, res: Response) => {
+    try {
+      const params = adminEmpresasIdParamSchema.parse(req.params);
+      const payload = adminEmpresasPlanoManualAssignSchema.parse(req.body);
+      const empresa = await adminEmpresasService.assignPlanoManual(params.id, payload);
+
+      if (!empresa) {
+        return res.status(404).json({
+          success: false,
+          code: 'EMPRESA_NOT_FOUND',
+          message: 'Empresa não encontrada',
+        });
+      }
+
+      res.status(201).json({ empresa });
+    } catch (error: any) {
+      if (error instanceof ZodError) {
+        return res.status(400).json({
+          success: false,
+          code: 'VALIDATION_ERROR',
+          message: 'Dados inválidos para cadastro manual do plano',
+          issues: error.flatten().fieldErrors,
+        });
+      }
+
+      if (error?.code === 'EMPRESA_NOT_FOUND' || error?.code === 'P2025') {
+        return res.status(404).json({
+          success: false,
+          code: 'EMPRESA_NOT_FOUND',
+          message: 'Empresa não encontrada',
+        });
+      }
+
+      if (error?.code === 'P2003') {
+        return res.status(404).json({
+          success: false,
+          code: 'PLANO_EMPRESARIAL_NOT_FOUND',
+          message: 'Plano empresarial informado não foi encontrado',
+        });
+      }
+
+      res.status(500).json({
+        success: false,
+        code: 'ADMIN_EMPRESAS_ASSIGN_PLANO_ERROR',
+        message: 'Erro ao cadastrar plano da empresa manualmente',
         error: error?.message,
       });
     }

--- a/src/modules/empresas/admin/validators/admin-empresas.schema.ts
+++ b/src/modules/empresas/admin/validators/admin-empresas.schema.ts
@@ -1,6 +1,9 @@
 import {
   EmpresasPlanoModo,
+  METODO_PAGAMENTO,
+  MODELO_PAGAMENTO,
   MotivosDeBloqueios,
+  STATUS_PAGAMENTO,
   Status,
   StatusDeVagas,
   TiposDeBloqueios,
@@ -55,6 +58,13 @@ const diasTesteSchema = z
   .positive('Dias de teste deve ser maior que zero')
   .max(365, 'Máximo de 365 dias');
 
+const nullableDate = z
+  .union([
+    z.coerce.date({ invalid_type_error: 'Informe uma data válida' }),
+    z.null(),
+  ])
+  .optional();
+
 const adminEmpresasPlanoBase = z.object({
   planosEmpresariaisId: uuidSchema,
   modo: clientePlanoModoSchema,
@@ -70,7 +80,14 @@ export const adminEmpresasPlanoSchema = adminEmpresasPlanoBase.refine(
 export type AdminEmpresasPlanoInput = z.infer<typeof adminEmpresasPlanoSchema>;
 
 export const adminEmpresasPlanoUpdateSchema = adminEmpresasPlanoBase
-  .extend({ resetPeriodo: z.boolean().optional() })
+  .extend({
+    resetPeriodo: z.boolean().optional(),
+    modeloPagamento: z.nativeEnum(MODELO_PAGAMENTO).nullable().optional(),
+    metodoPagamento: z.nativeEnum(METODO_PAGAMENTO).nullable().optional(),
+    statusPagamento: z.nativeEnum(STATUS_PAGAMENTO).nullable().optional(),
+    proximaCobranca: nullableDate,
+    graceUntil: nullableDate,
+  })
   .refine(
     (val) => (val.modo !== EmpresasPlanoModo.TESTE ? true : typeof val.diasTeste === 'number'),
     {
@@ -80,6 +97,18 @@ export const adminEmpresasPlanoUpdateSchema = adminEmpresasPlanoBase
   );
 
 export type AdminEmpresasPlanoUpdateInput = z.infer<typeof adminEmpresasPlanoUpdateSchema>;
+
+export const adminEmpresasPlanoManualAssignSchema = adminEmpresasPlanoSchema.extend({
+  modeloPagamento: z.nativeEnum(MODELO_PAGAMENTO).optional().nullable(),
+  metodoPagamento: z.nativeEnum(METODO_PAGAMENTO).optional().nullable(),
+  statusPagamento: z.nativeEnum(STATUS_PAGAMENTO).optional().nullable(),
+  proximaCobranca: nullableDate,
+  graceUntil: nullableDate,
+});
+
+export type AdminEmpresasPlanoManualAssignInput = z.infer<
+  typeof adminEmpresasPlanoManualAssignSchema
+>;
 
 export const adminEmpresasCreateSchema = z.object({
   nome: z


### PR DESCRIPTION
## Summary
- add manual admin route to register company plans manually with optional payment metadata
- extend validation/service layer to persist manual plans and cancel existing active plans
- document the new manual assignment endpoint in OpenAPI and Swagger components
- expand admin plan update flow to accept manual billing metadata and reflect the enhanced fields in API docs

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d60ba880648325a84876057c29c924