### PR TITLE
Fix candidaturas overview role filtering

### DIFF
--- a/src/modules/candidatos/candidaturas/controllers.ts
+++ b/src/modules/candidatos/candidaturas/controllers.ts
@@ -50,7 +50,12 @@ export const CandidaturasController = {
       Roles.MODERADOR,
       Roles.RECRUTADOR,
       Roles.PSICOLOGO,
-    ];
+    ] as const satisfies readonly Roles[];
+
+    type AllowedRole = (typeof allowedRoles)[number];
+
+    const isAllowedRole = (role: Roles): role is AllowedRole =>
+      allowedRoles.includes(role as AllowedRole);
 
     if (!user?.id || !user?.role) {
       return res.status(401).json({ success: false, code: 'UNAUTHORIZED' });
@@ -58,7 +63,7 @@ export const CandidaturasController = {
 
     const viewerRole = user.role as Roles;
 
-    if (!allowedRoles.includes(viewerRole)) {
+    if (!isAllowedRole(viewerRole)) {
       return res.status(403).json({ success: false, code: 'FORBIDDEN' });
     }
 

--- a/src/modules/candidatos/candidaturas/services/overview.service.ts
+++ b/src/modules/candidatos/candidaturas/services/overview.service.ts
@@ -76,7 +76,13 @@ const buildFilters = ({
   };
 
   if (searchWhere) {
-    usuariosWhere.AND = [...(usuariosWhere.AND ?? []), searchWhere];
+    const currentAnd = Array.isArray(usuariosWhere.AND)
+      ? usuariosWhere.AND
+      : usuariosWhere.AND
+        ? [usuariosWhere.AND]
+        : [];
+
+    usuariosWhere.AND = [...currentAnd, searchWhere];
   }
 
   const candidaturasWhereBase: Prisma.EmpresasCandidatosWhereInput = {};


### PR DESCRIPTION
## Summary
- add a type guard to validate roles allowed to view candidaturas overview
- normalize Prisma AND filters when composing overview queries

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68e837478abc8332b6dcd0fe0f697214