### PR TITLE
Add CRUD endpoints for candidato interest subareas

### DIFF
--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -3863,6 +3863,31 @@ const options: Options = {
             },
           },
         },
+        CandidatoSubareaInteresseCreateInput: {
+          type: 'object',
+          description: 'Payload para criação de uma nova subárea vinculada a uma área existente.',
+          required: ['nome'],
+          properties: {
+            nome: {
+              type: 'string',
+              example: 'Desenvolvimento Back-end',
+              maxLength: 120,
+            },
+          },
+        },
+        CandidatoSubareaInteresseUpdateInput: {
+          type: 'object',
+          description:
+            'Payload para atualização das informações de uma subárea de interesse específica.',
+          required: ['nome'],
+          properties: {
+            nome: {
+              type: 'string',
+              example: 'Segurança da Informação',
+              maxLength: 120,
+            },
+          },
+        },
         CandidatoAreaInteresse: {
           type: 'object',
           description:

--- a/src/modules/candidatos/areas-interesse/controllers/areas-interesse.controller.ts
+++ b/src/modules/candidatos/areas-interesse/controllers/areas-interesse.controller.ts
@@ -4,7 +4,9 @@ import { ZodError } from 'zod';
 import { areasInteresseService } from '../services/areas-interesse.service';
 import {
   createAreaInteresseSchema,
+  createSubareaInteresseSchema,
   updateAreaInteresseSchema,
+  updateSubareaInteresseSchema,
 } from '../validators/areas-interesse.schema';
 
 const parseId = (raw: string) => {
@@ -164,6 +166,120 @@ export class AreasInteresseController {
         success: false,
         code: 'AREAS_INTERESSE_DELETE_ERROR',
         message: 'Erro ao remover área de interesse',
+        error: error?.message,
+      });
+    }
+  };
+
+  static createSubarea = async (req: Request, res: Response) => {
+    const areaId = parseId(req.params.areaId);
+    if (!areaId) {
+      return res.status(400).json({
+        success: false,
+        code: 'VALIDATION_ERROR',
+        message: 'Identificador inválido para área de interesse',
+      });
+    }
+
+    try {
+      const data = createSubareaInteresseSchema.parse(req.body);
+      const subarea = await areasInteresseService.createSubarea(areaId, data);
+
+      res.status(201).json(subarea);
+    } catch (error: any) {
+      if (error instanceof ZodError) {
+        return res.status(400).json({
+          success: false,
+          code: 'VALIDATION_ERROR',
+          message: 'Dados inválidos para criação da subárea de interesse',
+          issues: error.flatten().fieldErrors,
+        });
+      }
+
+      if (error?.code === 'P2025') {
+        return res.status(404).json({
+          success: false,
+          code: 'AREAS_INTERESSE_NOT_FOUND',
+          message: 'Área de interesse não encontrada',
+        });
+      }
+
+      res.status(500).json({
+        success: false,
+        code: 'AREAS_INTERESSE_SUBAREA_CREATE_ERROR',
+        message: 'Erro ao criar subárea de interesse',
+        error: error?.message,
+      });
+    }
+  };
+
+  static updateSubarea = async (req: Request, res: Response) => {
+    const subareaId = parseId(req.params.subareaId);
+    if (!subareaId) {
+      return res.status(400).json({
+        success: false,
+        code: 'VALIDATION_ERROR',
+        message: 'Identificador inválido para subárea de interesse',
+      });
+    }
+
+    try {
+      const data = updateSubareaInteresseSchema.parse(req.body);
+      const subarea = await areasInteresseService.updateSubarea(subareaId, data);
+      res.json(subarea);
+    } catch (error: any) {
+      if (error instanceof ZodError) {
+        return res.status(400).json({
+          success: false,
+          code: 'VALIDATION_ERROR',
+          message: 'Dados inválidos para atualização da subárea de interesse',
+          issues: error.flatten().fieldErrors,
+        });
+      }
+
+      if (error?.code === 'P2025') {
+        return res.status(404).json({
+          success: false,
+          code: 'AREAS_INTERESSE_SUBAREA_NOT_FOUND',
+          message: 'Subárea de interesse não encontrada',
+        });
+      }
+
+      res.status(500).json({
+        success: false,
+        code: 'AREAS_INTERESSE_SUBAREA_UPDATE_ERROR',
+        message: 'Erro ao atualizar subárea de interesse',
+        error: error?.message,
+      });
+    }
+  };
+
+  static removeSubarea = async (req: Request, res: Response) => {
+    const subareaId = parseId(req.params.subareaId);
+    if (!subareaId) {
+      return res.status(400).json({
+        success: false,
+        code: 'VALIDATION_ERROR',
+        message: 'Identificador inválido para subárea de interesse',
+      });
+    }
+
+    try {
+      await areasInteresseService.removeSubarea(subareaId);
+      res.status(204).send();
+    } catch (error: any) {
+      if (error?.code === 'P2025') {
+        return res.status(404).json({
+          success: false,
+          code: 'AREAS_INTERESSE_SUBAREA_NOT_FOUND',
+          message: 'Subárea de interesse não encontrada',
+        });
+      }
+
+      res.status(500).json({
+        success: false,
+        code: 'AREAS_INTERESSE_SUBAREA_DELETE_ERROR',
+        message: 'Erro ao remover subárea de interesse',
         error: error?.message,
       });
     }

--- a/src/modules/candidatos/areas-interesse/routes/index.ts
+++ b/src/modules/candidatos/areas-interesse/routes/index.ts
@@ -363,4 +363,91 @@ router.put('/:id', supabaseAuthMiddleware(adminRoles), AreasInteresseController.
  */
 router.delete('/:id', supabaseAuthMiddleware(adminRoles), AreasInteresseController.remove);
 
+/**
+ * @openapi
+ * /api/v1/candidatos/areas-interesse/{areaId}/subareas:
+ *   post:
+ *     summary: Criar subárea vinculada a uma área de interesse
+ *     description: Disponível apenas para administradores e moderadores (roles: ADMIN, MODERADOR).
+ *     tags: [Candidatos - Áreas de Interesse]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: areaId
+ *         required: true
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *         description: Identificador da área de interesse principal
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/CandidatoSubareaInteresseCreateInput'
+ *     responses:
+ *       201:
+ *         description: Subárea criada com sucesso
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/CandidatoSubareaInteresse'
+ *             examples:
+ *               exemplo:
+ *                 summary: Subárea criada
+ *                 value:
+ *                   id: 98
+ *                   areaId: 10
+ *                   nome: Desenvolvimento Back-end
+ *                   vagasRelacionadas: []
+ *                   criadoEm: '2024-05-10T12:00:00.000Z'
+ *                   atualizadoEm: '2024-05-10T12:00:00.000Z'
+ *       400:
+ *         description: Dados inválidos para criação ou identificador incorreto
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ValidationErrorResponse'
+ *       401:
+ *         description: Token de autenticação ausente ou inválido
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/UnauthorizedResponse'
+ *       403:
+ *         description: Usuário sem permissão para executar a ação
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ForbiddenResponse'
+ *       404:
+ *         description: Área de interesse não encontrada
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno ao criar subárea
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X POST "http://localhost:3000/api/v1/candidatos/areas-interesse/10/subareas" \\
+ *            -H "Authorization: Bearer <TOKEN>" \\
+ *            -H "Content-Type: application/json" \\
+ *            -d '{
+ *                  "nome": "Desenvolvimento Back-end"
+ *                }'
+ */
+router.post(
+  '/:areaId/subareas',
+  supabaseAuthMiddleware(adminRoles),
+  AreasInteresseController.createSubarea,
+);
+
 export { router as areasInteresseRoutes };

--- a/src/modules/candidatos/areas-interesse/routes/subareas.ts
+++ b/src/modules/candidatos/areas-interesse/routes/subareas.ts
@@ -1,0 +1,161 @@
+import { Router } from 'express';
+
+import { supabaseAuthMiddleware } from '@/modules/usuarios/auth';
+import { Roles } from '@/modules/usuarios/enums/Roles';
+
+import { AreasInteresseController } from '../controllers/areas-interesse.controller';
+
+const router = Router();
+const adminRoles = [Roles.ADMIN, Roles.MODERADOR];
+
+/**
+ * @openapi
+ * /api/v1/candidatos/subareas-interesse/{subareaId}:
+ *   put:
+ *     summary: Atualizar subárea de interesse
+ *     description: Disponível apenas para administradores e moderadores (roles: ADMIN, MODERADOR).
+ *     tags: [Candidatos - Áreas de Interesse]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: subareaId
+ *         required: true
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *         description: Identificador da subárea de interesse
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/CandidatoSubareaInteresseUpdateInput'
+ *     responses:
+ *       200:
+ *         description: Subárea atualizada com sucesso
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/CandidatoSubareaInteresse'
+ *             examples:
+ *               exemplo:
+ *                 summary: Subárea atualizada
+ *                 value:
+ *                   id: 98
+ *                   areaId: 10
+ *                   nome: Segurança da Informação
+ *                   vagasRelacionadas: []
+ *                   criadoEm: '2024-05-10T12:00:00.000Z'
+ *                   atualizadoEm: '2024-05-12T14:20:00.000Z'
+ *       400:
+ *         description: Dados inválidos para atualização ou identificador incorreto
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ValidationErrorResponse'
+ *       401:
+ *         description: Token de autenticação ausente ou inválido
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/UnauthorizedResponse'
+ *       403:
+ *         description: Usuário sem permissão para executar a ação
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ForbiddenResponse'
+ *       404:
+ *         description: Subárea de interesse não encontrada
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno ao atualizar subárea
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X PUT "http://localhost:3000/api/v1/candidatos/subareas-interesse/98" \\
+ *            -H "Authorization: Bearer <TOKEN>" \\
+ *            -H "Content-Type: application/json" \\
+ *            -d '{
+ *                  "nome": "Segurança da Informação"
+ *                }'
+ */
+router.put(
+  '/:subareaId',
+  supabaseAuthMiddleware(adminRoles),
+  AreasInteresseController.updateSubarea,
+);
+
+/**
+ * @openapi
+ * /api/v1/candidatos/subareas-interesse/{subareaId}:
+ *   delete:
+ *     summary: Remover subárea de interesse
+ *     description: Disponível apenas para administradores e moderadores (roles: ADMIN, MODERADOR).
+ *     tags: [Candidatos - Áreas de Interesse]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: subareaId
+ *         required: true
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *         description: Identificador da subárea de interesse
+ *     responses:
+ *       204:
+ *         description: Subárea removida com sucesso
+ *       400:
+ *         description: Identificador inválido
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       401:
+ *         description: Token de autenticação ausente ou inválido
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/UnauthorizedResponse'
+ *       403:
+ *         description: Usuário sem permissão para executar a ação
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ForbiddenResponse'
+ *       404:
+ *         description: Subárea de interesse não encontrada
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Erro interno ao remover subárea
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *     x-codeSamples:
+ *       - lang: cURL
+ *         label: Exemplo
+ *         source: |
+ *           curl -X DELETE "http://localhost:3000/api/v1/candidatos/subareas-interesse/98" \\
+ *            -H "Authorization: Bearer <TOKEN>"
+ */
+router.delete(
+  '/:subareaId',
+  supabaseAuthMiddleware(adminRoles),
+  AreasInteresseController.removeSubarea,
+);
+
+export { router as subareasInteresseRoutes };

--- a/src/modules/candidatos/areas-interesse/validators/areas-interesse.schema.ts
+++ b/src/modules/candidatos/areas-interesse/validators/areas-interesse.schema.ts
@@ -1,5 +1,11 @@
 import { z } from 'zod';
 
+const subareaNomeSchema = z
+  .string({ required_error: 'Subárea é obrigatória' })
+  .trim()
+  .min(1, 'Subárea não pode ser vazia')
+  .max(120, 'Subárea deve ter no máximo 120 caracteres');
+
 export const createAreaInteresseSchema = z.object({
   categoria: z
     .string({ required_error: 'Categoria é obrigatória' })
@@ -7,13 +13,7 @@ export const createAreaInteresseSchema = z.object({
     .min(1, 'Categoria é obrigatória')
     .max(120, 'Categoria deve ter no máximo 120 caracteres'),
   subareas: z
-    .array(
-      z
-        .string({ required_error: 'Subárea é obrigatória' })
-        .trim()
-        .min(1, 'Subárea não pode ser vazia')
-        .max(120, 'Subárea deve ter no máximo 120 caracteres'),
-    )
+    .array(subareaNomeSchema)
     .nonempty('Informe ao menos uma subárea'),
 });
 
@@ -22,5 +22,15 @@ export const updateAreaInteresseSchema = createAreaInteresseSchema.partial({
   subareas: true,
 });
 
+export const createSubareaInteresseSchema = z.object({
+  nome: subareaNomeSchema,
+});
+
+export const updateSubareaInteresseSchema = z.object({
+  nome: subareaNomeSchema,
+});
+
 export type CreateAreaInteresseInput = z.infer<typeof createAreaInteresseSchema>;
 export type UpdateAreaInteresseInput = z.infer<typeof updateAreaInteresseSchema>;
+export type CreateSubareaInteresseInput = z.infer<typeof createSubareaInteresseSchema>;
+export type UpdateSubareaInteresseInput = z.infer<typeof updateSubareaInteresseSchema>;

--- a/src/modules/candidatos/routes/index.ts
+++ b/src/modules/candidatos/routes/index.ts
@@ -3,6 +3,7 @@ import { Router } from 'express';
 import { publicCache } from '@/middlewares/cache-control';
 
 import { areasInteresseRoutes } from '../areas-interesse/routes';
+import { subareasInteresseRoutes } from '../areas-interesse/routes/subareas';
 import { curriculosRoutes } from '@/modules/candidatos/curriculos/routes';
 import { CandidaturasController } from '@/modules/candidatos/candidaturas/controllers';
 import { supabaseAuthMiddleware } from '@/modules/usuarios/auth';
@@ -43,6 +44,7 @@ router.get('/', publicCache, (_req, res) => {
     timestamp: new Date().toISOString(),
     endpoints: {
       areasInteresse: '/areas-interesse',
+      subareasInteresse: '/subareas-interesse',
       curriculos: '/curriculos',
       aplicar: '/aplicar',
       vagas: '/vagas',
@@ -52,6 +54,7 @@ router.get('/', publicCache, (_req, res) => {
 });
 
 router.use('/areas-interesse', areasInteresseRoutes);
+router.use('/subareas-interesse', subareasInteresseRoutes);
 router.use('/curriculos', curriculosRoutes);
 /**
  * @openapi


### PR DESCRIPTION
## Summary
- add validation and service logic to manage candidate interest subareas alongside existing areas
- expose POST/PUT/DELETE routes for subareas and register them in the candidatos module with full OpenAPI descriptions
- document payloads in Swagger so subarea operations appear in Swagger UI and Redoc

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68d69cc7413c83258b16e990f8f5cbb2