### PR TITLE
Ajusta cálculo de fim de planos manuais e documentação

### DIFF
--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -3699,6 +3699,8 @@ const options: Options = {
               format: 'date-time',
               nullable: true,
               example: '2024-02-01T12:00:00Z',
+              description:
+                'Data final prevista do registro do plano. Em planos do modo CLIENTE, considera automaticamente a próxima cobrança ou data de carência disponível, privilegiando a data mais distante.',
             },
             criadoEm: {
               type: 'string',
@@ -6170,6 +6172,8 @@ const options: Options = {
               format: 'date-time',
               nullable: true,
               example: '2024-01-08T12:00:00Z',
+              description:
+                'Data configurada para expiração do plano. No modo CLIENTE, reflete automaticamente a próxima cobrança ou a data de carência mais recente informada.',
             },
             status: {
               type: 'string',
@@ -6389,6 +6393,8 @@ const options: Options = {
               format: 'date-time',
               nullable: true,
               example: '2024-02-10T12:00:00Z',
+              description:
+                'Data prevista para término do plano. Para planos no modo CLIENTE, corresponde à data mais recente entre a próxima cobrança registrada e o período de carência (grace period) informado.',
             },
             modeloPagamento: {
               allOf: [{ $ref: '#/components/schemas/ModeloPagamento' }],
@@ -6426,17 +6432,17 @@ const options: Options = {
           example: {
             id: '38f73d2d-40fa-47a6-9657-6a4f7f1bb610',
             nome: 'Plano Avançado',
-            modo: 'PARCEIRO',
+            modo: 'CLIENTE',
             status: 'ATIVO',
-            inicio: '2024-01-10T12:00:00Z',
-            fim: null,
+            inicio: '2024-05-10T12:00:00Z',
+            fim: '2024-06-10T12:00:00Z',
             modeloPagamento: 'ASSINATURA',
             metodoPagamento: 'PIX',
             statusPagamento: 'APROVADO',
             valor: '249.90',
             quantidadeVagas: 5,
-            duracaoEmDias: null,
-            diasRestantes: 18,
+            duracaoEmDias: 31,
+            diasRestantes: 12,
           },
         },
         UsuarioEndereco: {

--- a/src/modules/empresas/admin/routes/index.ts
+++ b/src/modules/empresas/admin/routes/index.ts
@@ -1515,7 +1515,7 @@ router.get('/', supabaseAuthMiddleware(adminRoles), AdminEmpresasController.list
  * /api/v1/empresas/admin/{id}/plano:
  *   post:
  *     summary: (Admin/Moderador) Cadastrar plano manualmente para a empresa
- *     description: "Permite registrar manualmente um novo plano empresarial para a empresa selecionada. Qualquer plano ativo é automaticamente cancelado antes do novo vínculo. Endpoint restrito aos perfis ADMIN e MODERADOR."
+ *     description: "Permite registrar manualmente um novo plano empresarial para a empresa selecionada. Qualquer plano ativo é automaticamente cancelado antes do novo vínculo. Quando informados, os campos de próxima cobrança ou período de carência definem automaticamente a data de término do plano. Endpoint restrito aos perfis ADMIN e MODERADOR."
  *     operationId: adminEmpresasAssignPlanoManual
  *     tags: [Empresas - Admin]
  *     security:
@@ -1571,14 +1571,14 @@ router.get('/', supabaseAuthMiddleware(adminRoles), AdminEmpresasController.list
  *                       modo: CLIENTE
  *                       status: ATIVO
  *                       inicio: '2024-05-10T12:00:00Z'
- *                       fim: '2024-08-10T12:00:00Z'
+ *                       fim: '2024-06-10T12:00:00Z'
  *                       modeloPagamento: ASSINATURA
  *                       metodoPagamento: PIX
  *                       statusPagamento: APROVADO
  *                       valor: '349.90'
  *                       quantidadeVagas: 20
- *                       duracaoEmDias: 92
- *                       diasRestantes: 92
+ *                       duracaoEmDias: 31
+ *                       diasRestantes: 12
  *       400:
  *         description: Dados inválidos
  *         content:

--- a/src/modules/empresas/shared/__tests__/planos.test.ts
+++ b/src/modules/empresas/shared/__tests__/planos.test.ts
@@ -1,0 +1,40 @@
+import { EmpresasPlanoModo } from '@prisma/client';
+
+import { calcularFim } from '../planos';
+
+describe('calcularFim', () => {
+  it('calcula o término padrão para planos de teste', () => {
+    const inicio = new Date('2024-05-10T12:00:00Z');
+
+    const fim = calcularFim(EmpresasPlanoModo.TESTE, inicio, 10);
+
+    expect(fim?.toISOString()).toBe('2024-05-20T12:00:00.000Z');
+  });
+
+  it('retorna a próxima cobrança para planos do modo CLIENTE', () => {
+    const inicio = new Date('2024-05-10T12:00:00Z');
+    const proximaCobranca = new Date('2024-06-10T12:00:00Z');
+
+    const fim = calcularFim(EmpresasPlanoModo.CLIENTE, inicio, undefined, proximaCobranca, null);
+
+    expect(fim?.toISOString()).toBe('2024-06-10T12:00:00.000Z');
+  });
+
+  it('prioriza o período de carência quando for mais distante que a próxima cobrança', () => {
+    const inicio = new Date('2024-05-10T12:00:00Z');
+    const proximaCobranca = new Date('2024-06-10T12:00:00Z');
+    const graceUntil = new Date('2024-06-15T12:00:00Z');
+
+    const fim = calcularFim(EmpresasPlanoModo.CLIENTE, inicio, undefined, proximaCobranca, graceUntil);
+
+    expect(fim?.toISOString()).toBe('2024-06-15T12:00:00.000Z');
+  });
+
+  it('retorna null para planos do modo CLIENTE sem limites definidos', () => {
+    const inicio = new Date('2024-05-10T12:00:00Z');
+
+    const fim = calcularFim(EmpresasPlanoModo.CLIENTE, inicio);
+
+    expect(fim).toBeNull();
+  });
+});

--- a/src/modules/empresas/shared/planos.ts
+++ b/src/modules/empresas/shared/planos.ts
@@ -6,23 +6,57 @@ export const addDays = (date: Date, days: number) => {
   return d;
 };
 
+const sanitizeDate = (value?: Date | null): Date | null => {
+  if (!value) {
+    return null;
+  }
+
+  const time = value.getTime();
+
+  if (Number.isNaN(time)) {
+    return null;
+  }
+
+  return new Date(time);
+};
+
 export const calcularFim = (
   modo: EmpresasPlanoModo | null | undefined,
   inicio: Date | null,
   diasTeste?: number | null,
+  proximaCobranca?: Date | null,
+  graceUntil?: Date | null,
 ): Date | null => {
   const base = inicio ?? new Date();
+
+  if (modo === EmpresasPlanoModo.CLIENTE) {
+    const limites = [sanitizeDate(proximaCobranca), sanitizeDate(graceUntil)].filter(
+      (value): value is Date => value !== null,
+    );
+
+    if (limites.length > 0) {
+      const [primeiro, ...restante] = limites;
+      const limiteMaisRecente = restante.reduce(
+        (maisRecente, atual) => (atual.getTime() > maisRecente.getTime() ? atual : maisRecente),
+        primeiro,
+      );
+
+      return new Date(limiteMaisRecente.getTime());
+    }
+
+    return null; // assinatura ativa controlada pelo gateway de pagamento
+  }
+
   if (modo === EmpresasPlanoModo.TESTE) {
     const dias = typeof diasTeste === 'number' && diasTeste > 0 ? diasTeste : 7;
     return addDays(base, dias);
   }
+
   if (modo === EmpresasPlanoModo.PARCEIRO) {
     return null; // sem validade
   }
-  if (modo === EmpresasPlanoModo.CLIENTE) {
-    return null; // assinatura ativa controlada pelo gateway de pagamento
-  }
-  // Assinatura recorrente: controlada pelo gateway; opcionalmente 30 dias
+
+  // Assinaturas recorrentes de outros modos: controladas pelo gateway
   return null;
 };
 


### PR DESCRIPTION
## Summary
- calcula o fim dos planos empresariais no modo CLIENTE usando a próxima cobrança ou a carência informada
- aplica o novo cálculo na atribuição/atualização de planos administrativos e documenta o comportamento no Swagger/Redoc
- adiciona testes unitários para garantir o cálculo correto do término do plano

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d6227bb8d083259134113430198a7c