### PR TITLE
Fix manual assign schema extension to use base schema

### DIFF
--- a/src/modules/empresas/admin/validators/admin-empresas.schema.ts
+++ b/src/modules/empresas/admin/validators/admin-empresas.schema.ts
@@ -98,13 +98,21 @@ export const adminEmpresasPlanoUpdateSchema = adminEmpresasPlanoBase
 
 export type AdminEmpresasPlanoUpdateInput = z.infer<typeof adminEmpresasPlanoUpdateSchema>;
 
-export const adminEmpresasPlanoManualAssignSchema = adminEmpresasPlanoSchema.extend({
-  modeloPagamento: z.nativeEnum(MODELO_PAGAMENTO).optional().nullable(),
-  metodoPagamento: z.nativeEnum(METODO_PAGAMENTO).optional().nullable(),
-  statusPagamento: z.nativeEnum(STATUS_PAGAMENTO).optional().nullable(),
-  proximaCobranca: nullableDate,
-  graceUntil: nullableDate,
-});
+export const adminEmpresasPlanoManualAssignSchema = adminEmpresasPlanoBase
+  .extend({
+    modeloPagamento: z.nativeEnum(MODELO_PAGAMENTO).optional().nullable(),
+    metodoPagamento: z.nativeEnum(METODO_PAGAMENTO).optional().nullable(),
+    statusPagamento: z.nativeEnum(STATUS_PAGAMENTO).optional().nullable(),
+    proximaCobranca: nullableDate,
+    graceUntil: nullableDate,
+  })
+  .refine(
+    (val) => (val.modo !== EmpresasPlanoModo.TESTE ? true : typeof val.diasTeste === 'number'),
+    {
+      message: 'Informe diasTeste para o modo teste',
+      path: ['diasTeste'],
+    },
+  );
 
 export type AdminEmpresasPlanoManualAssignInput = z.infer<
   typeof adminEmpresasPlanoManualAssignSchema


### PR DESCRIPTION
## Summary
- build the manual assign schema from the base plan schema instead of the refined schema
- ensure the mode-specific validation still applies after extending the schema

## Testing
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68d60f3fb9448325983c96052963d4ea