### PR TITLE
fix: garantir persistência completa do endereço no admin de empresas

### DIFF
--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -7231,6 +7231,21 @@ const options: Options = {
               example: '12345678000190',
               description: 'CNPJ da empresa, apenas números',
             },
+            logradouro: {
+              type: 'string',
+              nullable: true,
+              example: 'Rua Manoel Pedro de Oliveira',
+            },
+            numero: {
+              type: 'string',
+              nullable: true,
+              example: '245',
+            },
+            bairro: {
+              type: 'string',
+              nullable: true,
+              example: 'Benedito Bentes',
+            },
             cidade: {
               type: 'string',
               nullable: true,
@@ -7240,6 +7255,11 @@ const options: Options = {
               type: 'string',
               nullable: true,
               example: 'SP',
+            },
+            cep: {
+              type: 'string',
+              nullable: true,
+              example: '57084028',
             },
             descricao: {
               type: 'string',
@@ -7280,8 +7300,12 @@ const options: Options = {
             senha: 'SenhaForte123!',
             supabaseId: 'supabase-user-id',
             cnpj: '12345678000190',
+            logradouro: 'Rua Manoel Pedro de Oliveira',
+            numero: '245',
+            bairro: 'Benedito Bentes',
             cidade: 'São Paulo',
             estado: 'SP',
+            cep: '57084028',
             descricao: 'Consultoria especializada em recrutamento e seleção.',
             socialLinks: {
               instagram: 'https://instagram.com/advancemais',
@@ -7318,6 +7342,21 @@ const options: Options = {
               nullable: true,
               example: '12345678000190',
             },
+            logradouro: {
+              type: 'string',
+              nullable: true,
+              example: 'Rua Manoel Pedro de Oliveira',
+            },
+            numero: {
+              type: 'string',
+              nullable: true,
+              example: '245',
+            },
+            bairro: {
+              type: 'string',
+              nullable: true,
+              example: 'Benedito Bentes',
+            },
             cidade: {
               type: 'string',
               nullable: true,
@@ -7327,6 +7366,11 @@ const options: Options = {
               type: 'string',
               nullable: true,
               example: 'SP',
+            },
+            cep: {
+              type: 'string',
+              nullable: true,
+              example: '57084028',
             },
             descricao: {
               type: 'string',
@@ -7372,6 +7416,12 @@ const options: Options = {
           example: {
             nome: 'Advance Tech Consultoria LTDA',
             telefone: '11912345678',
+            logradouro: 'Rua Manoel Pedro de Oliveira',
+            numero: '245',
+            bairro: 'Benedito Bentes',
+            cidade: 'Maceió',
+            estado: 'AL',
+            cep: '57084028',
             descricao: 'Consultoria especializada em tecnologia e inovação.',
             socialLinks: {
               instagram: 'https://instagram.com/advancetech',

--- a/src/modules/empresas/admin/routes/index.ts
+++ b/src/modules/empresas/admin/routes/index.ts
@@ -1826,6 +1826,12 @@ router.put('/:id/plano', supabaseAuthMiddleware(adminRoles), AdminEmpresasContro
  *               summary: Atualização de dados cadastrais e plano
  *               value:
  *                 telefone: '11912345678'
+ *                 logradouro: 'Rua Manoel Pedro de Oliveira'
+ *                 numero: '245'
+ *                 bairro: 'Benedito Bentes'
+ *                 cep: '57084028'
+ *                 cidade: 'Maceió'
+ *                 estado: 'AL'
  *                 descricao: Consultoria especializada em tecnologia e inovação.
  *                 senha: NovaSenhaForte123!
  *                 confirmarSenha: NovaSenhaForte123!

--- a/src/modules/empresas/admin/services/admin-empresas.service.ts
+++ b/src/modules/empresas/admin/services/admin-empresas.service.ts
@@ -721,13 +721,47 @@ const generateSecurePassword = (length = DEFAULT_ADMIN_PASSWORD_LENGTH) => {
 const upsertEnderecoPrincipal = async (
   tx: Prisma.TransactionClient,
   usuarioId: string,
-  endereco: { cidade?: string | null; estado?: string | null },
+  endereco: {
+    logradouro?: string | null;
+    numero?: string | null;
+    bairro?: string | null;
+    cidade?: string | null;
+    estado?: string | null;
+    cep?: string | null;
+  },
 ) => {
   const dataToUpdate: Prisma.UsuariosEnderecosUpdateInput = {};
   const dataToCreate: Prisma.UsuariosEnderecosUncheckedCreateInput = { usuarioId };
 
   let hasDefinedField = false;
   let hasCreateValue = false;
+
+  if (endereco.logradouro !== undefined) {
+    dataToUpdate.logradouro = endereco.logradouro;
+    dataToCreate.logradouro = endereco.logradouro ?? null;
+    hasDefinedField = true;
+    if (endereco.logradouro && endereco.logradouro.length > 0) {
+      hasCreateValue = true;
+    }
+  }
+
+  if (endereco.numero !== undefined) {
+    dataToUpdate.numero = endereco.numero;
+    dataToCreate.numero = endereco.numero ?? null;
+    hasDefinedField = true;
+    if (endereco.numero && endereco.numero.length > 0) {
+      hasCreateValue = true;
+    }
+  }
+
+  if (endereco.bairro !== undefined) {
+    dataToUpdate.bairro = endereco.bairro;
+    dataToCreate.bairro = endereco.bairro ?? null;
+    hasDefinedField = true;
+    if (endereco.bairro && endereco.bairro.length > 0) {
+      hasCreateValue = true;
+    }
+  }
 
   if (endereco.cidade !== undefined) {
     dataToUpdate.cidade = endereco.cidade;
@@ -743,6 +777,15 @@ const upsertEnderecoPrincipal = async (
     dataToCreate.estado = endereco.estado ?? null;
     hasDefinedField = true;
     if (endereco.estado && endereco.estado.length > 0) {
+      hasCreateValue = true;
+    }
+  }
+
+  if (endereco.cep !== undefined) {
+    dataToUpdate.cep = endereco.cep;
+    dataToCreate.cep = endereco.cep ?? null;
+    hasDefinedField = true;
+    if (endereco.cep && endereco.cep.length > 0) {
       hasCreateValue = true;
     }
   }
@@ -1380,8 +1423,12 @@ export const adminEmpresasService = {
     const senhaHash = await sanitizeSenha(senhaOriginal);
     const aceitarTermos = input.aceitarTermos ?? true;
     const status = input.status ?? Status.ATIVO;
+    const logradouro = sanitizeOptionalValue(input.logradouro);
+    const numero = sanitizeOptionalValue(input.numero);
+    const bairro = sanitizeOptionalValue(input.bairro);
     const cidade = sanitizeOptionalValue(input.cidade);
     const estado = sanitizeOptionalValue(input.estado);
+    const cep = sanitizeOptionalValue(input.cep);
     const descricao = sanitizeOptionalValue(input.descricao);
     const avatarUrl = sanitizeOptionalValue(input.avatarUrl);
     const socialLinksInput = extractSocialLinksFromPayload(
@@ -1432,7 +1479,14 @@ export const adminEmpresasService = {
         select: { id: true },
       });
 
-      await upsertEnderecoPrincipal(tx, usuario.id, { cidade, estado });
+      await upsertEnderecoPrincipal(tx, usuario.id, {
+        logradouro,
+        numero,
+        bairro,
+        cidade,
+        estado,
+        cep,
+      });
 
       if (input.plano) {
         await assignPlanoToEmpresa(tx, usuario.id, input.plano);
@@ -1501,9 +1555,12 @@ export const adminEmpresasService = {
         updates.cnpj = data.cnpj === null ? null : normalizeDocumento(data.cnpj);
       }
 
+      const logradouro = sanitizeOptionalValue(data.logradouro);
+      const numero = sanitizeOptionalValue(data.numero);
+      const bairro = sanitizeOptionalValue(data.bairro);
       const cidade = sanitizeOptionalValue(data.cidade);
-
       const estado = sanitizeOptionalValue(data.estado);
+      const cep = sanitizeOptionalValue(data.cep);
 
       const descricao = sanitizeOptionalValue(data.descricao);
       if (descricao !== undefined) {
@@ -1515,7 +1572,14 @@ export const adminEmpresasService = {
         informacoesUpdates.avatarUrl = avatarUrl;
       }
 
-      await upsertEnderecoPrincipal(tx, id, { cidade, estado });
+      await upsertEnderecoPrincipal(tx, id, {
+        logradouro,
+        numero,
+        bairro,
+        cidade,
+        estado,
+        cep,
+      });
 
       if (data.status !== undefined) {
         updates.status = data.status;

--- a/src/modules/empresas/admin/validators/admin-empresas.schema.ts
+++ b/src/modules/empresas/admin/validators/admin-empresas.schema.ts
@@ -20,6 +20,24 @@ const nullableString = z
   .min(1, 'Informe um valor válido')
   .max(255, 'Valor muito longo');
 
+const nullableEnderecoString = z
+  .string()
+  .trim()
+  .min(1, 'Informe um valor válido para o endereço')
+  .max(255, 'Valor muito longo');
+
+const nullableEnderecoNumero = z
+  .string()
+  .trim()
+  .min(1, 'Informe um número válido')
+  .max(50, 'Número muito longo');
+
+const nullableCep = z
+  .string()
+  .trim()
+  .min(5, 'Informe um CEP válido')
+  .max(20, 'CEP muito longo');
+
 const securePasswordSchema = z
   .string()
   .min(8, 'Senha deve ter pelo menos 8 caracteres')
@@ -145,8 +163,12 @@ export const adminEmpresasCreateSchema = z.object({
     .trim()
     .min(14, 'CNPJ deve ter 14 dígitos')
     .max(18, 'CNPJ muito longo'),
+  logradouro: nullableEnderecoString.optional(),
+  numero: nullableEnderecoNumero.optional(),
+  bairro: nullableEnderecoString.optional(),
   cidade: nullableString.optional(),
   estado: nullableString.optional(),
+  cep: nullableCep.optional(),
   descricao: z.string().trim().max(500, 'Descrição muito longa').optional(),
   instagram: nullableString.optional(),
   linkedin: nullableString.optional(),
@@ -169,8 +191,12 @@ export const adminEmpresasUpdateSchema = z
     email: z.string().trim().toLowerCase().email('Informe um e-mail válido').optional(),
     telefone: z.string().trim().min(10, 'Informe um telefone válido').max(20).optional(),
     cnpj: z.string().trim().min(14, 'CNPJ deve ter 14 dígitos').max(18).optional().nullable(),
+    logradouro: nullableEnderecoString.optional().nullable(),
+    numero: nullableEnderecoNumero.optional().nullable(),
+    bairro: nullableEnderecoString.optional().nullable(),
     cidade: nullableString.optional().nullable(),
     estado: nullableString.optional().nullable(),
+    cep: nullableCep.optional().nullable(),
     descricao: z.string().trim().max(500, 'Descrição muito longa').optional().nullable(),
     instagram: nullableString.optional().nullable(),
     linkedin: nullableString.optional().nullable(),


### PR DESCRIPTION
## Resumo
- permite informar logradouro, número, bairro e CEP ao criar ou atualizar empresas via painel admin
- ajusta serviço para salvar os novos campos no endereço principal da empresa
- documenta os novos campos no schema OpenAPI e nos exemplos do Swagger/Redoc

## Testes
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68decbd4e52c8332bf78774839050b5a