### PR TITLE
feat: allow admin to reset company password

### DIFF
--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -7227,6 +7227,20 @@ const options: Options = {
               enum: ['ATIVO', 'INATIVO', 'BLOQUEADO', 'PENDENTE', 'SUSPENSO'],
               example: 'ATIVO',
             },
+            senha: {
+              type: 'string',
+              nullable: true,
+              minLength: 8,
+              example: 'NovaSenhaForte123!',
+              description: 'Informe para redefinir a senha da empresa. Requer confirmarSenha.',
+            },
+            confirmarSenha: {
+              type: 'string',
+              nullable: true,
+              minLength: 8,
+              example: 'NovaSenhaForte123!',
+              description: 'Deve ser idêntica à senha quando informado.',
+            },
             plano: {
               allOf: [{ $ref: '#/components/schemas/AdminEmpresasPlanoUpdateInput' }],
               nullable: true,

--- a/src/modules/empresas/admin/routes/index.ts
+++ b/src/modules/empresas/admin/routes/index.ts
@@ -1803,7 +1803,7 @@ router.put('/:id/plano', supabaseAuthMiddleware(adminRoles), AdminEmpresasContro
  * /api/v1/empresas/admin/{id}:
  *   put:
  *     summary: (Admin) Atualizar empresa
- *     description: "Atualiza dados cadastrais da empresa e permite gerenciar o plano vinculado. Endpoint restrito aos perfis ADMIN e MODERADOR."
+ *     description: "Atualiza dados cadastrais da empresa, permite redefinir a senha e gerenciar o plano vinculado. Endpoint restrito aos perfis ADMIN e MODERADOR."
  *     operationId: adminEmpresasUpdate
  *     tags: [Empresas - Admin]
  *     security:
@@ -1827,6 +1827,8 @@ router.put('/:id/plano', supabaseAuthMiddleware(adminRoles), AdminEmpresasContro
  *               value:
  *                 telefone: '11912345678'
  *                 descricao: Consultoria especializada em tecnologia e inovação.
+ *                 senha: NovaSenhaForte123!
+ *                 confirmarSenha: NovaSenhaForte123!
  *                 status: ATIVO
  *                 plano:
  *                   planosEmpresariaisId: b8d96a94-8a3d-4b90-8421-6f0a7bc1d42e

--- a/src/modules/empresas/admin/services/admin-empresas.service.ts
+++ b/src/modules/empresas/admin/services/admin-empresas.service.ts
@@ -1521,6 +1521,10 @@ export const adminEmpresasService = {
         updates.status = data.status;
       }
 
+      if (data.senha !== undefined) {
+        updates.senha = await sanitizeSenha(data.senha);
+      }
+
       if (Object.keys(informacoesUpdates).length > 0) {
         updates.informacoes = { update: informacoesUpdates };
       }

--- a/src/modules/empresas/admin/validators/admin-empresas.schema.ts
+++ b/src/modules/empresas/admin/validators/admin-empresas.schema.ts
@@ -181,8 +181,29 @@ export const adminEmpresasUpdateSchema = z
     socialLinks: socialLinksSchema.optional().nullable(),
     avatarUrl: nullableUrl.optional().nullable(),
     status: z.nativeEnum(Status).optional(),
+    senha: optionalSecurePassword,
+    confirmarSenha: optionalSecurePassword,
     plano: adminEmpresasPlanoUpdateSchema.optional().nullable(),
   })
+  .refine(
+    (values) =>
+      (values.senha === undefined && values.confirmarSenha === undefined) ||
+      (values.senha !== undefined && values.confirmarSenha !== undefined),
+    {
+      message: 'Informe senha e confirmarSenha para redefinir a senha',
+      path: ['confirmarSenha'],
+    },
+  )
+  .refine(
+    (values) =>
+      values.senha === undefined && values.confirmarSenha === undefined
+        ? true
+        : values.senha === values.confirmarSenha,
+    {
+      message: 'Senha e confirmarSenha devem ser iguais',
+      path: ['confirmarSenha'],
+    },
+  )
   .refine(
     (values) =>
       Object.values({ ...values, plano: undefined }).some((value) => value !== undefined) ||


### PR DESCRIPTION
## Summary
- allow the admin company update flow to accept password reset fields with confirmation validation
- hash and persist the new password when provided and document the contract in the OpenAPI spec

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68dc2f0f041c83328837e47b451a8fe3